### PR TITLE
[fix] bump go 1.18 & optional TAG definition in makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as builder
+FROM golang:1.18-alpine as builder
 
 RUN apk add --no-cache make git
 WORKDIR /workspace/helmfile

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ tools:
 	go get -u github.com/tcnksm/ghr github.com/mitchellh/gox
 .PHONY: tools
 
-TAG  = $(shell git describe --tags --abbrev=0 HEAD)
+TAG  ?= $(shell git describe --tags --abbrev=0 HEAD)
 LAST = $(shell git describe --tags --abbrev=0 HEAD^)
 BODY = "`git log ${LAST}..HEAD --oneline --decorate` `printf '\n\#\#\# [Build Info](${BUILD_URL})'`"
 


### PR DESCRIPTION
@mumoshu Sorry for the bug with Dockerfile :-(

`TAG ?=` is to used locally to run something like this

```
make image TAG=dev

docker build -t quay.io/github/helmfile:dev .
```