### PR TITLE
Fix helmfile deps not to remove entries for charts that are being chartified

### DIFF
--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -80,8 +80,11 @@ func (r *Run) withPreparedCharts(helmfileCommand string, opts state.ChartPrepare
 			Namespace:   rel.Namespace,
 			KubeContext: rel.KubeContext,
 		}
-		if chart := releaseToChart[key]; chart != "" {
-			rel.Chart = chart
+		if chart := releaseToChart[key]; chart != rel.Chart {
+			// In this case we assume that the chart is downloaded and modified by Helmfile and chartify.
+			// So we take note of the local filesystem path to the modified version of the chart
+			// and use it later via the Release.ChartPathOrName() func.
+			rel.ChartPath = chart
 		}
 	}
 

--- a/pkg/state/temp_test.go
+++ b/pkg/state/temp_test.go
@@ -38,39 +38,39 @@ func TestGenerateID(t *testing.T) {
 	run(testcase{
 		subject: "baseline",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
-		want:    "foo-values-6d97d4c7ff",
+		want:    "foo-values-789768d94b",
 	})
 
 	run(testcase{
 		subject: "different bytes content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    []byte(`{"k":"v"}`),
-		want:    "foo-values-74fcbfbd68",
+		want:    "foo-values-7d669b768f",
 	})
 
 	run(testcase{
 		subject: "different map content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    map[string]interface{}{"k": "v"},
-		want:    "foo-values-7b954b6b6b",
+		want:    "foo-values-dd597bd55",
 	})
 
 	run(testcase{
 		subject: "different chart",
 		release: ReleaseSpec{Name: "foo", Chart: "stable/envoy"},
-		want:    "foo-values-5c54676568",
+		want:    "foo-values-5d6c9f7f59",
 	})
 
 	run(testcase{
 		subject: "different name",
 		release: ReleaseSpec{Name: "bar", Chart: "incubator/raw"},
-		want:    "bar-values-5fff459546",
+		want:    "bar-values-b6cdc56c",
 	})
 
 	run(testcase{
 		subject: "specific ns",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw", Namespace: "myns"},
-		want:    "myns-foo-values-cfd9959dd",
+		want:    "myns-foo-values-7cddc65b5",
 	})
 
 	for id, n := range ids {


### PR DESCRIPTION
This fixes a bug in `helmfile deps`.

When chartify is involved due to the use of `forceNamespace`, `strategicMergePatches`, `jsonPatches`, and so on, we had been internally mutating the Release.Chart with the path to the local temporary directory that contains the modified version of the chart.

That resulted in us unintentionally making `helmfile deps` to remove entries for the chart being modified out of helmfile.lock file, which resulted in issues like #2110.

To be clear, although the original issue is reported to occur for `strategicMergePatches`, I believe that it occurered also for any remote charts using `jsonPatches` and `forceNamespace` too.

I also believe this has been an issue since our introduction of chartify (maybe a year or so ago??), and I guess why it took so much time to be found and reported is that not so many people use chartify in combination with `helmfile deps` :thinking:

Lastly, this changes chart names surfaced in the various log output from Helmfile, from temporary chart paths to the chart name/path declared in the helmfile.yaml. I think this is generally a good change, no fear of being a breaking change. But if anyone has any concern about that, please feel free to comment/report/etc.

Ref https://github.com/roboll/helmfile/issues/2110