### PR TITLE
feat: Auto-detect term for coloring helm-diff output

### DIFF
--- a/main.go
+++ b/main.go
@@ -952,6 +952,10 @@ func (c configImpl) Color() bool {
 		return c
 	}
 
+	if c.NoColor() {
+		return false
+	}
+
 	// We replicate the helm-diff behavior in helmfile
 	// because when when helmfile calls helm-diff, helm-diff has no access to term and therefore
 	// we can't rely on helm-diff's ability to auto-detect term for color output.
@@ -1018,6 +1022,10 @@ func action(do func(*app.App, configImpl) error) func(*cli.Context) error {
 	return func(implCtx *cli.Context) error {
 		conf, err := NewUrfaveCliConfigImpl(implCtx)
 		if err != nil {
+			return err
+		}
+
+		if err := app.ValidateConfig(conf); err != nil {
 			return err
 		}
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1259,6 +1259,7 @@ func (a *App) apply(r *Run, c ApplyConfigProvider) (bool, bool, []error) {
 	detailedExitCode := true
 
 	diffOpts := &state.DiffOpts{
+		Color:             c.Color(),
 		NoColor:           c.NoColor(),
 		Context:           c.Context(),
 		Output:            c.DiffOutput(),
@@ -1479,6 +1480,7 @@ func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) 
 	opts := &state.DiffOpts{
 		Context:           c.Context(),
 		Output:            c.DiffOutput(),
+		Color:             c.Color(),
 		NoColor:           c.NoColor(),
 		Set:               c.Set(),
 		SkipDiffOnInstall: c.SkipDiffOnInstall(),

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2426,6 +2426,10 @@ func (a applyConfig) SuppressDiff() bool {
 	return a.suppressDiff
 }
 
+func (a applyConfig) Color() bool {
+	return false
+}
+
 func (a applyConfig) NoColor() bool {
 	return a.noColor
 }

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -56,6 +56,7 @@ type ApplyConfigProvider interface {
 
 	DetailedExitcode() bool
 
+	Color() bool
 	NoColor() bool
 	Context() int
 	DiffOutput() string
@@ -113,6 +114,7 @@ type DiffConfigProvider interface {
 	IncludeNeeds() bool
 
 	DetailedExitcode() bool
+	Color() bool
 	NoColor() bool
 	Context() int
 	DiffOutput() string

--- a/pkg/app/diff_test.go
+++ b/pkg/app/diff_test.go
@@ -93,6 +93,10 @@ func (a diffConfig) SuppressDiff() bool {
 	return a.suppressDiff
 }
 
+func (a diffConfig) Color() bool {
+	return false
+}
+
 func (a diffConfig) NoColor() bool {
 	return a.noColor
 }

--- a/pkg/app/validate_config.go
+++ b/pkg/app/validate_config.go
@@ -1,0 +1,11 @@
+package app
+
+import "errors"
+
+func ValidateConfig(conf ApplyConfigProvider) error {
+	if conf.NoColor() && conf.Color() {
+		return errors.New("--color and --no-color cannot be specified at the same time")
+	}
+
+	return nil
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1718,6 +1718,8 @@ func (st *HelmState) prepareDiffReleases(helm helmexec.Interface, additionalValu
 
 				if opts.NoColor {
 					flags = append(flags, "--no-color")
+				} else if opts.Color {
+					flags = append(flags, "--color")
 				}
 
 				if opts.Context > 0 {
@@ -1802,8 +1804,13 @@ func (st *HelmState) createHelmContextWithWriter(spec *ReleaseSpec, w io.Writer)
 }
 
 type DiffOpts struct {
-	Context           int
-	Output            string
+	Context int
+	Output  string
+	// Color forces the color output on helm-diff.
+	// This takes effect only when NoColor is false.
+	Color bool
+	// NoColor forces disabling the color output on helm-diff.
+	// If this is true, Color has no effect.
 	NoColor           bool
 	Set               []string
 	SkipCleanup       bool


### PR DESCRIPTION
Since helm-diff has added an ability to auto-detect the term to decide if it should output with color or not, helmfile had been defaulted to no-color.
This resoloves that, by adding a term-detection logic that is same as helm-diff.

As a part of this work, I have also implemented a new global flag `--color`, which is used for forcing color without relying on the term-detection logic implemented in helmfile or explicitly setting the HELM_DIFF_COLOR envvar. I hope it is useful for folks.

Ref https://github.com/roboll/helmfile/issues/2043