### PR TITLE
Fix non-existent custom temp dir

### DIFF
--- a/pkg/state/temp.go
+++ b/pkg/state/temp.go
@@ -34,9 +34,11 @@ func tempValuesFilePath(release *ReleaseSpec, data interface{}) (*string, error)
 	workDir := os.Getenv("HELMFILE_TEMPDIR")
 	if workDir == "" {
 		workDir, err = os.MkdirTemp(os.TempDir(), "helmfile")
-		if err != nil {
-			panic(err)
-		}
+	} else {
+		err = os.MkdirAll(workDir, os.FileMode(0700))
+	}
+	if err != nil {
+		panic(err)
 	}
 
 	d := filepath.Join(workDir, id)


### PR DESCRIPTION
When using non-existent custom temporary dir with `HELMFILE_TEMPDIR`, raised errors are not clear. I propose that we try to create automatically the custom temp dir.

```
HELMFILE_TEMPDIR=.helmfile
```

```
in ./helmfile.yaml: in .helmfiles[2]: in ./helmfile.yaml: 2 errors:
err 0: open .helmfile/staging-x-values-6b4cd67d8b: no such file or directory
err 1: open .helmfile/staging-x-values-5f97d6746b: no such file or directory
```