### PR TITLE
Remote values and templating rendering fix

### DIFF
--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -159,6 +159,13 @@ func (helm *Helm) Lint(name, chart string, flags ...string) error {
 	return nil
 }
 func (helm *Helm) TemplateRelease(name, chart string, flags ...string) error {
+	if strings.Contains(name, "error") {
+		return errors.New("error")
+	}
+	helm.sync(helm.ReleasesMutex, func() {
+		helm.Releases = append(helm.Releases, Release{Name: name, Flags: flags})
+	})
+
 	return nil
 }
 func (helm *Helm) ChartPull(chart string, flags ...string) error {

--- a/pkg/state/create.go
+++ b/pkg/state/create.go
@@ -88,6 +88,7 @@ func (c *StateCreator) Parse(content []byte, baseDir, file string) (*HelmState, 
 
 	state.FilePath = file
 	state.basePath = baseDir
+	state.remote = c.remote
 
 	decoder := yaml.NewDecoder(bytes.NewReader(content))
 	if !c.Strict {


### PR DESCRIPTION
I solved an [issue][1] with templating a single chart with dependency. And added ability to use remote values in release that was requested few times: [one][2], [two][3]. 

Please check commit messages for additional details.

[1]: https://github.com/roboll/helmfile/issues/2048
[2]: https://github.com/roboll/helmfile/issues/1838
[3]: https://github.com/roboll/helmfile/issues/1499
