### PR TITLE
Adds feature to fetch release values and secret values from remote

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	neturl "net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -186,7 +187,11 @@ func (r *Remote) Fetch(goGetterSrc string, cacheDirOpt ...string) (string, error
 	replacer := strings.NewReplacer(":", "", "//", "_", "/", "_", ".", "_")
 	dirKey := replacer.Replace(srcDir)
 	if len(query) > 0 {
-		paramsKey := strings.Replace(query, "&", "_", -1)
+		q, _ := neturl.ParseQuery(query)
+		if q.Has("sshkey") {
+			q.Set("sshkey", "redacted")
+		}
+		paramsKey := strings.Replace(q.Encode(), "&", "_", -1)
 		cacheKey = fmt.Sprintf("%s.%s", dirKey, paramsKey)
 	} else {
 		cacheKey = dirKey

--- a/pkg/state/envvals_loader_test.go
+++ b/pkg/state/envvals_loader_test.go
@@ -49,6 +49,24 @@ func TestEnvValsLoad_SingleValuesFile(t *testing.T) {
 	}
 }
 
+// Fetch Environment values from remote
+func TestEnvValsLoad_SingleValuesFileRemote(t *testing.T) {
+	l := newLoader()
+
+	actual, err := l.LoadEnvironmentValues(nil, []interface{}{"git::https://github.com/helm/helm.git@cmd/helm/testdata/output/values.yaml?ref=v3.8.0"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]interface{}{
+		"name": string("value"),
+	}
+
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf(diff)
+	}
+}
+
 // See https://github.com/roboll/helmfile/issues/1150
 func TestEnvValsLoad_OverwriteNilValue_Issue1150(t *testing.T) {
 	l := newLoader()

--- a/pkg/state/storage.go
+++ b/pkg/state/storage.go
@@ -2,7 +2,7 @@ package state
 
 import (
 	"fmt"
-	"github.com/roboll/helmfile/pkg/remote"
+	"github.com/helmfile/helmfile/pkg/remote"
 	"go.uber.org/zap"
 	"net/url"
 	"path/filepath"

--- a/pkg/state/storage.go
+++ b/pkg/state/storage.go
@@ -2,11 +2,11 @@ package state
 
 import (
 	"fmt"
+	"github.com/roboll/helmfile/pkg/remote"
+	"go.uber.org/zap"
 	"net/url"
 	"path/filepath"
 	"sort"
-
-	"go.uber.org/zap"
 )
 
 type Storage struct {
@@ -14,6 +14,7 @@ type Storage struct {
 
 	FilePath string
 
+	readFile func(string) ([]byte, error)
 	basePath string
 	glob     func(string) ([]string, error)
 }
@@ -30,7 +31,17 @@ func NewStorage(forFile string, logger *zap.SugaredLogger, glob func(string) ([]
 func (st *Storage) resolveFile(missingFileHandler *string, tpe, path string) ([]string, bool, error) {
 	title := fmt.Sprintf("%s file", tpe)
 
-	files, err := st.ExpandPaths(path)
+	var files []string
+	var err error
+	if remote.IsRemote(path) {
+		r := remote.NewRemote(st.logger, "", st.readFile, directoryExistsAt, fileExistsAt)
+
+		fetchedDir, _ := r.Fetch(path, "values")
+		files = []string{fetchedDir}
+	} else {
+		files, err = st.ExpandPaths(path)
+	}
+
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
The releases and environment section allow for values files on the local
disk.
This enhancement allows for referencing remote (go-getter) files to be
fetched, cached and referenced.

Example:

```yaml
repositories:
  - name: "incubator"
    url: "https://charts.helm.sh/incubator/"

releases:
  - name: "test"
    namespace: "test"
    chart: "incubator/raw"
    version: "0.1.0"
    missingFileHandler: Debug
    values:
      # Reference a remote source file
      - "git::https://github.com/helm/charts.git@raw/ci/values.yaml"
```

In addition when fetching a remote git source with a ssh key the ssh key
will not be part of the caching folder name. This avoids two problems:
1. Don't leak sensitive information in the name of the caching folder
2. Base64 encoded SSH keys are very long. On some file systems the max
lenght of the directory name is hit when using the full base64
information in the path name.

The sshkey informations are reducted. Because of this fixed string
there is a change of colloding cache names. The likelihood of this
collision is very low. The git repo and git reference need to be the
same, but the sshkey can change. This will result in the same source to
be checkout out and referenced.