### PR TITLE
Make a few helmfile sub-commands consistently support needs-related flags

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -45,6 +45,10 @@ func addDiffSubcommand(cliApp *cli.App) {
 				Usage: `automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
 			},
 			cli.BoolFlag{
+				Name:  "include-transitive-needs",
+				Usage: `like --include-needs, but also includes transitive needs (needs of needs). Does nothing when when --selector/-l flag is not provided. Overrides exclusions of other selectors and conditions.`,
+			},
+			cli.BoolFlag{
 				Name:  "skip-diff-on-install",
 				Usage: "Skips running helm-diff on releases being newly installed on this apply. Useful when the release manifests are too huge to be reviewed, or it's too time-consuming to diff at all",
 			},

--- a/cmd/template.go
+++ b/cmd/template.go
@@ -50,6 +50,10 @@ func addTemplateSubcommand(cliApp *cli.App) {
 				Usage: "skip tests from templated output",
 			},
 			cli.BoolFlag{
+				Name:  "skip-needs",
+				Usage: `do not automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided. Defaults to true when --include-needs or --include-transitive-needs is not provided`,
+			},
+			cli.BoolFlag{
 				Name:  "include-needs",
 				Usage: `automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when when --selector/-l flag is not provided`,
 			},

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -200,7 +200,7 @@ func (a *App) Diff(c DiffConfigProvider) error {
 		}
 
 		return matched, criticalErrs
-	}, false)
+	}, c.IncludeTransitiveNeeds())
 
 	if err != nil {
 		return err
@@ -318,7 +318,7 @@ func (a *App) Lint(c LintConfigProvider) error {
 		}
 
 		return
-	}, false, SetFilter(true))
+	}, c.IncludeTransitiveNeeds(), SetFilter(true))
 
 	if err != nil {
 		return err
@@ -1461,7 +1461,7 @@ Do you really want to delete?
 func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) {
 	st := r.state
 
-	selectedReleases, deduplicatedReleases, err := a.getSelectedReleases(r, false)
+	selectedReleases, deduplicatedReleases, err := a.getSelectedReleases(r, c.IncludeTransitiveNeeds())
 	if err != nil {
 		return nil, false, false, []error{err}
 	}
@@ -1483,7 +1483,7 @@ func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) 
 
 	st.Releases = deduplicatedReleases
 
-	plan, err := st.PlanReleases(state.PlanOptions{Reverse: false, SelectedReleases: selectedReleases, SkipNeeds: c.SkipNeeds(), IncludeNeeds: c.IncludeNeeds(), IncludeTransitiveNeeds: false})
+	plan, err := st.PlanReleases(state.PlanOptions{Reverse: false, SelectedReleases: selectedReleases, SkipNeeds: c.SkipNeeds(), IncludeNeeds: c.IncludeNeeds(), IncludeTransitiveNeeds: c.IncludeTransitiveNeeds()})
 	if err != nil {
 		return nil, false, false, []error{err}
 	}
@@ -1513,72 +1513,51 @@ func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) 
 }
 
 func (a *App) lint(r *Run, c LintConfigProvider) (bool, []error, []error) {
-	st := r.state
-	helm := r.helm
-
-	allReleases := st.GetReleasesWithOverrides()
-
-	selectedReleases, _, err := a.getSelectedReleases(r, false)
-	if err != nil {
-		return false, nil, []error{err}
-	}
-	if len(selectedReleases) == 0 {
-		return false, nil, nil
-	}
-
-	// Do build deps and prepare only on selected releases so that we won't waste time
-	// on running various helm commands on unnecessary releases
-	st.Releases = selectedReleases
-
-	var toLint []state.ReleaseSpec
-	for _, r := range selectedReleases {
-		if r.Installed != nil && !*r.Installed {
-			continue
-		}
-		toLint = append(toLint, r)
-	}
-
-	var errs []error
-
-	// Traverse DAG of all the releases so that we don't suffer from false-positive missing dependencies
-	st.Releases = allReleases
-
-	args := argparser.GetArgs(c.Args(), st)
-
-	// Reset the extra args if already set, not to break `helm fetch` by adding the args intended for `lint`
-	helm.SetExtraArgs()
-
-	if len(args) > 0 {
-		helm.SetExtraArgs(args...)
-	}
-
 	var deferredLintErrs []error
 
-	if len(toLint) > 0 {
-		_, templateErrs := withDAG(st, helm, a.Logger, state.PlanOptions{SelectedReleases: toLint, Reverse: false, SkipNeeds: true}, a.WrapWithoutSelector(func(subst *state.HelmState, helm helmexec.Interface) []error {
-			opts := &state.LintOpts{
-				Set:         c.Set(),
-				SkipCleanup: c.SkipCleanup(),
-			}
-			lintErrs := subst.LintReleases(helm, c.Values(), args, c.Concurrency(), opts)
-			if len(lintErrs) == 1 {
-				if err, ok := lintErrs[0].(helmexec.ExitError); ok {
-					if err.Code > 0 {
-						deferredLintErrs = append(deferredLintErrs, err)
+	ok, errs := a.withNeeds(r, c, func(st *state.HelmState, toLint []state.ReleaseSpec) []error {
+		helm := r.helm
 
-						return nil
+		var errs []error
+
+		args := argparser.GetArgs(c.Args(), st)
+
+		// Reset the extra args if already set, not to break `helm fetch` by adding the args intended for `lint`
+		helm.SetExtraArgs()
+
+		if len(args) > 0 {
+			helm.SetExtraArgs(args...)
+		}
+
+		if len(toLint) > 0 {
+			_, templateErrs := withDAG(st, helm, a.Logger, state.PlanOptions{SelectedReleases: toLint, Reverse: false, SkipNeeds: c.SkipNeeds(), IncludeNeeds: c.IncludeNeeds(), IncludeTransitiveNeeds: c.IncludeTransitiveNeeds()}, a.WrapWithoutSelector(func(subst *state.HelmState, helm helmexec.Interface) []error {
+				opts := &state.LintOpts{
+					Set:         c.Set(),
+					SkipCleanup: c.SkipCleanup(),
+				}
+				lintErrs := subst.LintReleases(helm, c.Values(), args, c.Concurrency(), opts)
+				if len(lintErrs) == 1 {
+					if err, ok := lintErrs[0].(helmexec.ExitError); ok {
+						if err.Code > 0 {
+							deferredLintErrs = append(deferredLintErrs, err)
+
+							return nil
+						}
 					}
 				}
+
+				return lintErrs
+			}))
+
+			if len(templateErrs) > 0 {
+				errs = append(errs, templateErrs...)
 			}
-
-			return lintErrs
-		}))
-
-		if len(templateErrs) > 0 {
-			errs = append(errs, templateErrs...)
 		}
-	}
-	return true, deferredLintErrs, errs
+
+		return errs
+	})
+
+	return ok, deferredLintErrs, errs
 }
 
 func (a *App) status(r *Run, c StatusesConfigProvider) (bool, []error) {
@@ -1795,8 +1774,43 @@ func (a *App) sync(r *Run, c SyncConfigProvider) (bool, []error) {
 }
 
 func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
+	return a.withNeeds(r, c, func(st *state.HelmState, toRender []state.ReleaseSpec) []error {
+		helm := r.helm
+
+		args := argparser.GetArgs(c.Args(), st)
+
+		// Reset the extra args if already set, not to break `helm fetch` by adding the args intended for `lint`
+		helm.SetExtraArgs()
+
+		if len(args) > 0 {
+			helm.SetExtraArgs(args...)
+		}
+
+		var errs []error
+
+		if len(toRender) > 0 {
+			_, templateErrs := withDAG(st, helm, a.Logger, state.PlanOptions{SelectedReleases: toRender, Reverse: false, SkipNeeds: c.SkipNeeds(), IncludeNeeds: c.IncludeNeeds(), IncludeTransitiveNeeds: c.IncludeTransitiveNeeds()}, a.WrapWithoutSelector(func(subst *state.HelmState, helm helmexec.Interface) []error {
+				opts := &state.TemplateOpts{
+					Set:               c.Set(),
+					IncludeCRDs:       c.IncludeCRDs(),
+					OutputDirTemplate: c.OutputDirTemplate(),
+					SkipCleanup:       c.SkipCleanup(),
+					SkipTests:         c.SkipTests(),
+				}
+				return subst.TemplateReleases(helm, c.OutputDir(), c.Values(), args, c.Concurrency(), c.Validate(), opts)
+			}))
+
+			if len(templateErrs) > 0 {
+				errs = append(errs, templateErrs...)
+			}
+		}
+
+		return errs
+	})
+}
+
+func (a *App) withNeeds(r *Run, c DAGConfig, f func(*state.HelmState, []state.ReleaseSpec) []error) (bool, []error) {
 	st := r.state
-	helm := r.helm
 
 	selectedReleases, selectedAndNeededReleases, err := a.getSelectedReleases(r, c.IncludeTransitiveNeeds())
 	if err != nil {
@@ -1812,7 +1826,7 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 	// See https://github.com/roboll/helmfile/issues/1818 for more context.
 	st.Releases = selectedAndNeededReleases
 
-	batches, err := st.PlanReleases(state.PlanOptions{Reverse: false, SelectedReleases: selectedReleases, IncludeNeeds: c.IncludeNeeds(), IncludeTransitiveNeeds: c.IncludeTransitiveNeeds(), SkipNeeds: !c.IncludeNeeds()})
+	batches, err := st.PlanReleases(state.PlanOptions{Reverse: false, SelectedReleases: selectedReleases, IncludeNeeds: c.IncludeNeeds(), IncludeTransitiveNeeds: c.IncludeTransitiveNeeds(), SkipNeeds: c.SkipNeeds()})
 	if err != nil {
 		return false, []error{err}
 	}
@@ -1838,36 +1852,9 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 		}
 	}
 
-	var errs []error
-
 	// Traverse DAG of all the releases so that we don't suffer from false-positive missing dependencies
 	st.Releases = selectedReleasesWithNeeds
-
-	args := argparser.GetArgs(c.Args(), st)
-
-	// Reset the extra args if already set, not to break `helm fetch` by adding the args intended for `lint`
-	helm.SetExtraArgs()
-
-	if len(args) > 0 {
-		helm.SetExtraArgs(args...)
-	}
-
-	if len(toRender) > 0 {
-		_, templateErrs := withDAG(st, helm, a.Logger, state.PlanOptions{SelectedReleases: toRender, Reverse: false, SkipNeeds: true, IncludeTransitiveNeeds: c.IncludeTransitiveNeeds()}, a.WrapWithoutSelector(func(subst *state.HelmState, helm helmexec.Interface) []error {
-			opts := &state.TemplateOpts{
-				Set:               c.Set(),
-				IncludeCRDs:       c.IncludeCRDs(),
-				OutputDirTemplate: c.OutputDirTemplate(),
-				SkipCleanup:       c.SkipCleanup(),
-				SkipTests:         c.SkipTests(),
-			}
-			return subst.TemplateReleases(helm, c.OutputDir(), c.Values(), args, c.Concurrency(), c.Validate(), opts)
-		}))
-
-		if len(templateErrs) > 0 {
-			errs = append(errs, templateErrs...)
-		}
-	}
+	errs := f(st, toRender)
 	return true, errs
 }
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1793,7 +1793,7 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 		var errs []error
 
 		if len(toRender) > 0 {
-			_, templateErrs := withDAG(st, helm, a.Logger, state.PlanOptions{SelectedReleases: toRender, Reverse: false, SkipNeeds: c.SkipNeeds(), IncludeNeeds: c.IncludeNeeds(), IncludeTransitiveNeeds: c.IncludeTransitiveNeeds()}, a.WrapWithoutSelector(func(subst *state.HelmState, helm helmexec.Interface) []error {
+			_, templateErrs := withDAG(st, helm, a.Logger, state.PlanOptions{SelectedReleases: toRender, Reverse: false, SkipNeeds: c.SkipNeeds()}, a.WrapWithoutSelector(func(subst *state.HelmState, helm helmexec.Interface) []error {
 				opts := &state.TemplateOpts{
 					Set:               c.Set(),
 					IncludeCRDs:       c.IncludeCRDs(),

--- a/pkg/app/app_apply_nokubectx_test.go
+++ b/pkg/app/app_apply_nokubectx_test.go
@@ -208,6 +208,14 @@ releases:
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--namespacedefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
 				{Name: "my-release", Chart: "incubator/raw", Flags: "--namespacedefault--detailed-exitcode"}:       helmexec.ExitError{Code: 2},
 			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^external-secrets$", Flags: helmV2ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^my-release$", Flags: helmV2ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
 			log: `processing file "helmfile.yaml" in directory "."
@@ -284,14 +292,12 @@ GROUP RELEASES
 2     default/my-release
 
 processing releases in group 1/2: default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --deleting--deployed--failed--pending}
 processing releases in group 2/2: default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME               CHART           VERSION
-external-secrets   incubator/raw          
-my-release         incubator/raw          
+external-secrets   incubator/raw     3.1.0
+my-release         incubator/raw     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -466,6 +472,17 @@ releases:
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--namespacedefault--detailed-exitcode"}:                helmexec.ExitError{Code: 2},
 				{Name: "my-release", Chart: "incubator/raw", Flags: "--namespacedefault--detailed-exitcode"}:                      helmexec.ExitError{Code: 2},
 			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^kubernetes-external-secrets$", Flags: helmV2ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+kubernetes-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^external-secrets$", Flags: helmV2ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^my-release$", Flags: helmV2ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
 			log: `processing file "helmfile.yaml" in directory "."
@@ -544,17 +561,14 @@ GROUP RELEASES
 3     default/my-release
 
 processing releases in group 1/3: kube-system/kubernetes-external-secrets
-getting deployed release version failed:unexpected list key: {^kubernetes-external-secrets$ --deleting--deployed--failed--pending}
 processing releases in group 2/3: default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --deleting--deployed--failed--pending}
 processing releases in group 3/3: default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME                          CHART           VERSION
-kubernetes-external-secrets   incubator/raw          
-external-secrets              incubator/raw          
-my-release                    incubator/raw          
+kubernetes-external-secrets   incubator/raw     3.1.0
+external-secrets              incubator/raw     3.1.0
+my-release                    incubator/raw     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -596,11 +610,18 @@ releases:
 			},
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
-			lists:     nil,
 			diffs: map[exectest.DiffKey]error{
 				{Name: "kubernetes-external-secrets", Chart: "incubator/raw", Flags: "--namespacekube-system--detailed-exitcode"}: nil,
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--namespacedefault--detailed-exitcode"}:                helmexec.ExitError{Code: 2},
 				{Name: "my-release", Chart: "incubator/raw", Flags: "--namespacedefault--detailed-exitcode"}:                      helmexec.ExitError{Code: 2},
+			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^external-secrets$", Flags: helmV2ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^my-release$", Flags: helmV2ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -678,14 +699,12 @@ GROUP RELEASES
 2     default/my-release
 
 processing releases in group 1/2: default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --deleting--deployed--failed--pending}
 processing releases in group 2/2: default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME               CHART           VERSION
-external-secrets   incubator/raw          
-my-release         incubator/raw          
+external-secrets   incubator/raw     3.1.0
+my-release         incubator/raw     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -729,9 +748,14 @@ releases:
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
 			lists: map[exectest.ListKey]string{
-				// delete frontend-v1 and backend-v1
 				{Filter: "^kubernetes-external-secrets$", Flags: helmV2ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-^kubernetes-external-secrets$ 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
+				kubernetes-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^external-secrets$", Flags: helmV2ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^my-release$", Flags: helmV2ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
 `,
 			},
 			diffs: map[exectest.DiffKey]error{
@@ -822,14 +846,12 @@ GROUP RELEASES
 2     default/my-release
 
 processing releases in group 1/2: default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --deleting--deployed--failed--pending}
 processing releases in group 2/2: default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME               CHART           VERSION
-external-secrets   incubator/raw          
-my-release         incubator/raw          
+external-secrets   incubator/raw     3.1.0
+my-release         incubator/raw     3.1.0
 
 
 DELETED RELEASES:
@@ -877,8 +899,13 @@ releases:
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
 			lists: map[exectest.ListKey]string{
-				// delete frontend-v1 and backend-v1
 				{Filter: "^kubernetes-external-secrets$", Flags: helmV2ListFlagsWithoutKubeContext}: ``,
+				{Filter: "^external-secrets$", Flags: helmV2ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^my-release$", Flags: helmV2ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
 			},
 			diffs: map[exectest.DiffKey]error{
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--namespacedefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
@@ -962,14 +989,12 @@ GROUP RELEASES
 2     default/my-release
 
 processing releases in group 1/2: default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --deleting--deployed--failed--pending}
 processing releases in group 2/2: default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME               CHART           VERSION
-external-secrets   incubator/raw          
-my-release         incubator/raw          
+external-secrets   incubator/raw     3.1.0
+my-release         incubator/raw     3.1.0
 
 changing working directory back to "/path/to"
 `,

--- a/pkg/app/app_apply_test.go
+++ b/pkg/app/app_apply_test.go
@@ -210,6 +210,14 @@ releases:
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
 				{Name: "my-release", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}:       helmexec.ExitError{Code: 2},
 			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^my-release$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
 			log: `processing file "helmfile.yaml" in directory "."
@@ -286,14 +294,12 @@ GROUP RELEASES
 2     default/default/my-release
 
 processing releases in group 1/2: default/default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/2: default/default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME               CHART           VERSION
-external-secrets   incubator/raw          
-my-release         incubator/raw          
+external-secrets   incubator/raw     3.1.0
+my-release         incubator/raw     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -468,6 +474,17 @@ releases:
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}:                helmexec.ExitError{Code: 2},
 				{Name: "my-release", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}:                      helmexec.ExitError{Code: 2},
 			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^kubernetes-external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+kubernetes-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^my-release$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
 			log: `processing file "helmfile.yaml" in directory "."
@@ -546,17 +563,14 @@ GROUP RELEASES
 3     default/default/my-release
 
 processing releases in group 1/3: default/kube-system/kubernetes-external-secrets
-getting deployed release version failed:unexpected list key: {^kubernetes-external-secrets$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/3: default/default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 3/3: default/default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME                          CHART           VERSION
-kubernetes-external-secrets   incubator/raw          
-external-secrets              incubator/raw          
-my-release                    incubator/raw          
+kubernetes-external-secrets   incubator/raw     3.1.0
+external-secrets              incubator/raw     3.1.0
+my-release                    incubator/raw     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -598,11 +612,18 @@ releases:
 			},
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
-			lists:     nil,
 			diffs: map[exectest.DiffKey]error{
 				{Name: "kubernetes-external-secrets", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacekube-system--detailed-exitcode"}: nil,
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}:                helmexec.ExitError{Code: 2},
 				{Name: "my-release", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}:                      helmexec.ExitError{Code: 2},
+			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^my-release$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -680,14 +701,12 @@ GROUP RELEASES
 2     default/default/my-release
 
 processing releases in group 1/2: default/default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/2: default/default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME               CHART           VERSION
-external-secrets   incubator/raw          
-my-release         incubator/raw          
+external-secrets   incubator/raw     3.1.0
+my-release         incubator/raw     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -731,9 +750,14 @@ releases:
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
 			lists: map[exectest.ListKey]string{
-				// delete frontend-v1 and backend-v1
 				{Filter: "^kubernetes-external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-^kubernetes-external-secrets$ 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
+kubernetes-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
+				{Filter: "^external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^my-release$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
 `,
 			},
 			diffs: map[exectest.DiffKey]error{
@@ -824,14 +848,12 @@ GROUP RELEASES
 2     default/default/my-release
 
 processing releases in group 1/2: default/default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/2: default/default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME               CHART           VERSION
-external-secrets   incubator/raw          
-my-release         incubator/raw          
+external-secrets   incubator/raw     3.1.0
+my-release         incubator/raw     3.1.0
 
 
 DELETED RELEASES:
@@ -879,8 +901,13 @@ releases:
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
 			lists: map[exectest.ListKey]string{
-				// delete frontend-v1 and backend-v1
 				{Filter: "^kubernetes-external-secrets$", Flags: helmV2ListFlags}: ``,
+				{Filter: "^external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^my-release$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
 			},
 			diffs: map[exectest.DiffKey]error{
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
@@ -964,14 +991,12 @@ GROUP RELEASES
 2     default/default/my-release
 
 processing releases in group 1/2: default/default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/2: default/default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME               CHART           VERSION
-external-secrets   incubator/raw          
-my-release         incubator/raw          
+external-secrets   incubator/raw     3.1.0
+my-release         incubator/raw     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -1014,6 +1039,17 @@ releases:
 				{Name: "serviceA", Chart: "my/chart", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
 				{Name: "serviceB", Chart: "my/chart", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
 				{Name: "serviceC", Chart: "my/chart", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^serviceA$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+serviceA 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	chart-3.1.0	3.1.0      	default
+`,
+				{Filter: "^serviceB$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+serviceB 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	chart-3.1.0	3.1.0      	default
+`,
+				{Filter: "^serviceC$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+serviceC 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	chart-3.1.0	3.1.0      	default
+`,
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -1085,17 +1121,14 @@ GROUP RELEASES
 3     default//serviceA
 
 processing releases in group 1/3: default//serviceC
-getting deployed release version failed:unexpected list key: {^serviceC$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/3: default//serviceB
-getting deployed release version failed:unexpected list key: {^serviceB$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 3/3: default//serviceA
-getting deployed release version failed:unexpected list key: {^serviceA$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME       CHART      VERSION
-serviceC   my/chart          
-serviceB   my/chart          
-serviceA   my/chart          
+serviceC   my/chart     3.1.0
+serviceB   my/chart     3.1.0
+serviceA   my/chart     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -1231,6 +1264,11 @@ releases:
 			diffs: map[exectest.DiffKey]error{
 				{Name: "foo", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
 			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^foo$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
+			},
 			error: "",
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -1291,6 +1329,11 @@ releases:
 			upgraded:  []exectest.Release{},
 			diffs: map[exectest.DiffKey]error{
 				{Name: "foo", Chart: "incubator/raw", Flags: "--kube-contextdefault--namespacedefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^foo$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
 			},
 			error: "",
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result

--- a/pkg/app/app_diff_test.go
+++ b/pkg/app/app_diff_test.go
@@ -253,7 +253,7 @@ releases:
 		})
 	})
 
-	t.Run("include-transitive-needs fail on disabled transitive need", func(t *testing.T) {
+	t.Run("include-transitive-needs should not fail on disabled transitive need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:              false,
@@ -261,7 +261,10 @@ releases:
 				includeTransitiveNeeds: true,
 			},
 			selectors: []string{"name=test3"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			diffed: []exectest.Release{
+				{Name: "test2", Flags: []string{"--kube-context", "default"}},
+				{Name: "test3", Flags: []string{"--kube-context", "default"}},
+			},
 		})
 	})
 

--- a/pkg/app/app_diff_test.go
+++ b/pkg/app/app_diff_test.go
@@ -226,28 +226,30 @@ releases:
 		})
 	})
 
-	// TODO It seems liek helmfile-diff doesn't fail on disabled need, which is different from helmfile-lint and helmfile-template
-	// that fails in a same situation.
-
-	t.Run("include-needs fail on disabled direct need", func(t *testing.T) {
+	t.Run("include-needs should not fail on disabled direct need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:    false,
 				includeNeeds: true,
 			},
 			selectors: []string{"name=test2"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			diffed: []exectest.Release{
+				{Name: "test2", Flags: []string{"--kube-context", "default"}},
+			},
 		})
 	})
 
-	t.Run("include-needs fail on disabled transitive need", func(t *testing.T) {
+	t.Run("include-needs should not fail on disabled transitive need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:    false,
 				includeNeeds: true,
 			},
 			selectors: []string{"name=test3"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			diffed: []exectest.Release{
+				{Name: "test2", Flags: []string{"--kube-context", "default"}},
+				{Name: "test3", Flags: []string{"--kube-context", "default"}},
+			},
 		})
 	})
 
@@ -263,7 +265,7 @@ releases:
 		})
 	})
 
-	t.Run("include-needs with include-transitive-needs fail on disabled direct need", func(t *testing.T) {
+	t.Run("include-needs with include-transitive-needs should not fail on disabled direct need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:              false,
@@ -271,11 +273,13 @@ releases:
 				includeTransitiveNeeds: true,
 			},
 			selectors: []string{"name=test2"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			diffed: []exectest.Release{
+				{Name: "test2", Flags: []string{"--kube-context", "default"}},
+			},
 		})
 	})
 
-	t.Run("include-needs with include-transitive-needs fail on disabled transitive need", func(t *testing.T) {
+	t.Run("include-needs with include-transitive-needs should not fail on disabled transitive need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:              false,
@@ -283,7 +287,10 @@ releases:
 				includeTransitiveNeeds: true,
 			},
 			selectors: []string{"name=test3"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			diffed: []exectest.Release{
+				{Name: "test2", Flags: []string{"--kube-context", "default"}},
+				{Name: "test3", Flags: []string{"--kube-context", "default"}},
+			},
 		})
 	})
 

--- a/pkg/app/app_diff_test.go
+++ b/pkg/app/app_diff_test.go
@@ -4,9 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 
@@ -170,33 +168,7 @@ releases:
 			require.Equal(t, wantDiffs, helm.Diffed)
 		}()
 
-		testNameComponents := strings.Split(t.Name(), "/")
-		testBaseName := strings.ToLower(
-			strings.ReplaceAll(
-				testNameComponents[len(testNameComponents)-1],
-				" ",
-				"_",
-			),
-		)
-		wantLogFileDir := filepath.Join("testdata", "app_diff_test")
-		wantLogFile := filepath.Join(wantLogFileDir, testBaseName)
-		wantLogData, err := os.ReadFile(wantLogFile)
-		updateLogFile := err != nil
-		wantLog := string(wantLogData)
-		gotLog := bs.String()
-		if updateLogFile {
-			if err := os.MkdirAll(wantLogFileDir, 0755); err != nil {
-				t.Fatalf("unable to create directory %q: %v", wantLogFileDir, err)
-			}
-			if err := os.WriteFile(wantLogFile, bs.Bytes(), 0644); err != nil {
-				t.Fatalf("unable to update lint log snapshot: %v", err)
-			}
-		}
-
-		diff, exists := testhelper.Diff(wantLog, gotLog, 3)
-		if exists {
-			t.Errorf("unexpected log:\nDIFF\n%s\nEOD\nPlease remove %s and rerun the test to recapture this test snapshot", diff, wantLogFile)
-		}
+		testhelper.RequireLog(t, "app_diff_test", bs)
 	}
 
 	t.Run("fail on unselected need by default", func(t *testing.T) {

--- a/pkg/app/app_lint_test.go
+++ b/pkg/app/app_lint_test.go
@@ -254,25 +254,30 @@ releases:
 		})
 	})
 
-	t.Run("include-needs fail on disabled direct need", func(t *testing.T) {
+	t.Run("include-needs should not fail on disabled direct need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:    false,
 				includeNeeds: true,
 			},
 			selectors: []string{"name=test2"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			linted: []exectest.Release{
+				exectest.Release{Name: "test2", Flags: []string{}},
+			},
 		})
 	})
 
-	t.Run("include-needs fail on disabled transitive need", func(t *testing.T) {
+	t.Run("include-needs should not fail on disabled transitive need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:    false,
 				includeNeeds: true,
 			},
 			selectors: []string{"name=test3"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			linted: []exectest.Release{
+				exectest.Release{Name: "test2", Flags: []string{}},
+				exectest.Release{Name: "test3", Flags: []string{}},
+			},
 		})
 	})
 
@@ -288,7 +293,7 @@ releases:
 		})
 	})
 
-	t.Run("include-needs with include-transitive-needs fail on disabled direct need", func(t *testing.T) {
+	t.Run("include-needs with include-transitive-needs should not fail on disabled direct need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:              false,
@@ -296,11 +301,13 @@ releases:
 				includeTransitiveNeeds: true,
 			},
 			selectors: []string{"name=test2"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			linted: []exectest.Release{
+				exectest.Release{Name: "test2", Flags: []string{}},
+			},
 		})
 	})
 
-	t.Run("include-needs with include-transitive-needs fail on disabled transitive need", func(t *testing.T) {
+	t.Run("include-needs with include-transitive-needs should not fail on disabled transitive need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:              false,
@@ -308,7 +315,10 @@ releases:
 				includeTransitiveNeeds: true,
 			},
 			selectors: []string{"name=test3"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			linted: []exectest.Release{
+				exectest.Release{Name: "test2", Flags: []string{}},
+				exectest.Release{Name: "test3", Flags: []string{}},
+			},
 		})
 	})
 

--- a/pkg/app/app_lint_test.go
+++ b/pkg/app/app_lint_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/roboll/helmfile/pkg/exectest"
-	"github.com/roboll/helmfile/pkg/helmexec"
-	"github.com/roboll/helmfile/pkg/testhelper"
+	"github.com/helmfile/helmfile/pkg/exectest"
+	"github.com/helmfile/helmfile/pkg/helmexec"
+	"github.com/helmfile/helmfile/pkg/testhelper"
 	"github.com/stretchr/testify/require"
 	"github.com/variantdev/vals"
 )

--- a/pkg/app/app_lint_test.go
+++ b/pkg/app/app_lint_test.go
@@ -1,0 +1,304 @@
+package app
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/roboll/helmfile/pkg/exectest"
+	"github.com/roboll/helmfile/pkg/helmexec"
+	"github.com/roboll/helmfile/pkg/testhelper"
+	"github.com/stretchr/testify/require"
+	"github.com/variantdev/vals"
+)
+
+func TestLint(t *testing.T) {
+	type fields struct {
+		skipNeeds              bool
+		includeNeeds           bool
+		includeTransitiveNeeds bool
+	}
+
+	type testcase struct {
+		fields    fields
+		ns        string
+		error     string
+		selectors []string
+		linted    []exectest.Release
+	}
+
+	check := func(t *testing.T, tc testcase) {
+		t.Helper()
+
+		wantLints := tc.linted
+
+		var helm = &exectest.Helm{
+			FailOnUnexpectedList: true,
+			FailOnUnexpectedDiff: true,
+			DiffMutex:            &sync.Mutex{},
+			ChartsMutex:          &sync.Mutex{},
+			ReleasesMutex:        &sync.Mutex{},
+		}
+
+		bs := &bytes.Buffer{}
+
+		func() {
+			t.Helper()
+
+			logReader, logWriter := io.Pipe()
+
+			logFlushed := &sync.WaitGroup{}
+			// Ensure all the log is consumed into `bs` by calling `logWriter.Close()` followed by `logFlushed.Wait()`
+			logFlushed.Add(1)
+			go func() {
+				scanner := bufio.NewScanner(logReader)
+				for scanner.Scan() {
+					bs.Write(scanner.Bytes())
+					bs.WriteString("\n")
+				}
+				logFlushed.Done()
+			}()
+
+			defer func() {
+				// This is here to avoid data-trace on bytes buffer `bs` to capture logs
+				if err := logWriter.Close(); err != nil {
+					panic(err)
+				}
+				logFlushed.Wait()
+			}()
+
+			logger := helmexec.NewLogger(logWriter, "debug")
+
+			valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
+			if err != nil {
+				t.Errorf("unexpected error creating vals runtime: %v", err)
+			}
+
+			files := map[string]string{
+				"/path/to/helmfile.yaml": `
+releases:
+- name: logging
+  chart: incubator/raw
+  namespace: kube-system
+
+- name: kubernetes-external-secrets
+  chart: incubator/raw
+  namespace: kube-system
+  needs:
+  - kube-system/logging
+
+- name: external-secrets
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - kube-system/kubernetes-external-secrets
+
+- name: my-release
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - default/external-secrets
+
+
+# Disabled releases are treated as missing
+- name: disabled
+  chart: incubator/raw
+  namespace: kube-system
+  installed: false
+
+- name: test2
+  chart: incubator/raw
+  needs:
+  - kube-system/disabled
+
+- name: test3
+  chart: incubator/raw
+  needs:
+  - test2
+`,
+			}
+
+			app := appWithFs(&App{
+				OverrideHelmBinary:  DefaultHelmBinary,
+				glob:                filepath.Glob,
+				abs:                 filepath.Abs,
+				OverrideKubeContext: "default",
+				Env:                 "default",
+				Logger:              logger,
+				helms: map[helmKey]helmexec.Interface{
+					createHelmKey("helm", "default"): helm,
+				},
+				valsRuntime: valsRuntime,
+			}, files)
+
+			if tc.ns != "" {
+				app.Namespace = tc.ns
+			}
+
+			if tc.selectors != nil {
+				app.Selectors = tc.selectors
+			}
+
+			lintErr := app.Lint(applyConfig{
+				// if we check log output, concurrency must be 1. otherwise the test becomes non-deterministic.
+				concurrency:            1,
+				logger:                 logger,
+				skipNeeds:              tc.fields.skipNeeds,
+				includeNeeds:           tc.fields.includeNeeds,
+				includeTransitiveNeeds: tc.fields.includeTransitiveNeeds,
+			})
+
+			var gotErr string
+			if lintErr != nil {
+				gotErr = lintErr.Error()
+			}
+
+			if d := cmp.Diff(tc.error, gotErr); d != "" {
+				t.Fatalf("unexpected error: want (-), got (+): %s", d)
+			}
+
+			require.Equal(t, wantLints, helm.Linted)
+		}()
+
+		testNameComponents := strings.Split(t.Name(), "/")
+		testBaseName := strings.ToLower(
+			strings.ReplaceAll(
+				testNameComponents[len(testNameComponents)-1],
+				" ",
+				"_",
+			),
+		)
+		wantLogFileDir := filepath.Join("testdata", "app_lint_test")
+		wantLogFile := filepath.Join(wantLogFileDir, testBaseName)
+		wantLogData, err := os.ReadFile(wantLogFile)
+		updateLogFile := err != nil
+		wantLog := string(wantLogData)
+		gotLog := bs.String()
+		if updateLogFile {
+			if err := os.MkdirAll(wantLogFileDir, 0755); err != nil {
+				t.Fatalf("unable to create directory %q: %v", wantLogFileDir, err)
+			}
+			if err := os.WriteFile(wantLogFile, bs.Bytes(), 0644); err != nil {
+				t.Fatalf("unable to update lint log snapshot: %v", err)
+			}
+		}
+
+		diff, exists := testhelper.Diff(wantLog, gotLog, 3)
+		if exists {
+			t.Errorf("unexpected log:\nDIFF\n%s\nEOD", diff)
+		}
+	}
+
+	t.Run("skip-needs", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds: true,
+			},
+			selectors: []string{"app=test"},
+			linted: []exectest.Release{
+				{Name: "external-secrets", Flags: []string{"--namespace", "default"}},
+				{Name: "my-release", Flags: []string{"--namespace", "default"}},
+			},
+		})
+	})
+
+	t.Run("include-needs", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:    false,
+				includeNeeds: true,
+			},
+			error:     ``,
+			selectors: []string{"app=test"},
+			linted: []exectest.Release{
+				// TODO: Turned out we can't differentiate needs vs transitive needs in this case :thinking:
+				{Name: "logging", Flags: []string{"--namespace", "kube-system"}},
+				{Name: "kubernetes-external-secrets", Flags: []string{"--namespace", "kube-system"}},
+				{Name: "external-secrets", Flags: []string{"--namespace", "default"}},
+				{Name: "my-release", Flags: []string{"--namespace", "default"}},
+			},
+		})
+	})
+
+	t.Run("include-transitive-needs", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:              false,
+				includeTransitiveNeeds: true,
+			},
+			error:     ``,
+			selectors: []string{"app=test"},
+			linted: []exectest.Release{
+				{Name: "logging", Flags: []string{"--namespace", "kube-system"}},
+				{Name: "kubernetes-external-secrets", Flags: []string{"--namespace", "kube-system"}},
+				{Name: "external-secrets", Flags: []string{"--namespace", "default"}},
+				{Name: "my-release", Flags: []string{"--namespace", "default"}},
+			},
+		})
+	})
+
+	t.Run("include-needs fail on disabled direct need", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:    false,
+				includeNeeds: true,
+			},
+			selectors: []string{"name=test2"},
+			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+		})
+	})
+
+	t.Run("include-transitive-needs fail on disabled transitive need", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:              false,
+				includeNeeds:           false,
+				includeTransitiveNeeds: true,
+			},
+			selectors: []string{"name=test3"},
+			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+		})
+	})
+
+	t.Run("include-needs with include-transitive-needs fail on disabled direct need", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:              false,
+				includeNeeds:           true,
+				includeTransitiveNeeds: true,
+			},
+			selectors: []string{"name=test2"},
+			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+		})
+	})
+
+	t.Run("include-needs with include-transitive-needs fail on disabled transitive need", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:              false,
+				includeNeeds:           true,
+				includeTransitiveNeeds: true,
+			},
+			selectors: []string{"name=test3"},
+			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+		})
+	})
+
+	t.Run("bad selector", func(t *testing.T) {
+		check(t, testcase{
+			selectors: []string{"app=test_non_existent"},
+			linted:    nil,
+			error:     "err: no releases found that matches specified selector(app=test_non_existent) and environment(default), in any helmfile",
+		})
+	})
+}

--- a/pkg/app/app_lint_test.go
+++ b/pkg/app/app_lint_test.go
@@ -281,7 +281,7 @@ releases:
 		})
 	})
 
-	t.Run("include-transitive-needs fail on disabled transitive need", func(t *testing.T) {
+	t.Run("include-transitive-needs should not fail on disabled transitive need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:              false,
@@ -289,7 +289,10 @@ releases:
 				includeTransitiveNeeds: true,
 			},
 			selectors: []string{"name=test3"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			linted: []exectest.Release{
+				exectest.Release{Name: "test2", Flags: []string{}},
+				exectest.Release{Name: "test3", Flags: []string{}},
+			},
 		})
 	})
 

--- a/pkg/app/app_lint_test.go
+++ b/pkg/app/app_lint_test.go
@@ -258,6 +258,17 @@ releases:
 		})
 	})
 
+	t.Run("include-needs fail on disabled transitive need", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:    false,
+				includeNeeds: true,
+			},
+			selectors: []string{"name=test3"},
+			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+		})
+	})
+
 	t.Run("include-transitive-needs fail on disabled transitive need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{

--- a/pkg/app/app_lint_test.go
+++ b/pkg/app/app_lint_test.go
@@ -199,6 +199,13 @@ releases:
 		}
 	}
 
+	t.Run("fail on unselected need by default", func(t *testing.T) {
+		check(t, testcase{
+			selectors: []string{"app=test"},
+			error:     `in ./helmfile.yaml: release "default/default/external-secrets" depends on "default/kube-system/kubernetes-external-secrets" which does not match the selectors. Please add a selector like "--selector name=kubernetes-external-secrets", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+		})
+	})
+
 	t.Run("skip-needs", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{

--- a/pkg/app/app_sync_test.go
+++ b/pkg/app/app_sync_test.go
@@ -202,6 +202,14 @@ releases:
 				{Name: "external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 				{Name: "my-release", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
+				{Filter: "^my-release$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
+			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
 			log: `processing file "helmfile.yaml" in directory "."
@@ -278,14 +286,12 @@ GROUP RELEASES
 2     default/default/my-release
 
 processing releases in group 1/2: default/default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/2: default/default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME               CHART           VERSION
-external-secrets   incubator/raw          
-my-release         incubator/raw          
+external-secrets   incubator/raw     3.1.0
+my-release         incubator/raw     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -327,6 +333,17 @@ releases:
 			},
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^kubernetes-external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+kubernetes-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
+				{Filter: "^external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
+				{Filter: "^my-release$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
+			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
 			log: `processing file "helmfile.yaml" in directory "."
@@ -405,17 +422,14 @@ GROUP RELEASES
 3     default/default/my-release
 
 processing releases in group 1/3: default/kube-system/kubernetes-external-secrets
-getting deployed release version failed:unexpected list key: {^kubernetes-external-secrets$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/3: default/default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 3/3: default/default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME                          CHART           VERSION
-kubernetes-external-secrets   incubator/raw          
-external-secrets              incubator/raw          
-my-release                    incubator/raw          
+kubernetes-external-secrets   incubator/raw     3.1.0
+external-secrets              incubator/raw     3.1.0
+my-release                    incubator/raw     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -453,6 +467,17 @@ releases:
 			},
 			selectors: []string{"name=serviceA"},
 			upgraded:  []exectest.Release{},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^serviceC$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+serviceC 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	chart-3.1.0	3.1.0      	default
+				`,
+				{Filter: "^serviceB$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+serviceB 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	chart-3.1.0	3.1.0      	default
+				`,
+				{Filter: "^serviceA$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+serviceA 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	chart-3.1.0	3.1.0      	default
+				`,
+			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
 			log: `processing file "helmfile.yaml" in directory "."
@@ -523,17 +548,14 @@ GROUP RELEASES
 3     default//serviceA
 
 processing releases in group 1/3: default//serviceC
-getting deployed release version failed:unexpected list key: {^serviceC$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/3: default//serviceB
-getting deployed release version failed:unexpected list key: {^serviceB$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 3/3: default//serviceA
-getting deployed release version failed:unexpected list key: {^serviceA$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME       CHART      VERSION
-serviceC   my/chart          
-serviceB   my/chart          
-serviceA   my/chart          
+serviceC   my/chart     3.1.0
+serviceB   my/chart     3.1.0
+serviceA   my/chart     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -578,10 +600,15 @@ releases:
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
 			lists: map[exectest.ListKey]string{
-				// delete frontend-v1 and backend-v1
 				{Filter: "^kubernetes-external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-^kubernetes-external-secrets$ 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
-`,
+kubernetes-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
+				{Filter: "^external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
+				{Filter: "^my-release$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -667,14 +694,12 @@ GROUP RELEASES
 2     default/default/my-release
 
 processing releases in group 1/2: default/default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/2: default/default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME               CHART           VERSION
-external-secrets   incubator/raw          
-my-release         incubator/raw          
+external-secrets   incubator/raw     3.1.0
+my-release         incubator/raw     3.1.0
 
 
 DELETED RELEASES:
@@ -725,6 +750,12 @@ releases:
 			lists: map[exectest.ListKey]string{
 				// delete frontend-v1 and backend-v1
 				{Filter: "^kubernetes-external-secrets$", Flags: helmV2ListFlags}: ``,
+				{Filter: "^external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
+				{Filter: "^my-release$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+				`,
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -804,14 +835,12 @@ GROUP RELEASES
 2     default/default/my-release
 
 processing releases in group 1/2: default/default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/2: default/default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME               CHART           VERSION
-external-secrets   incubator/raw          
-my-release         incubator/raw          
+external-secrets   incubator/raw     3.1.0
+my-release         incubator/raw     3.1.0
 
 changing working directory back to "/path/to"
 `,

--- a/pkg/app/app_template_test.go
+++ b/pkg/app/app_template_test.go
@@ -281,7 +281,7 @@ releases:
 		})
 	})
 
-	t.Run("include-transitive-needs fail on disabled transitive need", func(t *testing.T) {
+	t.Run("include-transitive-needs should not fail on disabled transitive need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:              false,
@@ -289,7 +289,10 @@ releases:
 				includeTransitiveNeeds: true,
 			},
 			selectors: []string{"name=test3"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			templated: []exectest.Release{
+				exectest.Release{Name: "test2", Flags: []string(nil)},
+				exectest.Release{Name: "test3", Flags: []string(nil)},
+			},
 		})
 	})
 

--- a/pkg/app/app_template_test.go
+++ b/pkg/app/app_template_test.go
@@ -1,0 +1,322 @@
+package app
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/roboll/helmfile/pkg/exectest"
+	"github.com/roboll/helmfile/pkg/helmexec"
+	"github.com/roboll/helmfile/pkg/testhelper"
+	"github.com/stretchr/testify/require"
+	"github.com/variantdev/vals"
+)
+
+func TestTemplate(t *testing.T) {
+	type fields struct {
+		skipNeeds              bool
+		includeNeeds           bool
+		includeTransitiveNeeds bool
+	}
+
+	type testcase struct {
+		fields    fields
+		ns        string
+		error     string
+		selectors []string
+		linted    []exectest.Release
+	}
+
+	check := func(t *testing.T, tc testcase) {
+		t.Helper()
+
+		wantLints := tc.linted
+
+		var helm = &exectest.Helm{
+			FailOnUnexpectedList: true,
+			FailOnUnexpectedDiff: true,
+			DiffMutex:            &sync.Mutex{},
+			ChartsMutex:          &sync.Mutex{},
+			ReleasesMutex:        &sync.Mutex{},
+		}
+
+		bs := &bytes.Buffer{}
+
+		func() {
+			t.Helper()
+
+			logReader, logWriter := io.Pipe()
+
+			logFlushed := &sync.WaitGroup{}
+			// Ensure all the log is consumed into `bs` by calling `logWriter.Close()` followed by `logFlushed.Wait()`
+			logFlushed.Add(1)
+			go func() {
+				scanner := bufio.NewScanner(logReader)
+				for scanner.Scan() {
+					bs.Write(scanner.Bytes())
+					bs.WriteString("\n")
+				}
+				logFlushed.Done()
+			}()
+
+			defer func() {
+				// This is here to avoid data-trace on bytes buffer `bs` to capture logs
+				if err := logWriter.Close(); err != nil {
+					panic(err)
+				}
+				logFlushed.Wait()
+			}()
+
+			logger := helmexec.NewLogger(logWriter, "debug")
+
+			valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
+			if err != nil {
+				t.Errorf("unexpected error creating vals runtime: %v", err)
+			}
+
+			files := map[string]string{
+				"/path/to/helmfile.yaml": `
+releases:
+- name: logging
+  chart: incubator/raw
+  namespace: kube-system
+
+- name: kubernetes-external-secrets
+  chart: incubator/raw
+  namespace: kube-system
+  needs:
+  - kube-system/logging
+
+- name: external-secrets
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - kube-system/kubernetes-external-secrets
+
+- name: my-release
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - default/external-secrets
+
+
+# Disabled releases are treated as missing
+- name: disabled
+  chart: incubator/raw
+  namespace: kube-system
+  installed: false
+
+- name: test2
+  chart: incubator/raw
+  needs:
+  - kube-system/disabled
+
+- name: test3
+  chart: incubator/raw
+  needs:
+  - test2
+`,
+			}
+
+			app := appWithFs(&App{
+				OverrideHelmBinary:  DefaultHelmBinary,
+				glob:                filepath.Glob,
+				abs:                 filepath.Abs,
+				OverrideKubeContext: "default",
+				Env:                 "default",
+				Logger:              logger,
+				helms: map[helmKey]helmexec.Interface{
+					createHelmKey("helm", "default"): helm,
+				},
+				valsRuntime: valsRuntime,
+			}, files)
+
+			if tc.ns != "" {
+				app.Namespace = tc.ns
+			}
+
+			if tc.selectors != nil {
+				app.Selectors = tc.selectors
+			}
+
+			tmplErr := app.Template(applyConfig{
+				// if we check log output, concurrency must be 1. otherwise the test becomes non-deterministic.
+				concurrency:            1,
+				logger:                 logger,
+				skipNeeds:              tc.fields.skipNeeds,
+				includeNeeds:           tc.fields.includeNeeds,
+				includeTransitiveNeeds: tc.fields.includeTransitiveNeeds,
+			})
+
+			var gotErr string
+			if tmplErr != nil {
+				gotErr = tmplErr.Error()
+			}
+
+			if d := cmp.Diff(tc.error, gotErr); d != "" {
+				t.Fatalf("unexpected error: want (-), got (+): %s", d)
+			}
+
+			require.Equal(t, wantLints, helm.Templated)
+		}()
+
+		testNameComponents := strings.Split(t.Name(), "/")
+		testBaseName := strings.ToLower(
+			strings.ReplaceAll(
+				testNameComponents[len(testNameComponents)-1],
+				" ",
+				"_",
+			),
+		)
+		wantLogFileDir := filepath.Join("testdata", "app_template_test")
+		wantLogFile := filepath.Join(wantLogFileDir, testBaseName)
+		wantLogData, err := os.ReadFile(wantLogFile)
+		updateLogFile := err != nil
+		wantLog := string(wantLogData)
+		gotLog := bs.String()
+		if updateLogFile {
+			if err := os.MkdirAll(wantLogFileDir, 0755); err != nil {
+				t.Fatalf("unable to create directory %q: %v", wantLogFileDir, err)
+			}
+			if err := os.WriteFile(wantLogFile, bs.Bytes(), 0644); err != nil {
+				t.Fatalf("unable to update lint log snapshot: %v", err)
+			}
+		}
+
+		diff, exists := testhelper.Diff(wantLog, gotLog, 3)
+		if exists {
+			t.Errorf("unexpected log:\nDIFF\n%s\nEOD", diff)
+		}
+	}
+
+	t.Run("fail on unselected need by default", func(t *testing.T) {
+		check(t, testcase{
+			selectors: []string{"app=test"},
+			error:     `in ./helmfile.yaml: release "default/default/external-secrets" depends on "default/kube-system/kubernetes-external-secrets" which does not match the selectors. Please add a selector like "--selector name=kubernetes-external-secrets", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+		})
+	})
+
+	t.Run("skip-needs", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds: true,
+			},
+			selectors: []string{"app=test"},
+			linted: []exectest.Release{
+				{Name: "external-secrets", Flags: []string{"--namespace", "default"}},
+				{Name: "my-release", Flags: []string{"--namespace", "default"}},
+			},
+		})
+	})
+
+	t.Run("include-needs", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:    false,
+				includeNeeds: true,
+			},
+			error:     ``,
+			selectors: []string{"app=test"},
+			linted: []exectest.Release{
+				// TODO: Turned out we can't differentiate needs vs transitive needs in this case :thinking:
+				{Name: "logging", Flags: []string{"--namespace", "kube-system"}},
+				{Name: "kubernetes-external-secrets", Flags: []string{"--namespace", "kube-system"}},
+				{Name: "external-secrets", Flags: []string{"--namespace", "default"}},
+				{Name: "my-release", Flags: []string{"--namespace", "default"}},
+			},
+		})
+	})
+
+	t.Run("include-transitive-needs", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:              false,
+				includeTransitiveNeeds: true,
+			},
+			error:     ``,
+			selectors: []string{"app=test"},
+			linted: []exectest.Release{
+				{Name: "logging", Flags: []string{"--namespace", "kube-system"}},
+				{Name: "kubernetes-external-secrets", Flags: []string{"--namespace", "kube-system"}},
+				{Name: "external-secrets", Flags: []string{"--namespace", "default"}},
+				{Name: "my-release", Flags: []string{"--namespace", "default"}},
+			},
+		})
+	})
+
+	t.Run("include-needs fail on disabled direct need", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:    false,
+				includeNeeds: true,
+			},
+			selectors: []string{"name=test2"},
+			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+		})
+	})
+
+	t.Run("include-needs fail on disabled transitive need", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:    false,
+				includeNeeds: true,
+			},
+			selectors: []string{"name=test3"},
+			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+		})
+	})
+
+	t.Run("include-transitive-needs fail on disabled transitive need", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:              false,
+				includeNeeds:           false,
+				includeTransitiveNeeds: true,
+			},
+			selectors: []string{"name=test3"},
+			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+		})
+	})
+
+	t.Run("include-needs with include-transitive-needs fail on disabled direct need", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:              false,
+				includeNeeds:           true,
+				includeTransitiveNeeds: true,
+			},
+			selectors: []string{"name=test2"},
+			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+		})
+	})
+
+	t.Run("include-needs with include-transitive-needs fail on disabled transitive need", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:              false,
+				includeNeeds:           true,
+				includeTransitiveNeeds: true,
+			},
+			selectors: []string{"name=test3"},
+			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+		})
+	})
+
+	t.Run("bad selector", func(t *testing.T) {
+		check(t, testcase{
+			selectors: []string{"app=test_non_existent"},
+			linted:    nil,
+			error:     "err: no releases found that matches specified selector(app=test_non_existent) and environment(default), in any helmfile",
+		})
+	})
+}

--- a/pkg/app/app_template_test.go
+++ b/pkg/app/app_template_test.go
@@ -30,13 +30,13 @@ func TestTemplate(t *testing.T) {
 		ns        string
 		error     string
 		selectors []string
-		linted    []exectest.Release
+		templated []exectest.Release
 	}
 
 	check := func(t *testing.T, tc testcase) {
 		t.Helper()
 
-		wantLints := tc.linted
+		wantTemplates := tc.templated
 
 		var helm = &exectest.Helm{
 			FailOnUnexpectedList: true,
@@ -167,7 +167,7 @@ releases:
 				t.Fatalf("unexpected error: want (-), got (+): %s", d)
 			}
 
-			require.Equal(t, wantLints, helm.Templated)
+			require.Equal(t, wantTemplates, helm.Templated)
 		}()
 
 		testNameComponents := strings.Split(t.Name(), "/")
@@ -212,7 +212,7 @@ releases:
 				skipNeeds: true,
 			},
 			selectors: []string{"app=test"},
-			linted: []exectest.Release{
+			templated: []exectest.Release{
 				{Name: "external-secrets", Flags: []string{"--namespace", "default"}},
 				{Name: "my-release", Flags: []string{"--namespace", "default"}},
 			},
@@ -227,7 +227,7 @@ releases:
 			},
 			error:     ``,
 			selectors: []string{"app=test"},
-			linted: []exectest.Release{
+			templated: []exectest.Release{
 				// TODO: Turned out we can't differentiate needs vs transitive needs in this case :thinking:
 				{Name: "logging", Flags: []string{"--namespace", "kube-system"}},
 				{Name: "kubernetes-external-secrets", Flags: []string{"--namespace", "kube-system"}},
@@ -245,7 +245,7 @@ releases:
 			},
 			error:     ``,
 			selectors: []string{"app=test"},
-			linted: []exectest.Release{
+			templated: []exectest.Release{
 				{Name: "logging", Flags: []string{"--namespace", "kube-system"}},
 				{Name: "kubernetes-external-secrets", Flags: []string{"--namespace", "kube-system"}},
 				{Name: "external-secrets", Flags: []string{"--namespace", "default"}},
@@ -315,7 +315,7 @@ releases:
 	t.Run("bad selector", func(t *testing.T) {
 		check(t, testcase{
 			selectors: []string{"app=test_non_existent"},
-			linted:    nil,
+			templated: nil,
 			error:     "err: no releases found that matches specified selector(app=test_non_existent) and environment(default), in any helmfile",
 		})
 	})

--- a/pkg/app/app_template_test.go
+++ b/pkg/app/app_template_test.go
@@ -254,25 +254,30 @@ releases:
 		})
 	})
 
-	t.Run("include-needs fail on disabled direct need", func(t *testing.T) {
+	t.Run("include-needs should not fail on disabled direct need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:    false,
 				includeNeeds: true,
 			},
 			selectors: []string{"name=test2"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			templated: []exectest.Release{
+				exectest.Release{Name: "test2", Flags: []string(nil)},
+			},
 		})
 	})
 
-	t.Run("include-needs fail on disabled transitive need", func(t *testing.T) {
+	t.Run("include-needs should not fail on disabled transitive need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:    false,
 				includeNeeds: true,
 			},
 			selectors: []string{"name=test3"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			templated: []exectest.Release{
+				exectest.Release{Name: "test2", Flags: []string(nil)},
+				exectest.Release{Name: "test3", Flags: []string(nil)},
+			},
 		})
 	})
 
@@ -288,7 +293,7 @@ releases:
 		})
 	})
 
-	t.Run("include-needs with include-transitive-needs fail on disabled direct need", func(t *testing.T) {
+	t.Run("include-needs with include-transitive-needs should not fail on disabled direct need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:              false,
@@ -296,11 +301,13 @@ releases:
 				includeTransitiveNeeds: true,
 			},
 			selectors: []string{"name=test2"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			templated: []exectest.Release{
+				exectest.Release{Name: "test2", Flags: []string(nil)},
+			},
 		})
 	})
 
-	t.Run("include-needs with include-transitive-needs fail on disabled transitive need", func(t *testing.T) {
+	t.Run("include-needs with include-transitive-needs should not fail on disabled transitive need", func(t *testing.T) {
 		check(t, testcase{
 			fields: fields{
 				skipNeeds:              false,
@@ -308,7 +315,10 @@ releases:
 				includeTransitiveNeeds: true,
 			},
 			selectors: []string{"name=test3"},
-			error:     `in ./helmfile.yaml: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			templated: []exectest.Release{
+				exectest.Release{Name: "test2", Flags: []string(nil)},
+				exectest.Release{Name: "test3", Flags: []string(nil)},
+			},
 		})
 	})
 

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2871,11 +2871,32 @@ releases:
 			},
 			lists: map[exectest.ListKey]string{
 				// delete frontend-v1 and backend-v1
+				{Filter: "^logging$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+logging 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	fluent-bit-3.1.0	3.1.0      	default
+`,
+				{Filter: "^front-proxy$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+front-proxy 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	envoy-3.1.0	3.1.0      	default
+`,
+				{Filter: "^database$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+database 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mysql-3.1.0	3.1.0      	default
+`,
+				{Filter: "^servicemesh$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+servicemesh 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	istio-3.1.0	3.1.0      	default
+`,
+				{Filter: "^anotherbackend$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+anotherbackend 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	anotherbackend-3.1.0	3.1.0      	default
+`,
 				{Filter: "^frontend-v1$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-frontend-v1 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
+frontend-v1 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	frontend-3.1.0	3.1.0      	default
+`,
+				{Filter: "^frontend-v3$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+frontend-v3 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	frontend-3.1.0	3.1.0      	default
 `,
 				{Filter: "^backend-v1$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
 backend-v1 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
+`,
+				{Filter: "^backend-v2$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+backend-v2 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
 `,
 			},
 			// Disable concurrency to avoid in-deterministic result
@@ -2892,188 +2913,6 @@ backend-v1 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      
 			deleted: []exectest.Release{
 				{Name: "frontend-v1", Flags: []string{}},
 			},
-			log: `processing file "helmfile.yaml" in directory "."
-changing working directory to "/path/to"
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: database
- 3:   chart: charts/mysql
- 4:   needs:
- 5:   - logging
- 6: - name: frontend-v1
- 7:   chart: charts/frontend
- 8:   installed: false
- 9:   needs:
-10:   - servicemesh
-11:   - logging
-12:   - backend-v1
-13: - name: frontend-v2
-14:   chart: charts/frontend
-15:   needs:
-16:   - servicemesh
-17:   - logging
-18:   - backend-v2
-19: - name: frontend-v3
-20:   chart: charts/frontend
-21:   needs:
-22:   - servicemesh
-23:   - logging
-24:   - backend-v2
-25: - name: backend-v1
-26:   chart: charts/backend
-27:   installed: false
-28:   needs:
-29:   - servicemesh
-30:   - logging
-31:   - database
-32:   - anotherbackend
-33: - name: backend-v2
-34:   chart: charts/backend
-35:   needs:
-36:   - servicemesh
-37:   - logging
-38:   - database
-39:   - anotherbackend
-40: - name: anotherbackend
-41:   chart: charts/anotherbackend
-42:   needs:
-43:   - servicemesh
-44:   - logging
-45:   - database
-46: - name: servicemesh
-47:   chart: charts/istio
-48:   needs:
-49:   - logging
-50: - name: logging
-51:   chart: charts/fluent-bit
-52: - name: front-proxy
-53:   chart: stable/envoy
-54: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: database
- 3:   chart: charts/mysql
- 4:   needs:
- 5:   - logging
- 6: - name: frontend-v1
- 7:   chart: charts/frontend
- 8:   installed: false
- 9:   needs:
-10:   - servicemesh
-11:   - logging
-12:   - backend-v1
-13: - name: frontend-v2
-14:   chart: charts/frontend
-15:   needs:
-16:   - servicemesh
-17:   - logging
-18:   - backend-v2
-19: - name: frontend-v3
-20:   chart: charts/frontend
-21:   needs:
-22:   - servicemesh
-23:   - logging
-24:   - backend-v2
-25: - name: backend-v1
-26:   chart: charts/backend
-27:   installed: false
-28:   needs:
-29:   - servicemesh
-30:   - logging
-31:   - database
-32:   - anotherbackend
-33: - name: backend-v2
-34:   chart: charts/backend
-35:   needs:
-36:   - servicemesh
-37:   - logging
-38:   - database
-39:   - anotherbackend
-40: - name: anotherbackend
-41:   chart: charts/anotherbackend
-42:   needs:
-43:   - servicemesh
-44:   - logging
-45:   - database
-46: - name: servicemesh
-47:   chart: charts/istio
-48:   needs:
-49:   - logging
-50: - name: logging
-51:   chart: charts/fluent-bit
-52: - name: front-proxy
-53:   chart: stable/envoy
-54: 
-
-merged environment: &{default map[] map[]}
-10 release(s) found in helmfile.yaml
-
-Affected releases are:
-  anotherbackend (charts/anotherbackend) UPDATED
-  backend-v1 (charts/backend) DELETED
-  backend-v2 (charts/backend) UPDATED
-  database (charts/mysql) UPDATED
-  front-proxy (stable/envoy) UPDATED
-  frontend-v1 (charts/frontend) DELETED
-  frontend-v3 (charts/frontend) UPDATED
-  logging (charts/fluent-bit) UPDATED
-  servicemesh (charts/istio) UPDATED
-
-processing 2 groups of releases in this order:
-GROUP RELEASES
-1     default//frontend-v1
-2     default//backend-v1
-
-processing releases in group 1/2: default//frontend-v1
-processing releases in group 2/2: default//backend-v1
-processing 5 groups of releases in this order:
-GROUP RELEASES
-1     default//logging, default//front-proxy
-2     default//database, default//servicemesh
-3     default//anotherbackend
-4     default//backend-v2
-5     default//frontend-v3
-
-processing releases in group 1/5: default//logging, default//front-proxy
-getting deployed release version failed:unexpected list key: {^logging$ --kube-contextdefault--deleting--deployed--failed--pending}
-getting deployed release version failed:unexpected list key: {^front-proxy$ --kube-contextdefault--deleting--deployed--failed--pending}
-processing releases in group 2/5: default//database, default//servicemesh
-getting deployed release version failed:unexpected list key: {^database$ --kube-contextdefault--deleting--deployed--failed--pending}
-getting deployed release version failed:unexpected list key: {^servicemesh$ --kube-contextdefault--deleting--deployed--failed--pending}
-processing releases in group 3/5: default//anotherbackend
-getting deployed release version failed:unexpected list key: {^anotherbackend$ --kube-contextdefault--deleting--deployed--failed--pending}
-processing releases in group 4/5: default//backend-v2
-getting deployed release version failed:unexpected list key: {^backend-v2$ --kube-contextdefault--deleting--deployed--failed--pending}
-processing releases in group 5/5: default//frontend-v3
-getting deployed release version failed:unexpected list key: {^frontend-v3$ --kube-contextdefault--deleting--deployed--failed--pending}
-
-UPDATED RELEASES:
-NAME             CHART                   VERSION
-logging          charts/fluent-bit              
-front-proxy      stable/envoy                   
-database         charts/mysql                   
-servicemesh      charts/istio                   
-anotherbackend   charts/anotherbackend          
-backend-v2       charts/backend                 
-frontend-v3      charts/frontend                
-
-
-DELETED RELEASES:
-NAME
-frontend-v1
-backend-v1
-changing working directory back to "/path/to"
-`,
 		},
 		//
 		// noop: no changes
@@ -3137,68 +2976,6 @@ releases:
 			},
 			deleted:     []exectest.Release{},
 			concurrency: 1,
-			log: `processing file "helmfile.yaml" in directory "."
-changing working directory to "/path/to"
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: baz
- 3:   chart: stable/mychart3
- 4: - name: foo
- 5:   chart: stable/mychart1
- 6:   needs:
- 7:   - bar
- 8: - name: bar
- 9:   chart: stable/mychart2
-10: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: baz
- 3:   chart: stable/mychart3
- 4: - name: foo
- 5:   chart: stable/mychart1
- 6:   needs:
- 7:   - bar
- 8: - name: bar
- 9:   chart: stable/mychart2
-10: 
-
-merged environment: &{default map[] map[]}
-3 release(s) found in helmfile.yaml
-
-Affected releases are:
-  bar (stable/mychart2) UPDATED
-  baz (stable/mychart3) UPDATED
-  foo (stable/mychart1) UPDATED
-
-processing 2 groups of releases in this order:
-GROUP RELEASES
-1     default//baz, default//bar
-2     default//foo
-
-processing releases in group 1/2: default//baz, default//bar
-getting deployed release version failed:unexpected list key: {^baz$ --kube-contextdefault--deleting--deployed--failed--pending}
-getting deployed release version failed:unexpected list key: {^bar$ --kube-contextdefault--deleting--deployed--failed--pending}
-processing releases in group 2/2: default//foo
-getting deployed release version failed:unexpected list key: {^foo$ --kube-contextdefault--deleting--deployed--failed--pending}
-
-UPDATED RELEASES:
-NAME   CHART             VERSION
-baz    stable/mychart3          
-bar    stable/mychart2          
-foo    stable/mychart1          
-
-changing working directory back to "/path/to"
-`,
 		},
 		//
 		// install with upgrade
@@ -3621,6 +3398,14 @@ releases:
 				{Name: "foo", Flags: []string{"--tiller-namespace", "tns1", "--kube-context", "default", "--namespace", "ns1"}},
 				{Name: "bar", Flags: []string{"--tiller-namespace", "tns2", "--kube-context", "default", "--namespace", "ns2"}},
 			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^foo$", Flags: "--tiller-namespacetns1" + helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
+`,
+				{Filter: "^bar$", Flags: "--tiller-namespacetns2" + helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
+`,
+			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
 			log: `processing file "helmfile.yaml" in directory "."
@@ -3675,14 +3460,12 @@ GROUP RELEASES
 2     default/tns2/bar
 
 processing releases in group 1/2: default/tns1/foo
-getting deployed release version failed:unexpected list key: {^foo$ --tiller-namespacetns1--kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/2: default/tns2/bar
-getting deployed release version failed:unexpected list key: {^bar$ --tiller-namespacetns2--kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME   CHART             VERSION
-foo    stable/mychart1          
-bar    stable/mychart2          
+foo    stable/mychart1     3.1.0
+bar    stable/mychart2     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -3940,6 +3723,14 @@ releases:
 				{Name: "external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 				{Name: "my-release", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^external-secrets$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+				{Filter: "^my-release$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
+`,
+			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
 			log: `processing file "helmfile.yaml" in directory "."
@@ -4016,14 +3807,12 @@ GROUP RELEASES
 2     default/default/my-release
 
 processing releases in group 1/2: default/default/external-secrets
-getting deployed release version failed:unexpected list key: {^external-secrets$ --kube-contextdefault--deleting--deployed--failed--pending}
 processing releases in group 2/2: default/default/my-release
-getting deployed release version failed:unexpected list key: {^my-release$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME               CHART           VERSION
-external-secrets   incubator/raw          
-my-release         incubator/raw          
+external-secrets   incubator/raw     3.1.0
+my-release         incubator/raw     3.1.0
 
 changing working directory back to "/path/to"
 `,
@@ -4572,6 +4361,8 @@ changing working directory back to "/path/to"
 				if exists {
 					t.Errorf("unexpected log for data defined %s:\nDIFF\n%s\nEOD", tc.loc, diff)
 				}
+			} else {
+				assertEqualsToSnapshot(t, "log", bs.String())
 			}
 		})
 	}

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2360,6 +2360,10 @@ type applyConfig struct {
 	logger                 *zap.SugaredLogger
 	wait                   bool
 	waitForJobs            bool
+
+	// template-only options
+	includeCRDs, skipTests       bool
+	outputDir, outputDirTemplate string
 }
 
 func (a applyConfig) Args() string {
@@ -2468,6 +2472,23 @@ func (a applyConfig) RetainValuesFiles() bool {
 
 func (a applyConfig) SkipDiffOnInstall() bool {
 	return a.skipDiffOnInstall
+}
+
+// helmfile-template-only flags
+
+func (a applyConfig) IncludeCRDs() bool {
+	return a.includeCRDs
+}
+
+func (a applyConfig) SkipTests() bool {
+	return a.skipTests
+}
+
+func (a applyConfig) OutputDir() string {
+	return a.outputDir
+}
+func (a applyConfig) OutputDirTemplate() string {
+	return a.outputDirTemplate
 }
 
 type depsConfig struct {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -66,9 +66,7 @@ type ApplyConfigProvider interface {
 	SkipCleanup() bool
 	SkipDiffOnInstall() bool
 
-	SkipNeeds() bool
-	IncludeNeeds() bool
-	IncludeTransitiveNeeds() bool
+	DAGConfig
 
 	concurrencyConfig
 	interactive
@@ -90,6 +88,7 @@ type SyncConfigProvider interface {
 	SkipNeeds() bool
 	IncludeNeeds() bool
 	IncludeTransitiveNeeds() bool
+	DAGConfig
 
 	concurrencyConfig
 	loggingConfig
@@ -112,8 +111,7 @@ type DiffConfigProvider interface {
 	SuppressDiff() bool
 	SkipDiffOnInstall() bool
 
-	SkipNeeds() bool
-	IncludeNeeds() bool
+	DAGConfig
 
 	DetailedExitcode() bool
 	Color() bool
@@ -164,6 +162,8 @@ type LintConfigProvider interface {
 	SkipDeps() bool
 	SkipCleanup() bool
 
+	DAGConfig
+
 	concurrencyConfig
 }
 
@@ -186,10 +186,16 @@ type TemplateConfigProvider interface {
 	SkipTests() bool
 	OutputDir() string
 	IncludeCRDs() bool
-	IncludeNeeds() bool
-	IncludeTransitiveNeeds() bool
+
+	DAGConfig
 
 	concurrencyConfig
+}
+
+type DAGConfig interface {
+	SkipNeeds() bool
+	IncludeNeeds() bool
+	IncludeTransitiveNeeds() bool
 }
 
 type WriteValuesConfigProvider interface {

--- a/pkg/app/diff_nokubectx_test.go
+++ b/pkg/app/diff_nokubectx_test.go
@@ -128,145 +128,6 @@ backend-v1 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      
 			concurrency: 1,
 			upgraded:    []exectest.Release{},
 			deleted:     []exectest.Release{},
-			log: `processing file "helmfile.yaml" in directory "."
-changing working directory to "/path/to"
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: database
- 3:   chart: charts/mysql
- 4:   needs:
- 5:   - logging
- 6: - name: frontend-v1
- 7:   chart: charts/frontend
- 8:   installed: false
- 9:   needs:
-10:   - servicemesh
-11:   - logging
-12:   - backend-v1
-13: - name: frontend-v2
-14:   chart: charts/frontend
-15:   needs:
-16:   - servicemesh
-17:   - logging
-18:   - backend-v2
-19: - name: frontend-v3
-20:   chart: charts/frontend
-21:   needs:
-22:   - servicemesh
-23:   - logging
-24:   - backend-v2
-25: - name: backend-v1
-26:   chart: charts/backend
-27:   installed: false
-28:   needs:
-29:   - servicemesh
-30:   - logging
-31:   - database
-32:   - anotherbackend
-33: - name: backend-v2
-34:   chart: charts/backend
-35:   needs:
-36:   - servicemesh
-37:   - logging
-38:   - database
-39:   - anotherbackend
-40: - name: anotherbackend
-41:   chart: charts/anotherbackend
-42:   needs:
-43:   - servicemesh
-44:   - logging
-45:   - database
-46: - name: servicemesh
-47:   chart: charts/istio
-48:   needs:
-49:   - logging
-50: - name: logging
-51:   chart: charts/fluent-bit
-52: - name: front-proxy
-53:   chart: stable/envoy
-54: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: database
- 3:   chart: charts/mysql
- 4:   needs:
- 5:   - logging
- 6: - name: frontend-v1
- 7:   chart: charts/frontend
- 8:   installed: false
- 9:   needs:
-10:   - servicemesh
-11:   - logging
-12:   - backend-v1
-13: - name: frontend-v2
-14:   chart: charts/frontend
-15:   needs:
-16:   - servicemesh
-17:   - logging
-18:   - backend-v2
-19: - name: frontend-v3
-20:   chart: charts/frontend
-21:   needs:
-22:   - servicemesh
-23:   - logging
-24:   - backend-v2
-25: - name: backend-v1
-26:   chart: charts/backend
-27:   installed: false
-28:   needs:
-29:   - servicemesh
-30:   - logging
-31:   - database
-32:   - anotherbackend
-33: - name: backend-v2
-34:   chart: charts/backend
-35:   needs:
-36:   - servicemesh
-37:   - logging
-38:   - database
-39:   - anotherbackend
-40: - name: anotherbackend
-41:   chart: charts/anotherbackend
-42:   needs:
-43:   - servicemesh
-44:   - logging
-45:   - database
-46: - name: servicemesh
-47:   chart: charts/istio
-48:   needs:
-49:   - logging
-50: - name: logging
-51:   chart: charts/fluent-bit
-52: - name: front-proxy
-53:   chart: stable/envoy
-54: 
-
-merged environment: &{default map[] map[]}
-10 release(s) found in helmfile.yaml
-
-Affected releases are:
-  anotherbackend (charts/anotherbackend) UPDATED
-  backend-v1 (charts/backend) DELETED
-  backend-v2 (charts/backend) UPDATED
-  database (charts/mysql) UPDATED
-  front-proxy (stable/envoy) UPDATED
-  frontend-v1 (charts/frontend) DELETED
-  frontend-v3 (charts/frontend) UPDATED
-  logging (charts/fluent-bit) UPDATED
-  servicemesh (charts/istio) UPDATED
-
-changing working directory back to "/path/to"
-`,
 		},
 		//
 		// noop: no changes
@@ -330,51 +191,6 @@ releases:
 			upgraded:    []exectest.Release{},
 			deleted:     []exectest.Release{},
 			concurrency: 1,
-			log: `processing file "helmfile.yaml" in directory "."
-changing working directory to "/path/to"
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: baz
- 3:   chart: mychart3
- 4: - name: foo
- 5:   chart: mychart1
- 6:   needs:
- 7:   - bar
- 8: - name: bar
- 9:   chart: mychart2
-10: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: baz
- 3:   chart: mychart3
- 4: - name: foo
- 5:   chart: mychart1
- 6:   needs:
- 7:   - bar
- 8: - name: bar
- 9:   chart: mychart2
-10: 
-
-merged environment: &{default map[] map[]}
-3 release(s) found in helmfile.yaml
-
-Affected releases are:
-  bar (mychart2) UPDATED
-  baz (mychart3) UPDATED
-  foo (mychart1) UPDATED
-
-changing working directory back to "/path/to"
-`,
 		},
 		//
 		// upgrades
@@ -518,7 +334,7 @@ releases:
 			upgraded: []exectest.Release{},
 		},
 		{
-			name: "helm2: upgrade when tns1/foo needs tns2/bar",
+			name: "helm2 upgrade when tns1 foo needs tns2 bar",
 			loc:  location(),
 
 			files: map[string]string{
@@ -545,7 +361,7 @@ releases:
 			upgraded: []exectest.Release{},
 		},
 		{
-			name: "helm2: upgrade when tns2/bar needs tns1/foo",
+			name: "helm2 upgrade when tns2 bar needs tns1 foo",
 			loc:  location(),
 			files: map[string]string{
 				"/path/to/helmfile.yaml": `
@@ -571,57 +387,9 @@ releases:
 			upgraded: []exectest.Release{},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
-			log: `processing file "helmfile.yaml" in directory "."
-changing working directory to "/path/to"
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: bar
- 3:   chart: mychart2
- 4:   namespace: ns2
- 5:   tillerNamespace: tns2
- 6:   needs:
- 7:   - tns1/foo
- 8: - name: foo
- 9:   chart: mychart1
-10:   namespace: ns1
-11:   tillerNamespace: tns1
-12: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: bar
- 3:   chart: mychart2
- 4:   namespace: ns2
- 5:   tillerNamespace: tns2
- 6:   needs:
- 7:   - tns1/foo
- 8: - name: foo
- 9:   chart: mychart1
-10:   namespace: ns1
-11:   tillerNamespace: tns1
-12: 
-
-merged environment: &{default map[] map[]}
-2 release(s) found in helmfile.yaml
-
-Affected releases are:
-  bar (mychart2) UPDATED
-  foo (mychart1) UPDATED
-
-changing working directory back to "/path/to"
-`,
 		},
 		{
-			name: "helm3: upgrade when ns2/bar needs ns1/foo",
+			name: "helm3 upgrade when ns2 bar needs ns1 foo",
 			loc:  location(),
 			files: map[string]string{
 				"/path/to/helmfile.yaml": `
@@ -645,50 +413,6 @@ releases:
 			upgraded: []exectest.Release{},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
-			log: `processing file "helmfile.yaml" in directory "."
-changing working directory to "/path/to"
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: bar
- 3:   chart: mychart2
- 4:   namespace: ns2
- 5:   needs:
- 6:   - ns1/foo
- 7: - name: foo
- 8:   chart: mychart1
- 9:   namespace: ns1
-10: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: bar
- 3:   chart: mychart2
- 4:   namespace: ns2
- 5:   needs:
- 6:   - ns1/foo
- 7: - name: foo
- 8:   chart: mychart1
- 9:   namespace: ns1
-10: 
-
-merged environment: &{default map[] map[]}
-2 release(s) found in helmfile.yaml
-
-Affected releases are:
-  bar (mychart2) UPDATED
-  foo (mychart1) UPDATED
-
-changing working directory back to "/path/to"
-`,
 		},
 		//
 		// deletes: deleting all releases in the correct order
@@ -910,7 +634,7 @@ releases:
 `,
 			},
 			detailedExitcode: true,
-			error:            "Identified at least one change",
+			error:            `in ./helmfile.yaml: release "bar" depends on "foo" which does not match the selectors. Please add a selector like "--selector name=foo", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
 			diffs: map[exectest.DiffKey]error{
 				{Name: "bar", Chart: "mychart2", Flags: "--detailed-exitcode"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--detailed-exitcode"}: helmexec.ExitError{Code: 2},
@@ -1002,76 +726,6 @@ releases:
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
 			error:       "Identified at least one change",
-			log: `processing file "helmfile.yaml" in directory "."
-changing working directory to "/path/to"
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: 
- 2: 
- 3: releases:
- 4: - name: kubernetes-external-secrets
- 5:   chart: incubator/raw
- 6:   namespace: kube-system
- 7: 
- 8: - name: external-secrets
- 9:   chart: incubator/raw
-10:   namespace: default
-11:   labels:
-12:     app: test
-13:   needs:
-14:   - kube-system/kubernetes-external-secrets
-15: 
-16: - name: my-release
-17:   chart: incubator/raw
-18:   namespace: default
-19:   labels:
-20:     app: test
-21:   needs:
-22:   - default/external-secrets
-23: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: 
- 2: 
- 3: releases:
- 4: - name: kubernetes-external-secrets
- 5:   chart: incubator/raw
- 6:   namespace: kube-system
- 7: 
- 8: - name: external-secrets
- 9:   chart: incubator/raw
-10:   namespace: default
-11:   labels:
-12:     app: test
-13:   needs:
-14:   - kube-system/kubernetes-external-secrets
-15: 
-16: - name: my-release
-17:   chart: incubator/raw
-18:   namespace: default
-19:   labels:
-20:     app: test
-21:   needs:
-22:   - default/external-secrets
-23: 
-
-merged environment: &{default map[] map[]}
-2 release(s) matching app=test found in helmfile.yaml
-
-Affected releases are:
-  external-secrets (incubator/raw) UPDATED
-  my-release (incubator/raw) UPDATED
-
-changing working directory back to "/path/to"
-`,
 		},
 		{
 			name:  "upgrades with good selector with --skip-needs=false",
@@ -1480,6 +1134,8 @@ changing working directory back to "/path/to"
 				if exists {
 					t.Errorf("unexpected log for data defined %s:\nDIFF\n%s\nEOD", tc.loc, diff)
 				}
+			} else {
+				testhelper.RequireLog(t, "app_diff_test_2", bs)
 			}
 		})
 	}

--- a/pkg/app/diff_test.go
+++ b/pkg/app/diff_test.go
@@ -140,7 +140,8 @@ func (a diffConfig) RetainValuesFiles() bool {
 
 func TestDiff(t *testing.T) {
 	type flags struct {
-		skipNeeds bool
+		skipNeeds    bool
+		includeNeeds bool
 	}
 
 	testcases := []struct {
@@ -931,7 +932,77 @@ releases:
 `,
 			},
 			detailedExitcode: true,
-			error:            "Identified at least one change",
+			error:            `in ./helmfile.yaml: release "default//foo" depends on "default//bar" which does not match the selectors. Please add a selector like "--selector name=bar", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			diffs: map[exectest.DiffKey]error{
+				{Name: "bar", Chart: "mychart2", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+				{Name: "foo", Chart: "mychart1", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^foo$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
+`,
+				{Filter: "^bar$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
+`,
+			},
+			upgraded: []exectest.Release{},
+			deleted:  []exectest.Release{},
+		},
+		{
+			name: "delete bar when foo needs bar with include-needs",
+			loc:  location(),
+			files: map[string]string{
+				"/path/to/helmfile.yaml": `
+releases:
+- name: bar
+  chart: mychart2
+  installed: false
+- name: foo
+  chart: mychart1
+  needs:
+  - bar
+`,
+			},
+			detailedExitcode: true,
+			flags: flags{
+				includeNeeds: true,
+			},
+			error: "Identified at least one change",
+			diffs: map[exectest.DiffKey]error{
+				{Name: "bar", Chart: "mychart2", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+				{Name: "foo", Chart: "mychart1", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^foo$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
+`,
+				{Filter: "^bar$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
+`,
+			},
+			upgraded: []exectest.Release{},
+			deleted:  []exectest.Release{},
+		},
+		{
+			name: "delete bar when foo needs bar with skip-needs",
+			loc:  location(),
+			files: map[string]string{
+				"/path/to/helmfile.yaml": `
+releases:
+- name: bar
+  chart: mychart2
+  installed: false
+- name: foo
+  chart: mychart1
+  needs:
+  - bar
+`,
+			},
+			detailedExitcode: true,
+			flags: flags{
+				skipNeeds: true,
+			},
+			error: "Identified at least one change",
 			diffs: map[exectest.DiffKey]error{
 				{Name: "bar", Chart: "mychart2", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
@@ -961,6 +1032,76 @@ releases:
   needs:
   - foo
 `,
+			},
+			detailedExitcode: true,
+			error:            `in ./helmfile.yaml: release "default//bar" depends on "default//foo" which does not match the selectors. Please add a selector like "--selector name=foo", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies`,
+			diffs: map[exectest.DiffKey]error{
+				{Name: "bar", Chart: "mychart2", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+				{Name: "foo", Chart: "mychart1", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^foo$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
+`,
+				{Filter: "^bar$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
+`,
+			},
+			upgraded: []exectest.Release{},
+			deleted:  []exectest.Release{},
+		},
+		{
+			name: "delete foo when bar needs foo with include-needs",
+			loc:  location(),
+			files: map[string]string{
+				"/path/to/helmfile.yaml": `
+releases:
+- name: foo
+  chart: mychart1
+  installed: false
+- name: bar
+  chart: mychart2
+  needs:
+  - foo
+`,
+			},
+			flags: flags{
+				includeNeeds: true,
+			},
+			detailedExitcode: true,
+			error:            "Identified at least one change",
+			diffs: map[exectest.DiffKey]error{
+				{Name: "bar", Chart: "mychart2", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+				{Name: "foo", Chart: "mychart1", Flags: "--kube-contextdefault--detailed-exitcode"}: helmexec.ExitError{Code: 2},
+			},
+			lists: map[exectest.ListKey]string{
+				{Filter: "^foo$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
+`,
+				{Filter: "^bar$", Flags: helmV2ListFlags}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
+bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
+`,
+			},
+			upgraded: []exectest.Release{},
+			deleted:  []exectest.Release{},
+		},
+		{
+			name: "delete foo when bar needs foo with skip-needs",
+			loc:  location(),
+			files: map[string]string{
+				"/path/to/helmfile.yaml": `
+releases:
+- name: foo
+  chart: mychart1
+  installed: false
+- name: bar
+  chart: mychart2
+  needs:
+  - foo
+`,
+			},
+			flags: flags{
+				skipNeeds: true,
 			},
 			detailedExitcode: true,
 			error:            "Identified at least one change",
@@ -1547,6 +1688,7 @@ changing working directory back to "/path/to"
 					logger:           logger,
 					detailedExitcode: tc.detailedExitcode,
 					skipNeeds:        tc.flags.skipNeeds,
+					includeNeeds:     tc.flags.includeNeeds,
 				})
 
 				var diffErrStr string

--- a/pkg/app/diff_test.go
+++ b/pkg/app/diff_test.go
@@ -17,28 +17,29 @@ import (
 )
 
 type diffConfig struct {
-	args              string
-	values            []string
-	retainValuesFiles bool
-	set               []string
-	validate          bool
-	skipCRDs          bool
-	skipDeps          bool
-	includeTests      bool
-	includeNeeds      bool
-	skipNeeds         bool
-	suppress          []string
-	suppressSecrets   bool
-	showSecrets       bool
-	suppressDiff      bool
-	noColor           bool
-	context           int
-	diffOutput        string
-	concurrency       int
-	detailedExitcode  bool
-	interactive       bool
-	skipDiffOnInstall bool
-	logger            *zap.SugaredLogger
+	args                   string
+	values                 []string
+	retainValuesFiles      bool
+	set                    []string
+	validate               bool
+	skipCRDs               bool
+	skipDeps               bool
+	includeTests           bool
+	skipNeeds              bool
+	includeNeeds           bool
+	includeTransitiveNeeds bool
+	suppress               []string
+	suppressSecrets        bool
+	showSecrets            bool
+	suppressDiff           bool
+	noColor                bool
+	context                int
+	diffOutput             string
+	concurrency            int
+	detailedExitcode       bool
+	interactive            bool
+	skipDiffOnInstall      bool
+	logger                 *zap.SugaredLogger
 }
 
 func (a diffConfig) Args() string {
@@ -69,12 +70,16 @@ func (a diffConfig) IncludeTests() bool {
 	return a.includeTests
 }
 
+func (a diffConfig) SkipNeeds() bool {
+	return a.skipNeeds
+}
+
 func (a diffConfig) IncludeNeeds() bool {
 	return a.includeNeeds
 }
 
-func (a diffConfig) SkipNeeds() bool {
-	return a.skipNeeds
+func (a diffConfig) IncludeTransitiveNeeds() bool {
+	return a.includeTransitiveNeeds
 }
 
 func (a diffConfig) Suppress() []string {

--- a/pkg/app/diff_test.go
+++ b/pkg/app/diff_test.go
@@ -252,145 +252,6 @@ backend-v1 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      
 			concurrency: 1,
 			upgraded:    []exectest.Release{},
 			deleted:     []exectest.Release{},
-			log: `processing file "helmfile.yaml" in directory "."
-changing working directory to "/path/to"
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: database
- 3:   chart: charts/mysql
- 4:   needs:
- 5:   - logging
- 6: - name: frontend-v1
- 7:   chart: charts/frontend
- 8:   installed: false
- 9:   needs:
-10:   - servicemesh
-11:   - logging
-12:   - backend-v1
-13: - name: frontend-v2
-14:   chart: charts/frontend
-15:   needs:
-16:   - servicemesh
-17:   - logging
-18:   - backend-v2
-19: - name: frontend-v3
-20:   chart: charts/frontend
-21:   needs:
-22:   - servicemesh
-23:   - logging
-24:   - backend-v2
-25: - name: backend-v1
-26:   chart: charts/backend
-27:   installed: false
-28:   needs:
-29:   - servicemesh
-30:   - logging
-31:   - database
-32:   - anotherbackend
-33: - name: backend-v2
-34:   chart: charts/backend
-35:   needs:
-36:   - servicemesh
-37:   - logging
-38:   - database
-39:   - anotherbackend
-40: - name: anotherbackend
-41:   chart: charts/anotherbackend
-42:   needs:
-43:   - servicemesh
-44:   - logging
-45:   - database
-46: - name: servicemesh
-47:   chart: charts/istio
-48:   needs:
-49:   - logging
-50: - name: logging
-51:   chart: charts/fluent-bit
-52: - name: front-proxy
-53:   chart: stable/envoy
-54: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: database
- 3:   chart: charts/mysql
- 4:   needs:
- 5:   - logging
- 6: - name: frontend-v1
- 7:   chart: charts/frontend
- 8:   installed: false
- 9:   needs:
-10:   - servicemesh
-11:   - logging
-12:   - backend-v1
-13: - name: frontend-v2
-14:   chart: charts/frontend
-15:   needs:
-16:   - servicemesh
-17:   - logging
-18:   - backend-v2
-19: - name: frontend-v3
-20:   chart: charts/frontend
-21:   needs:
-22:   - servicemesh
-23:   - logging
-24:   - backend-v2
-25: - name: backend-v1
-26:   chart: charts/backend
-27:   installed: false
-28:   needs:
-29:   - servicemesh
-30:   - logging
-31:   - database
-32:   - anotherbackend
-33: - name: backend-v2
-34:   chart: charts/backend
-35:   needs:
-36:   - servicemesh
-37:   - logging
-38:   - database
-39:   - anotherbackend
-40: - name: anotherbackend
-41:   chart: charts/anotherbackend
-42:   needs:
-43:   - servicemesh
-44:   - logging
-45:   - database
-46: - name: servicemesh
-47:   chart: charts/istio
-48:   needs:
-49:   - logging
-50: - name: logging
-51:   chart: charts/fluent-bit
-52: - name: front-proxy
-53:   chart: stable/envoy
-54: 
-
-merged environment: &{default map[] map[]}
-10 release(s) found in helmfile.yaml
-
-Affected releases are:
-  anotherbackend (charts/anotherbackend) UPDATED
-  backend-v1 (charts/backend) DELETED
-  backend-v2 (charts/backend) UPDATED
-  database (charts/mysql) UPDATED
-  front-proxy (stable/envoy) UPDATED
-  frontend-v1 (charts/frontend) DELETED
-  frontend-v3 (charts/frontend) UPDATED
-  logging (charts/fluent-bit) UPDATED
-  servicemesh (charts/istio) UPDATED
-
-changing working directory back to "/path/to"
-`,
 		},
 		//
 		// noop: no changes
@@ -454,51 +315,6 @@ releases:
 			upgraded:    []exectest.Release{},
 			deleted:     []exectest.Release{},
 			concurrency: 1,
-			log: `processing file "helmfile.yaml" in directory "."
-changing working directory to "/path/to"
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: baz
- 3:   chart: mychart3
- 4: - name: foo
- 5:   chart: mychart1
- 6:   needs:
- 7:   - bar
- 8: - name: bar
- 9:   chart: mychart2
-10: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: baz
- 3:   chart: mychart3
- 4: - name: foo
- 5:   chart: mychart1
- 6:   needs:
- 7:   - bar
- 8: - name: bar
- 9:   chart: mychart2
-10: 
-
-merged environment: &{default map[] map[]}
-3 release(s) found in helmfile.yaml
-
-Affected releases are:
-  bar (mychart2) UPDATED
-  baz (mychart3) UPDATED
-  foo (mychart1) UPDATED
-
-changing working directory back to "/path/to"
-`,
 		},
 		//
 		// upgrades
@@ -618,31 +434,7 @@ releases:
 			upgraded: []exectest.Release{},
 		},
 		{
-			name: "helm3: upgrade when ns2/bar needs ns1/foo",
-			loc:  location(),
-			files: map[string]string{
-				"/path/to/helmfile.yaml": `
-releases:
-- name: bar
-  chart: mychart2
-  namespace: ns2
-  needs:
-  - ns1/foo
-- name: foo
-  chart: mychart1
-  namespace: ns1
-`,
-			},
-			detailedExitcode: true,
-			error:            "Identified at least one change",
-			diffs: map[exectest.DiffKey]error{
-				{Name: "bar", Chart: "mychart2", Flags: "--kube-contextdefault--namespacens2--detailed-exitcode"}: helmexec.ExitError{Code: 2},
-				{Name: "foo", Chart: "mychart1", Flags: "--kube-contextdefault--namespacens1--detailed-exitcode"}: helmexec.ExitError{Code: 2},
-			},
-			upgraded: []exectest.Release{},
-		},
-		{
-			name: "upgrade when tns1/ns1/foo needs tns2/ns2/bar",
+			name: "upgrade when tns1 ns1 foo needs tns2 ns2 bar",
 			loc:  location(),
 
 			files: map[string]string{
@@ -669,7 +461,7 @@ releases:
 			upgraded: []exectest.Release{},
 		},
 		{
-			name: "helm2: upgrade when tns2/bar needs tns1/foo",
+			name: "helm2 upgrade when tns2 bar needs tns1 foo",
 			loc:  location(),
 			files: map[string]string{
 				"/path/to/helmfile.yaml": `
@@ -695,57 +487,9 @@ releases:
 			upgraded: []exectest.Release{},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
-			log: `processing file "helmfile.yaml" in directory "."
-changing working directory to "/path/to"
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: bar
- 3:   chart: mychart2
- 4:   namespace: ns2
- 5:   tillerNamespace: tns2
- 6:   needs:
- 7:   - tns1/foo
- 8: - name: foo
- 9:   chart: mychart1
-10:   namespace: ns1
-11:   tillerNamespace: tns1
-12: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: bar
- 3:   chart: mychart2
- 4:   namespace: ns2
- 5:   tillerNamespace: tns2
- 6:   needs:
- 7:   - tns1/foo
- 8: - name: foo
- 9:   chart: mychart1
-10:   namespace: ns1
-11:   tillerNamespace: tns1
-12: 
-
-merged environment: &{default map[] map[]}
-2 release(s) found in helmfile.yaml
-
-Affected releases are:
-  bar (mychart2) UPDATED
-  foo (mychart1) UPDATED
-
-changing working directory back to "/path/to"
-`,
 		},
 		{
-			name: "helm3: upgrade when ns2/bar needs ns1/foo",
+			name: "helm3 upgrade when ns2 bar needs ns1 foo",
 			loc:  location(),
 			files: map[string]string{
 				"/path/to/helmfile.yaml": `
@@ -769,50 +513,6 @@ releases:
 			upgraded: []exectest.Release{},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
-			log: `processing file "helmfile.yaml" in directory "."
-changing working directory to "/path/to"
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: bar
- 3:   chart: mychart2
- 4:   namespace: ns2
- 5:   needs:
- 6:   - ns1/foo
- 7: - name: foo
- 8:   chart: mychart1
- 9:   namespace: ns1
-10: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: releases:
- 2: - name: bar
- 3:   chart: mychart2
- 4:   namespace: ns2
- 5:   needs:
- 6:   - ns1/foo
- 7: - name: foo
- 8:   chart: mychart1
- 9:   namespace: ns1
-10: 
-
-merged environment: &{default map[] map[]}
-2 release(s) found in helmfile.yaml
-
-Affected releases are:
-  bar (mychart2) UPDATED
-  foo (mychart1) UPDATED
-
-changing working directory back to "/path/to"
-`,
 		},
 		//
 		// deletes: deleting all releases in the correct order
@@ -1196,76 +896,6 @@ releases:
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
 			error:       "Identified at least one change",
-			log: `processing file "helmfile.yaml" in directory "."
-changing working directory to "/path/to"
-first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
-first-pass uses: &{default map[] map[]}
-first-pass rendering output of "helmfile.yaml.part.0":
- 0: 
- 1: 
- 2: 
- 3: releases:
- 4: - name: kubernetes-external-secrets
- 5:   chart: incubator/raw
- 6:   namespace: kube-system
- 7: 
- 8: - name: external-secrets
- 9:   chart: incubator/raw
-10:   namespace: default
-11:   labels:
-12:     app: test
-13:   needs:
-14:   - kube-system/kubernetes-external-secrets
-15: 
-16: - name: my-release
-17:   chart: incubator/raw
-18:   namespace: default
-19:   labels:
-20:     app: test
-21:   needs:
-22:   - default/external-secrets
-23: 
-
-first-pass produced: &{default map[] map[]}
-first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
-vals:
-map[]
-defaultVals:[]
-second-pass rendering result of "helmfile.yaml.part.0":
- 0: 
- 1: 
- 2: 
- 3: releases:
- 4: - name: kubernetes-external-secrets
- 5:   chart: incubator/raw
- 6:   namespace: kube-system
- 7: 
- 8: - name: external-secrets
- 9:   chart: incubator/raw
-10:   namespace: default
-11:   labels:
-12:     app: test
-13:   needs:
-14:   - kube-system/kubernetes-external-secrets
-15: 
-16: - name: my-release
-17:   chart: incubator/raw
-18:   namespace: default
-19:   labels:
-20:     app: test
-21:   needs:
-22:   - default/external-secrets
-23: 
-
-merged environment: &{default map[] map[]}
-2 release(s) matching app=test found in helmfile.yaml
-
-Affected releases are:
-  external-secrets (incubator/raw) UPDATED
-  my-release (incubator/raw) UPDATED
-
-changing working directory back to "/path/to"
-`,
 		},
 		{
 			name:  "upgrades with good selector with --skip-needs=false",
@@ -1738,6 +1368,8 @@ changing working directory back to "/path/to"
 				if exists {
 					t.Errorf("unexpected log for data defined %s:\nDIFF\n%s\nEOD", tc.loc, diff)
 				}
+			} else {
+				testhelper.RequireLog(t, "app_diff_test_1", bs)
 			}
 		})
 	}

--- a/pkg/app/testdata/app_diff_test/bad_selector
+++ b/pkg/app/testdata/app_diff_test/bad_selector
@@ -1,0 +1,105 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+0 release(s) matching app=test_non_existent found in helmfile.yaml
+

--- a/pkg/app/testdata/app_diff_test/bad_selector
+++ b/pkg/app/testdata/app_diff_test/bad_selector
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -103,3 +104,4 @@ second-pass rendering result of "helmfile.yaml.part.0":
 merged environment: &{default map[] map[]}
 0 release(s) matching app=test_non_existent found in helmfile.yaml
 
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/fail_on_unselected_need_by_default
+++ b/pkg/app/testdata/app_diff_test/fail_on_unselected_need_by_default
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 2 release(s) matching app=test found in helmfile.yaml
 
 err: release "default/default/external-secrets" depends on "default/kube-system/kubernetes-external-secrets" which does not match the selectors. Please add a selector like "--selector name=kubernetes-external-secrets", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/fail_on_unselected_need_by_default
+++ b/pkg/app/testdata/app_diff_test/fail_on_unselected_need_by_default
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+err: release "default/default/external-secrets" depends on "default/kube-system/kubernetes-external-secrets" which does not match the selectors. Please add a selector like "--selector name=kubernetes-external-secrets", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_diff_test/include-needs
+++ b/pkg/app/testdata/app_diff_test/include-needs
@@ -1,0 +1,105 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+

--- a/pkg/app/testdata/app_diff_test/include-needs
+++ b/pkg/app/testdata/app_diff_test/include-needs
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -103,3 +104,4 @@ second-pass rendering result of "helmfile.yaml.part.0":
 merged environment: &{default map[] map[]}
 2 release(s) matching app=test found in helmfile.yaml
 
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-needs
+++ b/pkg/app/testdata/app_diff_test/include-needs
@@ -104,4 +104,15 @@ second-pass rendering result of "helmfile.yaml.part.0":
 merged environment: &{default map[] map[]}
 2 release(s) matching app=test found in helmfile.yaml
 
+processing 4 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/logging
+2     default/kube-system/kubernetes-external-secrets
+3     default/default/external-secrets
+4     default/default/my-release
+
+processing releases in group 1/4: default/kube-system/logging
+processing releases in group 2/4: default/kube-system/kubernetes-external-secrets
+processing releases in group 3/4: default/default/external-secrets
+processing releases in group 4/4: default/default/my-release
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-needs_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_diff_test/include-needs_fail_on_disabled_direct_need
@@ -102,13 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-2 release(s) matching app=test found in helmfile.yaml
+1 release(s) matching name=test2 found in helmfile.yaml
 
-processing 2 groups of releases in this order:
-GROUP RELEASES
-1     default/default/external-secrets
-2     default/default/my-release
-
-processing releases in group 1/2: default/default/external-secrets
-processing releases in group 2/2: default/default/my-release
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_diff_test/include-needs_fail_on_disabled_transitive_need
@@ -102,13 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-2 release(s) matching app=test found in helmfile.yaml
+1 release(s) matching name=test3 found in helmfile.yaml
 
-processing 2 groups of releases in this order:
-GROUP RELEASES
-1     default/default/external-secrets
-2     default/default/my-release
-
-processing releases in group 1/2: default/default/external-secrets
-processing releases in group 2/2: default/default/my-release
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-needs_should_not_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_diff_test/include-needs_should_not_fail_on_disabled_direct_need
@@ -1,0 +1,117 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+1 release(s) matching name=test2 found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+
+processing releases in group 1/2: default/kube-system/disabled
+processing releases in group 2/2: default//test2
+Affected releases are:
+  disabled (incubator/raw) DELETED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-needs_should_not_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_diff_test/include-needs_should_not_fail_on_disabled_transitive_need
@@ -1,0 +1,119 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+1 release(s) matching name=test3 found in helmfile.yaml
+
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+3     default//test3
+
+processing releases in group 1/3: default/kube-system/disabled
+processing releases in group 2/3: default//test2
+processing releases in group 3/3: default//test3
+Affected releases are:
+  disabled (incubator/raw) DELETED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-needs_with_include-transitive-needs_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_diff_test/include-needs_with_include-transitive-needs_fail_on_disabled_direct_need
@@ -102,13 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-2 release(s) matching app=test found in helmfile.yaml
+2 release(s) matching name=test2 found in helmfile.yaml
 
-processing 2 groups of releases in this order:
-GROUP RELEASES
-1     default/default/external-secrets
-2     default/default/my-release
-
-processing releases in group 1/2: default/default/external-secrets
-processing releases in group 2/2: default/default/my-release
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-needs_with_include-transitive-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_diff_test/include-needs_with_include-transitive-needs_fail_on_disabled_transitive_need
@@ -102,13 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-2 release(s) matching app=test found in helmfile.yaml
+3 release(s) matching name=test3 found in helmfile.yaml
 
-processing 2 groups of releases in this order:
-GROUP RELEASES
-1     default/default/external-secrets
-2     default/default/my-release
-
-processing releases in group 1/2: default/default/external-secrets
-processing releases in group 2/2: default/default/my-release
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_diff_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_direct_need
@@ -1,0 +1,117 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching name=test2 found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+
+processing releases in group 1/2: default/kube-system/disabled
+processing releases in group 2/2: default//test2
+Affected releases are:
+  disabled (incubator/raw) DELETED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_diff_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_direct_need
@@ -102,7 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-2 release(s) matching name=test2 found in helmfile.yaml
+1 release(s) matching name=test2 found in helmfile.yaml
 
 processing 2 groups of releases in this order:
 GROUP RELEASES

--- a/pkg/app/testdata/app_diff_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_diff_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_transitive_need
@@ -102,7 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-3 release(s) matching name=test3 found in helmfile.yaml
+1 release(s) matching name=test3 found in helmfile.yaml
 
 processing 3 groups of releases in this order:
 GROUP RELEASES

--- a/pkg/app/testdata/app_diff_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_diff_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_transitive_need
@@ -1,0 +1,119 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+3 release(s) matching name=test3 found in helmfile.yaml
+
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+3     default//test3
+
+processing releases in group 1/3: default/kube-system/disabled
+processing releases in group 2/3: default//test2
+processing releases in group 3/3: default//test3
+Affected releases are:
+  disabled (incubator/raw) DELETED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-transitive-needs
+++ b/pkg/app/testdata/app_diff_test/include-transitive-needs
@@ -1,0 +1,105 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+4 release(s) matching app=test found in helmfile.yaml
+

--- a/pkg/app/testdata/app_diff_test/include-transitive-needs
+++ b/pkg/app/testdata/app_diff_test/include-transitive-needs
@@ -104,4 +104,15 @@ second-pass rendering result of "helmfile.yaml.part.0":
 merged environment: &{default map[] map[]}
 4 release(s) matching app=test found in helmfile.yaml
 
+processing 4 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/logging
+2     default/kube-system/kubernetes-external-secrets
+3     default/default/external-secrets
+4     default/default/my-release
+
+processing releases in group 1/4: default/kube-system/logging
+processing releases in group 2/4: default/kube-system/kubernetes-external-secrets
+processing releases in group 3/4: default/default/external-secrets
+processing releases in group 4/4: default/default/my-release
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-transitive-needs
+++ b/pkg/app/testdata/app_diff_test/include-transitive-needs
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -103,3 +104,4 @@ second-pass rendering result of "helmfile.yaml.part.0":
 merged environment: &{default map[] map[]}
 4 release(s) matching app=test found in helmfile.yaml
 
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-transitive-needs
+++ b/pkg/app/testdata/app_diff_test/include-transitive-needs
@@ -102,7 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-4 release(s) matching app=test found in helmfile.yaml
+2 release(s) matching app=test found in helmfile.yaml
 
 processing 4 groups of releases in this order:
 GROUP RELEASES

--- a/pkg/app/testdata/app_diff_test/include-transitive-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_diff_test/include-transitive-needs_fail_on_disabled_transitive_need
@@ -102,13 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-2 release(s) matching app=test found in helmfile.yaml
+3 release(s) matching name=test3 found in helmfile.yaml
 
-processing 2 groups of releases in this order:
-GROUP RELEASES
-1     default/default/external-secrets
-2     default/default/my-release
-
-processing releases in group 1/2: default/default/external-secrets
-processing releases in group 2/2: default/default/my-release
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/include-transitive-needs_should_not_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_diff_test/include-transitive-needs_should_not_fail_on_disabled_transitive_need
@@ -102,7 +102,18 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-3 release(s) matching name=test3 found in helmfile.yaml
+1 release(s) matching name=test3 found in helmfile.yaml
 
-err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+3     default//test3
+
+processing releases in group 1/3: default/kube-system/disabled
+processing releases in group 2/3: default//test2
+processing releases in group 3/3: default//test3
+Affected releases are:
+  disabled (incubator/raw) DELETED
+
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test/skip-needs
+++ b/pkg/app/testdata/app_diff_test/skip-needs
@@ -1,0 +1,105 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+

--- a/pkg/app/testdata/app_diff_test/skip-needs
+++ b/pkg/app/testdata/app_diff_test/skip-needs
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -103,3 +104,4 @@ second-pass rendering result of "helmfile.yaml.part.0":
 merged environment: &{default map[] map[]}
 2 release(s) matching app=test found in helmfile.yaml
 
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/bar
+++ b/pkg/app/testdata/app_diff_test_1/bar
@@ -1,0 +1,50 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   namespace: ns1
+ 5:   needs:
+ 6:   - ns2/bar
+ 7: - name: bar
+ 8:   chart: mychart2
+ 9:   namespace: ns2
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   namespace: ns1
+ 5:   needs:
+ 6:   - ns2/bar
+ 7: - name: bar
+ 8:   chart: mychart2
+ 9:   namespace: ns2
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/ns2/bar
+2     default/ns1/foo
+
+processing releases in group 1/2: default/ns2/bar
+processing releases in group 2/2: default/ns1/foo
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/delete_bar_when_bar_needs_foo
+++ b/pkg/app/testdata/app_diff_test_1/delete_bar_when_bar_needs_foo
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6:   installed: false
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6:   installed: false
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//foo
+
+processing releases in group 1/1: default//foo
+Affected releases are:
+  bar (mychart2) DELETED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/delete_bar_when_foo_needs_bar
+++ b/pkg/app/testdata/app_diff_test_1/delete_bar_when_foo_needs_bar
@@ -1,0 +1,38 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+err: release "default//foo" depends on "default//bar" which does not match the selectors. Please add a selector like "--selector name=bar", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/delete_bar_when_foo_needs_bar_with_include-needs
+++ b/pkg/app/testdata/app_diff_test_1/delete_bar_when_foo_needs_bar_with_include-needs
@@ -1,0 +1,48 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//bar
+2     default//foo
+
+processing releases in group 1/2: default//bar
+processing releases in group 2/2: default//foo
+Affected releases are:
+  bar (mychart2) DELETED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/delete_bar_when_foo_needs_bar_with_skip-needs
+++ b/pkg/app/testdata/app_diff_test_1/delete_bar_when_foo_needs_bar_with_skip-needs
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//foo
+
+processing releases in group 1/1: default//foo
+Affected releases are:
+  bar (mychart2) DELETED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/delete_foo_and_bar_when_bar_needs_foo
+++ b/pkg/app/testdata/app_diff_test_1/delete_foo_and_bar_when_bar_needs_foo
@@ -1,0 +1,50 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5:   needs:
+ 6:   - foo
+ 7: - name: foo
+ 8:   chart: mychart1
+ 9:   installed: false
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5:   needs:
+ 6:   - foo
+ 7: - name: foo
+ 8:   chart: mychart1
+ 9:   installed: false
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//foo
+2     default//bar
+
+processing releases in group 1/2: default//foo
+processing releases in group 2/2: default//bar
+Affected releases are:
+  bar (mychart2) DELETED
+  foo (mychart1) DELETED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/delete_foo_and_bar_when_foo_needs_bar
+++ b/pkg/app/testdata/app_diff_test_1/delete_foo_and_bar_when_foo_needs_bar
@@ -1,0 +1,50 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   installed: false
+ 8:   needs:
+ 9:   - bar
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   installed: false
+ 8:   needs:
+ 9:   - bar
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//bar
+2     default//foo
+
+processing releases in group 1/2: default//bar
+processing releases in group 2/2: default//foo
+Affected releases are:
+  bar (mychart2) DELETED
+  foo (mychart1) DELETED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/delete_foo_when_bar_needs_foo
+++ b/pkg/app/testdata/app_diff_test_1/delete_foo_when_bar_needs_foo
@@ -1,0 +1,38 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   installed: false
+ 5: - name: bar
+ 6:   chart: mychart2
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   installed: false
+ 5: - name: bar
+ 6:   chart: mychart2
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+err: release "default//bar" depends on "default//foo" which does not match the selectors. Please add a selector like "--selector name=foo", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/delete_foo_when_bar_needs_foo_with_include-needs
+++ b/pkg/app/testdata/app_diff_test_1/delete_foo_when_bar_needs_foo_with_include-needs
@@ -1,0 +1,48 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   installed: false
+ 5: - name: bar
+ 6:   chart: mychart2
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   installed: false
+ 5: - name: bar
+ 6:   chart: mychart2
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//foo
+2     default//bar
+
+processing releases in group 1/2: default//foo
+processing releases in group 2/2: default//bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) DELETED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/delete_foo_when_bar_needs_foo_with_skip-needs
+++ b/pkg/app/testdata/app_diff_test_1/delete_foo_when_bar_needs_foo_with_skip-needs
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   installed: false
+ 5: - name: bar
+ 6:   chart: mychart2
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   installed: false
+ 5: - name: bar
+ 6:   chart: mychart2
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//bar
+
+processing releases in group 1/1: default//bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) DELETED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/delete_foo_when_foo_needs_bar
+++ b/pkg/app/testdata/app_diff_test_1/delete_foo_when_foo_needs_bar
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   installed: false
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   installed: false
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//bar
+
+processing releases in group 1/1: default//bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) DELETED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/helm2_upgrade_when_tns2_bar_needs_tns1_foo
+++ b/pkg/app/testdata/app_diff_test_1/helm2_upgrade_when_tns2_bar_needs_tns1_foo
@@ -1,0 +1,54 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   namespace: ns2
+ 5:   tillerNamespace: tns2
+ 6:   needs:
+ 7:   - tns1/foo
+ 8: - name: foo
+ 9:   chart: mychart1
+10:   namespace: ns1
+11:   tillerNamespace: tns1
+12: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   namespace: ns2
+ 5:   tillerNamespace: tns2
+ 6:   needs:
+ 7:   - tns1/foo
+ 8: - name: foo
+ 9:   chart: mychart1
+10:   namespace: ns1
+11:   tillerNamespace: tns1
+12: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/tns1/foo
+2     default/tns2/bar
+
+processing releases in group 1/2: default/tns1/foo
+processing releases in group 2/2: default/tns2/bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/helm3_upgrade_when_ns2_bar_needs_ns1_foo
+++ b/pkg/app/testdata/app_diff_test_1/helm3_upgrade_when_ns2_bar_needs_ns1_foo
@@ -1,0 +1,50 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   namespace: ns2
+ 5:   needs:
+ 6:   - ns1/foo
+ 7: - name: foo
+ 8:   chart: mychart1
+ 9:   namespace: ns1
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   namespace: ns2
+ 5:   needs:
+ 6:   - ns1/foo
+ 7: - name: foo
+ 8:   chart: mychart1
+ 9:   namespace: ns1
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/ns1/foo
+2     default/ns2/bar
+
+processing releases in group 1/2: default/ns1/foo
+processing releases in group 2/2: default/ns2/bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/install
+++ b/pkg/app/testdata/app_diff_test_1/install
@@ -1,0 +1,51 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: baz
+ 3:   chart: mychart3
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: - name: bar
+ 9:   chart: mychart2
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: baz
+ 3:   chart: mychart3
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: - name: bar
+ 9:   chart: mychart2
+10: 
+
+merged environment: &{default map[] map[]}
+3 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//baz, default//bar
+2     default//foo
+
+processing releases in group 1/2: default//baz, default//bar
+processing releases in group 2/2: default//foo
+Affected releases are:
+  bar (mychart2) UPDATED
+  baz (mychart3) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/noop
+++ b/pkg/app/testdata/app_diff_test_1/noop
@@ -1,0 +1,43 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   installed: false
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   installed: false
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//bar
+
+processing releases in group 1/1: default//bar
+No affected releases
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/smoke
+++ b/pkg/app/testdata/app_diff_test_1/smoke
@@ -1,0 +1,151 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: database
+ 3:   chart: charts/mysql
+ 4:   needs:
+ 5:   - logging
+ 6: - name: frontend-v1
+ 7:   chart: charts/frontend
+ 8:   installed: false
+ 9:   needs:
+10:   - servicemesh
+11:   - logging
+12:   - backend-v1
+13: - name: frontend-v2
+14:   chart: charts/frontend
+15:   needs:
+16:   - servicemesh
+17:   - logging
+18:   - backend-v2
+19: - name: frontend-v3
+20:   chart: charts/frontend
+21:   needs:
+22:   - servicemesh
+23:   - logging
+24:   - backend-v2
+25: - name: backend-v1
+26:   chart: charts/backend
+27:   installed: false
+28:   needs:
+29:   - servicemesh
+30:   - logging
+31:   - database
+32:   - anotherbackend
+33: - name: backend-v2
+34:   chart: charts/backend
+35:   needs:
+36:   - servicemesh
+37:   - logging
+38:   - database
+39:   - anotherbackend
+40: - name: anotherbackend
+41:   chart: charts/anotherbackend
+42:   needs:
+43:   - servicemesh
+44:   - logging
+45:   - database
+46: - name: servicemesh
+47:   chart: charts/istio
+48:   needs:
+49:   - logging
+50: - name: logging
+51:   chart: charts/fluent-bit
+52: - name: front-proxy
+53:   chart: stable/envoy
+54: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: database
+ 3:   chart: charts/mysql
+ 4:   needs:
+ 5:   - logging
+ 6: - name: frontend-v1
+ 7:   chart: charts/frontend
+ 8:   installed: false
+ 9:   needs:
+10:   - servicemesh
+11:   - logging
+12:   - backend-v1
+13: - name: frontend-v2
+14:   chart: charts/frontend
+15:   needs:
+16:   - servicemesh
+17:   - logging
+18:   - backend-v2
+19: - name: frontend-v3
+20:   chart: charts/frontend
+21:   needs:
+22:   - servicemesh
+23:   - logging
+24:   - backend-v2
+25: - name: backend-v1
+26:   chart: charts/backend
+27:   installed: false
+28:   needs:
+29:   - servicemesh
+30:   - logging
+31:   - database
+32:   - anotherbackend
+33: - name: backend-v2
+34:   chart: charts/backend
+35:   needs:
+36:   - servicemesh
+37:   - logging
+38:   - database
+39:   - anotherbackend
+40: - name: anotherbackend
+41:   chart: charts/anotherbackend
+42:   needs:
+43:   - servicemesh
+44:   - logging
+45:   - database
+46: - name: servicemesh
+47:   chart: charts/istio
+48:   needs:
+49:   - logging
+50: - name: logging
+51:   chart: charts/fluent-bit
+52: - name: front-proxy
+53:   chart: stable/envoy
+54: 
+
+merged environment: &{default map[] map[]}
+10 release(s) found in helmfile.yaml
+
+processing 5 groups of releases in this order:
+GROUP RELEASES
+1     default//logging, default//front-proxy
+2     default//database, default//servicemesh
+3     default//anotherbackend
+4     default//backend-v2
+5     default//frontend-v2, default//frontend-v3
+
+processing releases in group 1/5: default//logging, default//front-proxy
+processing releases in group 2/5: default//database, default//servicemesh
+processing releases in group 3/5: default//anotherbackend
+processing releases in group 4/5: default//backend-v2
+processing releases in group 5/5: default//frontend-v2, default//frontend-v3
+Affected releases are:
+  anotherbackend (charts/anotherbackend) UPDATED
+  backend-v1 (charts/backend) DELETED
+  backend-v2 (charts/backend) UPDATED
+  database (charts/mysql) UPDATED
+  front-proxy (stable/envoy) UPDATED
+  frontend-v1 (charts/frontend) DELETED
+  frontend-v3 (charts/frontend) UPDATED
+  logging (charts/fluent-bit) UPDATED
+  servicemesh (charts/istio) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/upgrade_when_bar_needs_foo
+++ b/pkg/app/testdata/app_diff_test_1/upgrade_when_bar_needs_foo
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6:   needs:
+ 7:   - foo
+ 8: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6:   needs:
+ 7:   - foo
+ 8: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//foo
+2     default//bar
+
+processing releases in group 1/2: default//foo
+processing releases in group 2/2: default//bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/upgrade_when_bar_needs_foo,_with_ns_override
+++ b/pkg/app/testdata/app_diff_test_1/upgrade_when_bar_needs_foo,_with_ns_override
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6:   needs:
+ 7:   - foo
+ 8: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6:   needs:
+ 7:   - foo
+ 8: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/testNamespace/foo
+2     default/testNamespace/bar
+
+processing releases in group 1/2: default/testNamespace/foo
+processing releases in group 2/2: default/testNamespace/bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/upgrade_when_foo_needs_bar
+++ b/pkg/app/testdata/app_diff_test_1/upgrade_when_foo_needs_bar
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//bar
+2     default//foo
+
+processing releases in group 1/2: default//bar
+processing releases in group 2/2: default//foo
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/upgrade_when_foo_needs_bar,_with_ns_override
+++ b/pkg/app/testdata/app_diff_test_1/upgrade_when_foo_needs_bar,_with_ns_override
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/testNamespace/bar
+2     default/testNamespace/foo
+
+processing releases in group 1/2: default/testNamespace/bar
+processing releases in group 2/2: default/testNamespace/foo
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/upgrade_when_tns1_ns1_foo_needs_tns2_ns2_bar
+++ b/pkg/app/testdata/app_diff_test_1/upgrade_when_tns1_ns1_foo_needs_tns2_ns2_bar
@@ -1,0 +1,54 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   namespace: ns1
+ 5:   tillerNamespace: tns1
+ 6:   needs:
+ 7:   - tns2/bar
+ 8: - name: bar
+ 9:   chart: mychart2
+10:   namespace: ns2
+11:   tillerNamespace: tns2
+12: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   namespace: ns1
+ 5:   tillerNamespace: tns1
+ 6:   needs:
+ 7:   - tns2/bar
+ 8: - name: bar
+ 9:   chart: mychart2
+10:   namespace: ns2
+11:   tillerNamespace: tns2
+12: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/tns2/bar
+2     default/tns1/foo
+
+processing releases in group 1/2: default/tns2/bar
+processing releases in group 2/2: default/tns1/foo
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/upgrades_with_good_selector_with_--skip-needs=true
+++ b/pkg/app/testdata/app_diff_test_1/upgrades_with_good_selector_with_--skip-needs=true
@@ -1,0 +1,76 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7: 
+ 8: - name: external-secrets
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13:   needs:
+14:   - kube-system/kubernetes-external-secrets
+15: 
+16: - name: my-release
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - default/external-secrets
+23: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7: 
+ 8: - name: external-secrets
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13:   needs:
+14:   - kube-system/kubernetes-external-secrets
+15: 
+16: - name: my-release
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - default/external-secrets
+23: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/default/external-secrets
+2     default/default/my-release
+
+processing releases in group 1/2: default/default/external-secrets
+processing releases in group 2/2: default/default/my-release
+Affected releases are:
+  external-secrets (incubator/raw) UPDATED
+  my-release (incubator/raw) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/bar
+++ b/pkg/app/testdata/app_diff_test_2/bar
@@ -1,0 +1,50 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   namespace: ns1
+ 5:   needs:
+ 6:   - ns2/bar
+ 7: - name: bar
+ 8:   chart: mychart2
+ 9:   namespace: ns2
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   namespace: ns1
+ 5:   needs:
+ 6:   - ns2/bar
+ 7: - name: bar
+ 8:   chart: mychart2
+ 9:   namespace: ns2
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     ns2/bar
+2     ns1/foo
+
+processing releases in group 1/2: ns2/bar
+processing releases in group 2/2: ns1/foo
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/delete_bar_when_bar_needs_foo
+++ b/pkg/app/testdata/app_diff_test_2/delete_bar_when_bar_needs_foo
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6:   installed: false
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6:   installed: false
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     foo
+
+processing releases in group 1/1: foo
+Affected releases are:
+  bar (mychart2) DELETED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/delete_bar_when_foo_needs_bar
+++ b/pkg/app/testdata/app_diff_test_2/delete_bar_when_foo_needs_bar
@@ -1,0 +1,38 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+err: release "foo" depends on "bar" which does not match the selectors. Please add a selector like "--selector name=bar", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/delete_bar_when_foo_needs_bar_with_include-needs
+++ b/pkg/app/testdata/app_diff_test_2/delete_bar_when_foo_needs_bar_with_include-needs
@@ -1,0 +1,48 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     bar
+2     foo
+
+processing releases in group 1/2: bar
+processing releases in group 2/2: foo
+Affected releases are:
+  bar (mychart2) DELETED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/delete_bar_when_foo_needs_bar_with_skip-needs
+++ b/pkg/app/testdata/app_diff_test_2/delete_bar_when_foo_needs_bar_with_skip-needs
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     foo
+
+processing releases in group 1/1: foo
+Affected releases are:
+  bar (mychart2) DELETED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/delete_foo_and_bar_when_bar_needs_foo
+++ b/pkg/app/testdata/app_diff_test_2/delete_foo_and_bar_when_bar_needs_foo
@@ -1,0 +1,50 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5:   needs:
+ 6:   - foo
+ 7: - name: foo
+ 8:   chart: mychart1
+ 9:   installed: false
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5:   needs:
+ 6:   - foo
+ 7: - name: foo
+ 8:   chart: mychart1
+ 9:   installed: false
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     foo
+2     bar
+
+processing releases in group 1/2: foo
+processing releases in group 2/2: bar
+Affected releases are:
+  bar (mychart2) DELETED
+  foo (mychart1) DELETED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/delete_foo_and_bar_when_foo_needs_bar
+++ b/pkg/app/testdata/app_diff_test_2/delete_foo_and_bar_when_foo_needs_bar
@@ -1,0 +1,50 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   installed: false
+ 8:   needs:
+ 9:   - bar
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: mychart1
+ 7:   installed: false
+ 8:   needs:
+ 9:   - bar
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     bar
+2     foo
+
+processing releases in group 1/2: bar
+processing releases in group 2/2: foo
+Affected releases are:
+  bar (mychart2) DELETED
+  foo (mychart1) DELETED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/delete_foo_when_bar_needs_foo
+++ b/pkg/app/testdata/app_diff_test_2/delete_foo_when_bar_needs_foo
@@ -1,0 +1,38 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   installed: false
+ 5: - name: bar
+ 6:   chart: mychart2
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   installed: false
+ 5: - name: bar
+ 6:   chart: mychart2
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+err: release "bar" depends on "foo" which does not match the selectors. Please add a selector like "--selector name=foo", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/delete_foo_when_foo_needs_bar
+++ b/pkg/app/testdata/app_diff_test_2/delete_foo_when_foo_needs_bar
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   installed: false
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   installed: false
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     bar
+
+processing releases in group 1/1: bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) DELETED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/foo
+++ b/pkg/app/testdata/app_diff_test_2/foo
@@ -1,0 +1,50 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   namespace: ns2
+ 5:   needs:
+ 6:   - ns1/foo
+ 7: - name: foo
+ 8:   chart: mychart1
+ 9:   namespace: ns1
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   namespace: ns2
+ 5:   needs:
+ 6:   - ns1/foo
+ 7: - name: foo
+ 8:   chart: mychart1
+ 9:   namespace: ns1
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     ns1/foo
+2     ns2/bar
+
+processing releases in group 1/2: ns1/foo
+processing releases in group 2/2: ns2/bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/helm2_upgrade_when_tns1_foo_needs_tns2_bar
+++ b/pkg/app/testdata/app_diff_test_2/helm2_upgrade_when_tns1_foo_needs_tns2_bar
@@ -1,0 +1,54 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   namespace: ns1
+ 5:   tillerNamespace: tns1
+ 6:   needs:
+ 7:   - tns2/bar
+ 8: - name: bar
+ 9:   chart: mychart2
+10:   namespace: ns2
+11:   tillerNamespace: tns2
+12: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4:   namespace: ns1
+ 5:   tillerNamespace: tns1
+ 6:   needs:
+ 7:   - tns2/bar
+ 8: - name: bar
+ 9:   chart: mychart2
+10:   namespace: ns2
+11:   tillerNamespace: tns2
+12: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     tns2/bar
+2     tns1/foo
+
+processing releases in group 1/2: tns2/bar
+processing releases in group 2/2: tns1/foo
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/helm2_upgrade_when_tns2_bar_needs_tns1_foo
+++ b/pkg/app/testdata/app_diff_test_2/helm2_upgrade_when_tns2_bar_needs_tns1_foo
@@ -1,0 +1,54 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   namespace: ns2
+ 5:   tillerNamespace: tns2
+ 6:   needs:
+ 7:   - tns1/foo
+ 8: - name: foo
+ 9:   chart: mychart1
+10:   namespace: ns1
+11:   tillerNamespace: tns1
+12: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   namespace: ns2
+ 5:   tillerNamespace: tns2
+ 6:   needs:
+ 7:   - tns1/foo
+ 8: - name: foo
+ 9:   chart: mychart1
+10:   namespace: ns1
+11:   tillerNamespace: tns1
+12: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     tns1/foo
+2     tns2/bar
+
+processing releases in group 1/2: tns1/foo
+processing releases in group 2/2: tns2/bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/helm3_upgrade_when_ns2_bar_needs_ns1_foo
+++ b/pkg/app/testdata/app_diff_test_2/helm3_upgrade_when_ns2_bar_needs_ns1_foo
@@ -1,0 +1,50 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   namespace: ns2
+ 5:   needs:
+ 6:   - ns1/foo
+ 7: - name: foo
+ 8:   chart: mychart1
+ 9:   namespace: ns1
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4:   namespace: ns2
+ 5:   needs:
+ 6:   - ns1/foo
+ 7: - name: foo
+ 8:   chart: mychart1
+ 9:   namespace: ns1
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     ns1/foo
+2     ns2/bar
+
+processing releases in group 1/2: ns1/foo
+processing releases in group 2/2: ns2/bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/install
+++ b/pkg/app/testdata/app_diff_test_2/install
@@ -1,0 +1,51 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: baz
+ 3:   chart: mychart3
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: - name: bar
+ 9:   chart: mychart2
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: baz
+ 3:   chart: mychart3
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: - name: bar
+ 9:   chart: mychart2
+10: 
+
+merged environment: &{default map[] map[]}
+3 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     baz, bar
+2     foo
+
+processing releases in group 1/2: baz, bar
+processing releases in group 2/2: foo
+Affected releases are:
+  bar (mychart2) UPDATED
+  baz (mychart3) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/noop
+++ b/pkg/app/testdata/app_diff_test_2/noop
@@ -1,0 +1,43 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   installed: false
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   installed: false
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     bar
+
+processing releases in group 1/1: bar
+No affected releases
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/smoke
+++ b/pkg/app/testdata/app_diff_test_2/smoke
@@ -1,0 +1,151 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: database
+ 3:   chart: charts/mysql
+ 4:   needs:
+ 5:   - logging
+ 6: - name: frontend-v1
+ 7:   chart: charts/frontend
+ 8:   installed: false
+ 9:   needs:
+10:   - servicemesh
+11:   - logging
+12:   - backend-v1
+13: - name: frontend-v2
+14:   chart: charts/frontend
+15:   needs:
+16:   - servicemesh
+17:   - logging
+18:   - backend-v2
+19: - name: frontend-v3
+20:   chart: charts/frontend
+21:   needs:
+22:   - servicemesh
+23:   - logging
+24:   - backend-v2
+25: - name: backend-v1
+26:   chart: charts/backend
+27:   installed: false
+28:   needs:
+29:   - servicemesh
+30:   - logging
+31:   - database
+32:   - anotherbackend
+33: - name: backend-v2
+34:   chart: charts/backend
+35:   needs:
+36:   - servicemesh
+37:   - logging
+38:   - database
+39:   - anotherbackend
+40: - name: anotherbackend
+41:   chart: charts/anotherbackend
+42:   needs:
+43:   - servicemesh
+44:   - logging
+45:   - database
+46: - name: servicemesh
+47:   chart: charts/istio
+48:   needs:
+49:   - logging
+50: - name: logging
+51:   chart: charts/fluent-bit
+52: - name: front-proxy
+53:   chart: stable/envoy
+54: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: database
+ 3:   chart: charts/mysql
+ 4:   needs:
+ 5:   - logging
+ 6: - name: frontend-v1
+ 7:   chart: charts/frontend
+ 8:   installed: false
+ 9:   needs:
+10:   - servicemesh
+11:   - logging
+12:   - backend-v1
+13: - name: frontend-v2
+14:   chart: charts/frontend
+15:   needs:
+16:   - servicemesh
+17:   - logging
+18:   - backend-v2
+19: - name: frontend-v3
+20:   chart: charts/frontend
+21:   needs:
+22:   - servicemesh
+23:   - logging
+24:   - backend-v2
+25: - name: backend-v1
+26:   chart: charts/backend
+27:   installed: false
+28:   needs:
+29:   - servicemesh
+30:   - logging
+31:   - database
+32:   - anotherbackend
+33: - name: backend-v2
+34:   chart: charts/backend
+35:   needs:
+36:   - servicemesh
+37:   - logging
+38:   - database
+39:   - anotherbackend
+40: - name: anotherbackend
+41:   chart: charts/anotherbackend
+42:   needs:
+43:   - servicemesh
+44:   - logging
+45:   - database
+46: - name: servicemesh
+47:   chart: charts/istio
+48:   needs:
+49:   - logging
+50: - name: logging
+51:   chart: charts/fluent-bit
+52: - name: front-proxy
+53:   chart: stable/envoy
+54: 
+
+merged environment: &{default map[] map[]}
+10 release(s) found in helmfile.yaml
+
+processing 5 groups of releases in this order:
+GROUP RELEASES
+1     logging, front-proxy
+2     database, servicemesh
+3     anotherbackend
+4     backend-v2
+5     frontend-v2, frontend-v3
+
+processing releases in group 1/5: logging, front-proxy
+processing releases in group 2/5: database, servicemesh
+processing releases in group 3/5: anotherbackend
+processing releases in group 4/5: backend-v2
+processing releases in group 5/5: frontend-v2, frontend-v3
+Affected releases are:
+  anotherbackend (charts/anotherbackend) UPDATED
+  backend-v1 (charts/backend) DELETED
+  backend-v2 (charts/backend) UPDATED
+  database (charts/mysql) UPDATED
+  front-proxy (stable/envoy) UPDATED
+  frontend-v1 (charts/frontend) DELETED
+  frontend-v3 (charts/frontend) UPDATED
+  logging (charts/fluent-bit) UPDATED
+  servicemesh (charts/istio) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/upgrade_when_bar_needs_foo
+++ b/pkg/app/testdata/app_diff_test_2/upgrade_when_bar_needs_foo
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6:   needs:
+ 7:   - foo
+ 8: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6:   needs:
+ 7:   - foo
+ 8: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     foo
+2     bar
+
+processing releases in group 1/2: foo
+processing releases in group 2/2: bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/upgrade_when_bar_needs_foo,_with_ns_override
+++ b/pkg/app/testdata/app_diff_test_2/upgrade_when_bar_needs_foo,_with_ns_override
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6:   needs:
+ 7:   - foo
+ 8: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: mychart1
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6:   needs:
+ 7:   - foo
+ 8: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     testNamespace/foo
+2     testNamespace/bar
+
+processing releases in group 1/2: testNamespace/foo
+processing releases in group 2/2: testNamespace/bar
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/upgrade_when_foo_needs_bar
+++ b/pkg/app/testdata/app_diff_test_2/upgrade_when_foo_needs_bar
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     bar
+2     foo
+
+processing releases in group 1/2: bar
+processing releases in group 2/2: foo
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/upgrade_when_foo_needs_bar,_with_ns_override
+++ b/pkg/app/testdata/app_diff_test_2/upgrade_when_foo_needs_bar,_with_ns_override
@@ -1,0 +1,46 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: mychart2
+ 4: - name: foo
+ 5:   chart: mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     testNamespace/bar
+2     testNamespace/foo
+
+processing releases in group 1/2: testNamespace/bar
+processing releases in group 2/2: testNamespace/foo
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_2/upgrades_with_good_selector_with_--skip-needs=true
+++ b/pkg/app/testdata/app_diff_test_2/upgrades_with_good_selector_with_--skip-needs=true
@@ -1,0 +1,76 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7: 
+ 8: - name: external-secrets
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13:   needs:
+14:   - kube-system/kubernetes-external-secrets
+15: 
+16: - name: my-release
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - default/external-secrets
+23: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: 
+ 2: 
+ 3: releases:
+ 4: - name: kubernetes-external-secrets
+ 5:   chart: incubator/raw
+ 6:   namespace: kube-system
+ 7: 
+ 8: - name: external-secrets
+ 9:   chart: incubator/raw
+10:   namespace: default
+11:   labels:
+12:     app: test
+13:   needs:
+14:   - kube-system/kubernetes-external-secrets
+15: 
+16: - name: my-release
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - default/external-secrets
+23: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/external-secrets
+2     default/my-release
+
+processing releases in group 1/2: default/external-secrets
+processing releases in group 2/2: default/my-release
+Affected releases are:
+  external-secrets (incubator/raw) UPDATED
+  my-release (incubator/raw) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/bad_selector
+++ b/pkg/app/testdata/app_lint_test/bad_selector
@@ -1,0 +1,105 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+0 release(s) matching app=test_non_existent found in helmfile.yaml
+

--- a/pkg/app/testdata/app_lint_test/bad_selector
+++ b/pkg/app/testdata/app_lint_test/bad_selector
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -103,3 +104,4 @@ second-pass rendering result of "helmfile.yaml.part.0":
 merged environment: &{default map[] map[]}
 0 release(s) matching app=test_non_existent found in helmfile.yaml
 
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/fail_on_unselected_need_by_default
+++ b/pkg/app/testdata/app_lint_test/fail_on_unselected_need_by_default
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 2 release(s) matching app=test found in helmfile.yaml
 
 err: release "default/default/external-secrets" depends on "default/kube-system/kubernetes-external-secrets" which does not match the selectors. Please add a selector like "--selector name=kubernetes-external-secrets", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/fail_on_unselected_need_by_default
+++ b/pkg/app/testdata/app_lint_test/fail_on_unselected_need_by_default
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+err: release "default/default/external-secrets" depends on "default/kube-system/kubernetes-external-secrets" which does not match the selectors. Please add a selector like "--selector name=kubernetes-external-secrets", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_lint_test/include-needs
+++ b/pkg/app/testdata/app_lint_test/include-needs
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -114,3 +115,4 @@ processing releases in group 1/4: default/kube-system/logging
 processing releases in group 2/4: default/kube-system/kubernetes-external-secrets
 processing releases in group 3/4: default/default/external-secrets
 processing releases in group 4/4: default/default/my-release
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/include-needs
+++ b/pkg/app/testdata/app_lint_test/include-needs
@@ -1,0 +1,116 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+processing 4 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/logging
+2     default/kube-system/kubernetes-external-secrets
+3     default/default/external-secrets
+4     default/default/my-release
+
+processing releases in group 1/4: default/kube-system/logging
+processing releases in group 2/4: default/kube-system/kubernetes-external-secrets
+processing releases in group 3/4: default/default/external-secrets
+processing releases in group 4/4: default/default/my-release

--- a/pkg/app/testdata/app_lint_test/include-needs_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_fail_on_disabled_direct_need
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+1 release(s) matching name=test2 found in helmfile.yaml
+
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_lint_test/include-needs_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_fail_on_disabled_direct_need
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 1 release(s) matching name=test2 found in helmfile.yaml
 
 err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/include-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_fail_on_disabled_transitive_need
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+1 release(s) matching name=test3 found in helmfile.yaml
+
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_lint_test/include-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_fail_on_disabled_transitive_need
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 1 release(s) matching name=test3 found in helmfile.yaml
 
 err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/include-needs_should_not_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_should_not_fail_on_disabled_direct_need
@@ -1,0 +1,114 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+1 release(s) matching name=test2 found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+
+processing releases in group 1/2: default/kube-system/disabled
+processing releases in group 2/2: default//test2
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/include-needs_should_not_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_should_not_fail_on_disabled_transitive_need
@@ -1,0 +1,116 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+1 release(s) matching name=test3 found in helmfile.yaml
+
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+3     default//test3
+
+processing releases in group 1/3: default/kube-system/disabled
+processing releases in group 2/3: default//test2
+processing releases in group 3/3: default//test3
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_fail_on_disabled_direct_need
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 2 release(s) matching name=test2 found in helmfile.yaml
 
 err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_fail_on_disabled_direct_need
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching name=test2 found in helmfile.yaml
+
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_fail_on_disabled_transitive_need
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+3 release(s) matching name=test3 found in helmfile.yaml
+
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_fail_on_disabled_transitive_need
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 3 release(s) matching name=test3 found in helmfile.yaml
 
 err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_direct_need
@@ -102,7 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-2 release(s) matching name=test2 found in helmfile.yaml
+1 release(s) matching name=test2 found in helmfile.yaml
 
 processing 2 groups of releases in this order:
 GROUP RELEASES

--- a/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_direct_need
@@ -1,0 +1,114 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching name=test2 found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+
+processing releases in group 1/2: default/kube-system/disabled
+processing releases in group 2/2: default//test2
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_transitive_need
@@ -102,7 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-3 release(s) matching name=test3 found in helmfile.yaml
+1 release(s) matching name=test3 found in helmfile.yaml
 
 processing 3 groups of releases in this order:
 GROUP RELEASES

--- a/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_lint_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_transitive_need
@@ -1,0 +1,116 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+3 release(s) matching name=test3 found in helmfile.yaml
+
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+3     default//test3
+
+processing releases in group 1/3: default/kube-system/disabled
+processing releases in group 2/3: default//test2
+processing releases in group 3/3: default//test3
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/include-transitive-needs
+++ b/pkg/app/testdata/app_lint_test/include-transitive-needs
@@ -1,0 +1,116 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+4 release(s) matching app=test found in helmfile.yaml
+
+processing 4 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/logging
+2     default/kube-system/kubernetes-external-secrets
+3     default/default/external-secrets
+4     default/default/my-release
+
+processing releases in group 1/4: default/kube-system/logging
+processing releases in group 2/4: default/kube-system/kubernetes-external-secrets
+processing releases in group 3/4: default/default/external-secrets
+processing releases in group 4/4: default/default/my-release

--- a/pkg/app/testdata/app_lint_test/include-transitive-needs
+++ b/pkg/app/testdata/app_lint_test/include-transitive-needs
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -114,3 +115,4 @@ processing releases in group 1/4: default/kube-system/logging
 processing releases in group 2/4: default/kube-system/kubernetes-external-secrets
 processing releases in group 3/4: default/default/external-secrets
 processing releases in group 4/4: default/default/my-release
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/include-transitive-needs
+++ b/pkg/app/testdata/app_lint_test/include-transitive-needs
@@ -102,7 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-4 release(s) matching app=test found in helmfile.yaml
+2 release(s) matching app=test found in helmfile.yaml
 
 processing 4 groups of releases in this order:
 GROUP RELEASES

--- a/pkg/app/testdata/app_lint_test/include-transitive-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_lint_test/include-transitive-needs_fail_on_disabled_transitive_need
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+3 release(s) matching name=test3 found in helmfile.yaml
+
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_lint_test/include-transitive-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_lint_test/include-transitive-needs_fail_on_disabled_transitive_need
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 3 release(s) matching name=test3 found in helmfile.yaml
 
 err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/include-transitive-needs_should_not_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_lint_test/include-transitive-needs_should_not_fail_on_disabled_transitive_need
@@ -102,7 +102,15 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-3 release(s) matching name=test3 found in helmfile.yaml
+1 release(s) matching name=test3 found in helmfile.yaml
 
-err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+3     default//test3
+
+processing releases in group 1/3: default/kube-system/disabled
+processing releases in group 2/3: default//test2
+processing releases in group 3/3: default//test3
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/skip-needs
+++ b/pkg/app/testdata/app_lint_test/skip-needs
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -110,3 +111,4 @@ GROUP RELEASES
 
 processing releases in group 1/2: default/default/external-secrets
 processing releases in group 2/2: default/default/my-release
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_lint_test/skip-needs
+++ b/pkg/app/testdata/app_lint_test/skip-needs
@@ -1,0 +1,112 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/default/external-secrets
+2     default/default/my-release
+
+processing releases in group 1/2: default/default/external-secrets
+processing releases in group 2/2: default/default/my-release

--- a/pkg/app/testdata/app_template_test/bad_selector
+++ b/pkg/app/testdata/app_template_test/bad_selector
@@ -1,0 +1,105 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+0 release(s) matching app=test_non_existent found in helmfile.yaml
+

--- a/pkg/app/testdata/app_template_test/bad_selector
+++ b/pkg/app/testdata/app_template_test/bad_selector
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -103,3 +104,4 @@ second-pass rendering result of "helmfile.yaml.part.0":
 merged environment: &{default map[] map[]}
 0 release(s) matching app=test_non_existent found in helmfile.yaml
 
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/fail_on_unselected_need_by_default
+++ b/pkg/app/testdata/app_template_test/fail_on_unselected_need_by_default
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 2 release(s) matching app=test found in helmfile.yaml
 
 err: release "default/default/external-secrets" depends on "default/kube-system/kubernetes-external-secrets" which does not match the selectors. Please add a selector like "--selector name=kubernetes-external-secrets", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/fail_on_unselected_need_by_default
+++ b/pkg/app/testdata/app_template_test/fail_on_unselected_need_by_default
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+err: release "default/default/external-secrets" depends on "default/kube-system/kubernetes-external-secrets" which does not match the selectors. Please add a selector like "--selector name=kubernetes-external-secrets", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_template_test/include-needs
+++ b/pkg/app/testdata/app_template_test/include-needs
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -114,3 +115,4 @@ processing releases in group 1/4: default/kube-system/logging
 processing releases in group 2/4: default/kube-system/kubernetes-external-secrets
 processing releases in group 3/4: default/default/external-secrets
 processing releases in group 4/4: default/default/my-release
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/include-needs
+++ b/pkg/app/testdata/app_template_test/include-needs
@@ -1,0 +1,116 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+processing 4 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/logging
+2     default/kube-system/kubernetes-external-secrets
+3     default/default/external-secrets
+4     default/default/my-release
+
+processing releases in group 1/4: default/kube-system/logging
+processing releases in group 2/4: default/kube-system/kubernetes-external-secrets
+processing releases in group 3/4: default/default/external-secrets
+processing releases in group 4/4: default/default/my-release

--- a/pkg/app/testdata/app_template_test/include-needs_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_template_test/include-needs_fail_on_disabled_direct_need
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+1 release(s) matching name=test2 found in helmfile.yaml
+
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_template_test/include-needs_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_template_test/include-needs_fail_on_disabled_direct_need
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 1 release(s) matching name=test2 found in helmfile.yaml
 
 err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/include-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_template_test/include-needs_fail_on_disabled_transitive_need
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+1 release(s) matching name=test3 found in helmfile.yaml
+
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_template_test/include-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_template_test/include-needs_fail_on_disabled_transitive_need
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 1 release(s) matching name=test3 found in helmfile.yaml
 
 err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/include-needs_should_not_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_template_test/include-needs_should_not_fail_on_disabled_direct_need
@@ -1,0 +1,114 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+1 release(s) matching name=test2 found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+
+processing releases in group 1/2: default/kube-system/disabled
+processing releases in group 2/2: default//test2
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/include-needs_should_not_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_template_test/include-needs_should_not_fail_on_disabled_transitive_need
@@ -1,0 +1,116 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+1 release(s) matching name=test3 found in helmfile.yaml
+
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+3     default//test3
+
+processing releases in group 1/3: default/kube-system/disabled
+processing releases in group 2/3: default//test2
+processing releases in group 3/3: default//test3
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_fail_on_disabled_direct_need
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 2 release(s) matching name=test2 found in helmfile.yaml
 
 err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_fail_on_disabled_direct_need
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching name=test2 found in helmfile.yaml
+
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_fail_on_disabled_transitive_need
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+3 release(s) matching name=test3 found in helmfile.yaml
+
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_fail_on_disabled_transitive_need
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 3 release(s) matching name=test3 found in helmfile.yaml
 
 err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_direct_need
@@ -102,7 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-2 release(s) matching name=test2 found in helmfile.yaml
+1 release(s) matching name=test2 found in helmfile.yaml
 
 processing 2 groups of releases in this order:
 GROUP RELEASES

--- a/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_direct_need
+++ b/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_direct_need
@@ -1,0 +1,114 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching name=test2 found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+
+processing releases in group 1/2: default/kube-system/disabled
+processing releases in group 2/2: default//test2
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_transitive_need
@@ -102,7 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-3 release(s) matching name=test3 found in helmfile.yaml
+1 release(s) matching name=test3 found in helmfile.yaml
 
 processing 3 groups of releases in this order:
 GROUP RELEASES

--- a/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_template_test/include-needs_with_include-transitive-needs_should_not_fail_on_disabled_transitive_need
@@ -1,0 +1,116 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+3 release(s) matching name=test3 found in helmfile.yaml
+
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+3     default//test3
+
+processing releases in group 1/3: default/kube-system/disabled
+processing releases in group 2/3: default//test2
+processing releases in group 3/3: default//test3
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/include-transitive-needs
+++ b/pkg/app/testdata/app_template_test/include-transitive-needs
@@ -1,0 +1,116 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+4 release(s) matching app=test found in helmfile.yaml
+
+processing 4 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/logging
+2     default/kube-system/kubernetes-external-secrets
+3     default/default/external-secrets
+4     default/default/my-release
+
+processing releases in group 1/4: default/kube-system/logging
+processing releases in group 2/4: default/kube-system/kubernetes-external-secrets
+processing releases in group 3/4: default/default/external-secrets
+processing releases in group 4/4: default/default/my-release

--- a/pkg/app/testdata/app_template_test/include-transitive-needs
+++ b/pkg/app/testdata/app_template_test/include-transitive-needs
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -114,3 +115,4 @@ processing releases in group 1/4: default/kube-system/logging
 processing releases in group 2/4: default/kube-system/kubernetes-external-secrets
 processing releases in group 3/4: default/default/external-secrets
 processing releases in group 4/4: default/default/my-release
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/include-transitive-needs
+++ b/pkg/app/testdata/app_template_test/include-transitive-needs
@@ -102,7 +102,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-4 release(s) matching app=test found in helmfile.yaml
+2 release(s) matching app=test found in helmfile.yaml
 
 processing 4 groups of releases in this order:
 GROUP RELEASES

--- a/pkg/app/testdata/app_template_test/include-transitive-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_template_test/include-transitive-needs_fail_on_disabled_transitive_need
@@ -1,0 +1,106 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+3 release(s) matching name=test3 found in helmfile.yaml
+
+err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies

--- a/pkg/app/testdata/app_template_test/include-transitive-needs_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_template_test/include-transitive-needs_fail_on_disabled_transitive_need
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -104,3 +105,4 @@ merged environment: &{default map[] map[]}
 3 release(s) matching name=test3 found in helmfile.yaml
 
 err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/include-transitive-needs_should_not_fail_on_disabled_transitive_need
+++ b/pkg/app/testdata/app_template_test/include-transitive-needs_should_not_fail_on_disabled_transitive_need
@@ -102,7 +102,15 @@ second-pass rendering result of "helmfile.yaml.part.0":
 44: 
 
 merged environment: &{default map[] map[]}
-3 release(s) matching name=test3 found in helmfile.yaml
+1 release(s) matching name=test3 found in helmfile.yaml
 
-err: release "default//test2" depends on "default/kube-system/disabled" which does not match the selectors. Please add a selector like "--selector name=disabled", or indicate whether to skip (--skip-needs) or include (--include-needs) these dependencies
+processing 3 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/disabled
+2     default//test2
+3     default//test3
+
+processing releases in group 1/3: default/kube-system/disabled
+processing releases in group 2/3: default//test2
+processing releases in group 3/3: default//test3
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/skip-needs
+++ b/pkg/app/testdata/app_template_test/skip-needs
@@ -1,4 +1,5 @@
 processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
 first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
 first-pass uses: &{default map[] map[]}
 first-pass rendering output of "helmfile.yaml.part.0":
@@ -110,3 +111,4 @@ GROUP RELEASES
 
 processing releases in group 1/2: default/default/external-secrets
 processing releases in group 2/2: default/default/my-release
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_template_test/skip-needs
+++ b/pkg/app/testdata/app_template_test/skip-needs
@@ -1,0 +1,112 @@
+processing file "helmfile.yaml" in directory "."
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: logging
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+ 6: - name: kubernetes-external-secrets
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9:   needs:
+10:   - kube-system/logging
+11: 
+12: - name: external-secrets
+13:   chart: incubator/raw
+14:   namespace: default
+15:   labels:
+16:     app: test
+17:   needs:
+18:   - kube-system/kubernetes-external-secrets
+19: 
+20: - name: my-release
+21:   chart: incubator/raw
+22:   namespace: default
+23:   labels:
+24:     app: test
+25:   needs:
+26:   - default/external-secrets
+27: 
+28: 
+29: # Disabled releases are treated as missing
+30: - name: disabled
+31:   chart: incubator/raw
+32:   namespace: kube-system
+33:   installed: false
+34: 
+35: - name: test2
+36:   chart: incubator/raw
+37:   needs:
+38:   - kube-system/disabled
+39: 
+40: - name: test3
+41:   chart: incubator/raw
+42:   needs:
+43:   - test2
+44: 
+
+merged environment: &{default map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/default/external-secrets
+2     default/default/my-release
+
+processing releases in group 1/2: default/default/external-secrets
+processing releases in group 2/2: default/default/my-release

--- a/pkg/app/testdata/testapply/delete_bar_when_bar_needs_foo/log
+++ b/pkg/app/testdata/testapply/delete_bar_when_bar_needs_foo/log
@@ -1,0 +1,60 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: stable/mychart1
+ 4: - name: bar
+ 5:   chart: stable/mychart2
+ 6:   installed: false
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: stable/mychart1
+ 4: - name: bar
+ 5:   chart: stable/mychart2
+ 6:   installed: false
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) DELETED
+  foo (stable/mychart1) UPDATED
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//bar
+
+processing releases in group 1/1: default//bar
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//foo
+
+processing releases in group 1/1: default//foo
+
+UPDATED RELEASES:
+NAME   CHART             VERSION
+foo    stable/mychart1     3.1.0
+
+
+DELETED RELEASES:
+NAME
+bar
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/delete_bar_when_foo_needs_bar/log
+++ b/pkg/app/testdata/testapply/delete_bar_when_foo_needs_bar/log
@@ -1,0 +1,60 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: stable/mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: stable/mychart1
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) DELETED
+  foo (stable/mychart1) UPDATED
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//bar
+
+processing releases in group 1/1: default//bar
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//foo
+
+processing releases in group 1/1: default//foo
+
+UPDATED RELEASES:
+NAME   CHART             VERSION
+foo    stable/mychart1     3.1.0
+
+
+DELETED RELEASES:
+NAME
+bar
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/delete_foo_and_bar_when_bar_needs_foo/log
+++ b/pkg/app/testdata/testapply/delete_foo_and_bar_when_bar_needs_foo/log
@@ -1,0 +1,55 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4:   installed: false
+ 5:   needs:
+ 6:   - foo
+ 7: - name: foo
+ 8:   chart: stable/mychart1
+ 9:   installed: false
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4:   installed: false
+ 5:   needs:
+ 6:   - foo
+ 7: - name: foo
+ 8:   chart: stable/mychart1
+ 9:   installed: false
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) DELETED
+  foo (stable/mychart1) DELETED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//bar
+2     default//foo
+
+processing releases in group 1/2: default//bar
+processing releases in group 2/2: default//foo
+
+DELETED RELEASES:
+NAME
+bar
+foo
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/delete_foo_and_bar_when_foo_needs_bar/log
+++ b/pkg/app/testdata/testapply/delete_foo_and_bar_when_foo_needs_bar/log
@@ -1,0 +1,55 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: stable/mychart1
+ 7:   installed: false
+ 8:   needs:
+ 9:   - bar
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4:   installed: false
+ 5: - name: foo
+ 6:   chart: stable/mychart1
+ 7:   installed: false
+ 8:   needs:
+ 9:   - bar
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) DELETED
+  foo (stable/mychart1) DELETED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//foo
+2     default//bar
+
+processing releases in group 1/2: default//foo
+processing releases in group 2/2: default//bar
+
+DELETED RELEASES:
+NAME
+foo
+bar
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/delete_foo_when_bar_needs_foo/log
+++ b/pkg/app/testdata/testapply/delete_foo_when_bar_needs_foo/log
@@ -1,0 +1,60 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: stable/mychart1
+ 4:   installed: false
+ 5: - name: bar
+ 6:   chart: stable/mychart2
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: stable/mychart1
+ 4:   installed: false
+ 5: - name: bar
+ 6:   chart: stable/mychart2
+ 7:   needs:
+ 8:   - foo
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) UPDATED
+  foo (stable/mychart1) DELETED
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//foo
+
+processing releases in group 1/1: default//foo
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//bar
+
+processing releases in group 1/1: default//bar
+
+UPDATED RELEASES:
+NAME   CHART             VERSION
+bar    stable/mychart2     3.1.0
+
+
+DELETED RELEASES:
+NAME
+foo
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/delete_foo_when_foo_needs_bar/log
+++ b/pkg/app/testdata/testapply/delete_foo_when_foo_needs_bar/log
@@ -1,0 +1,60 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4: - name: foo
+ 5:   chart: stable/mychart1
+ 6:   installed: false
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4: - name: foo
+ 5:   chart: stable/mychart1
+ 6:   installed: false
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) UPDATED
+  foo (stable/mychart1) DELETED
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//foo
+
+processing releases in group 1/1: default//foo
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default//bar
+
+processing releases in group 1/1: default//bar
+
+UPDATED RELEASES:
+NAME   CHART             VERSION
+bar    stable/mychart2     3.1.0
+
+
+DELETED RELEASES:
+NAME
+foo
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/helm2:_upgrade_when_tns1/foo_needs_tns2/bar/log
+++ b/pkg/app/testdata/testapply/helm2:_upgrade_when_tns1/foo_needs_tns2/bar/log
@@ -1,0 +1,62 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: stable/mychart1
+ 4:   namespace: ns1
+ 5:   tillerNamespace: tns1
+ 6:   needs:
+ 7:   - tns2/bar
+ 8: - name: bar
+ 9:   chart: stable/mychart2
+10:   namespace: ns2
+11:   tillerNamespace: tns2
+12: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: stable/mychart1
+ 4:   namespace: ns1
+ 5:   tillerNamespace: tns1
+ 6:   needs:
+ 7:   - tns2/bar
+ 8: - name: bar
+ 9:   chart: stable/mychart2
+10:   namespace: ns2
+11:   tillerNamespace: tns2
+12: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) UPDATED
+  foo (stable/mychart1) UPDATED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/tns2/bar
+2     default/tns1/foo
+
+processing releases in group 1/2: default/tns2/bar
+getting deployed release version failed:Failed to get the version for:mychart2
+processing releases in group 2/2: default/tns1/foo
+getting deployed release version failed:Failed to get the version for:mychart1
+
+UPDATED RELEASES:
+NAME   CHART             VERSION
+bar    stable/mychart2          
+foo    stable/mychart1          
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/install/log
+++ b/pkg/app/testdata/testapply/install/log
@@ -1,0 +1,61 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: baz
+ 3:   chart: stable/mychart3
+ 4: - name: foo
+ 5:   chart: stable/mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: - name: bar
+ 9:   chart: stable/mychart2
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: baz
+ 3:   chart: stable/mychart3
+ 4: - name: foo
+ 5:   chart: stable/mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: - name: bar
+ 9:   chart: stable/mychart2
+10: 
+
+merged environment: &{default map[] map[]}
+3 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) UPDATED
+  baz (stable/mychart3) UPDATED
+  foo (stable/mychart1) UPDATED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//baz, default//bar
+2     default//foo
+
+processing releases in group 1/2: default//baz, default//bar
+getting deployed release version failed:unexpected list key: listkey(filter=^baz$,flags=--kube-contextdefault--deleting--deployed--failed--pending) in 
+getting deployed release version failed:unexpected list key: listkey(filter=^bar$,flags=--kube-contextdefault--deleting--deployed--failed--pending) in 
+processing releases in group 2/2: default//foo
+getting deployed release version failed:unexpected list key: listkey(filter=^foo$,flags=--kube-contextdefault--deleting--deployed--failed--pending) in 
+
+UPDATED RELEASES:
+NAME   CHART             VERSION
+baz    stable/mychart3          
+bar    stable/mychart2          
+foo    stable/mychart1          
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/noop/log
+++ b/pkg/app/testdata/testapply/noop/log
@@ -1,0 +1,37 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4: - name: foo
+ 5:   chart: stable/mychart1
+ 6:   installed: false
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4: - name: foo
+ 5:   chart: stable/mychart1
+ 6:   installed: false
+ 7:   needs:
+ 8:   - bar
+ 9: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/smoke/log
+++ b/pkg/app/testdata/testapply/smoke/log
@@ -1,0 +1,174 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: database
+ 3:   chart: charts/mysql
+ 4:   needs:
+ 5:   - logging
+ 6: - name: frontend-v1
+ 7:   chart: charts/frontend
+ 8:   installed: false
+ 9:   needs:
+10:   - servicemesh
+11:   - logging
+12:   - backend-v1
+13: - name: frontend-v2
+14:   chart: charts/frontend
+15:   needs:
+16:   - servicemesh
+17:   - logging
+18:   - backend-v2
+19: - name: frontend-v3
+20:   chart: charts/frontend
+21:   needs:
+22:   - servicemesh
+23:   - logging
+24:   - backend-v2
+25: - name: backend-v1
+26:   chart: charts/backend
+27:   installed: false
+28:   needs:
+29:   - servicemesh
+30:   - logging
+31:   - database
+32:   - anotherbackend
+33: - name: backend-v2
+34:   chart: charts/backend
+35:   needs:
+36:   - servicemesh
+37:   - logging
+38:   - database
+39:   - anotherbackend
+40: - name: anotherbackend
+41:   chart: charts/anotherbackend
+42:   needs:
+43:   - servicemesh
+44:   - logging
+45:   - database
+46: - name: servicemesh
+47:   chart: charts/istio
+48:   needs:
+49:   - logging
+50: - name: logging
+51:   chart: charts/fluent-bit
+52: - name: front-proxy
+53:   chart: stable/envoy
+54: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: database
+ 3:   chart: charts/mysql
+ 4:   needs:
+ 5:   - logging
+ 6: - name: frontend-v1
+ 7:   chart: charts/frontend
+ 8:   installed: false
+ 9:   needs:
+10:   - servicemesh
+11:   - logging
+12:   - backend-v1
+13: - name: frontend-v2
+14:   chart: charts/frontend
+15:   needs:
+16:   - servicemesh
+17:   - logging
+18:   - backend-v2
+19: - name: frontend-v3
+20:   chart: charts/frontend
+21:   needs:
+22:   - servicemesh
+23:   - logging
+24:   - backend-v2
+25: - name: backend-v1
+26:   chart: charts/backend
+27:   installed: false
+28:   needs:
+29:   - servicemesh
+30:   - logging
+31:   - database
+32:   - anotherbackend
+33: - name: backend-v2
+34:   chart: charts/backend
+35:   needs:
+36:   - servicemesh
+37:   - logging
+38:   - database
+39:   - anotherbackend
+40: - name: anotherbackend
+41:   chart: charts/anotherbackend
+42:   needs:
+43:   - servicemesh
+44:   - logging
+45:   - database
+46: - name: servicemesh
+47:   chart: charts/istio
+48:   needs:
+49:   - logging
+50: - name: logging
+51:   chart: charts/fluent-bit
+52: - name: front-proxy
+53:   chart: stable/envoy
+54: 
+
+merged environment: &{default map[] map[]}
+10 release(s) found in helmfile.yaml
+
+Affected releases are:
+  anotherbackend (charts/anotherbackend) UPDATED
+  backend-v1 (charts/backend) DELETED
+  backend-v2 (charts/backend) UPDATED
+  database (charts/mysql) UPDATED
+  front-proxy (stable/envoy) UPDATED
+  frontend-v1 (charts/frontend) DELETED
+  frontend-v3 (charts/frontend) UPDATED
+  logging (charts/fluent-bit) UPDATED
+  servicemesh (charts/istio) UPDATED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//frontend-v1
+2     default//backend-v1
+
+processing releases in group 1/2: default//frontend-v1
+processing releases in group 2/2: default//backend-v1
+processing 5 groups of releases in this order:
+GROUP RELEASES
+1     default//logging, default//front-proxy
+2     default//database, default//servicemesh
+3     default//anotherbackend
+4     default//backend-v2
+5     default//frontend-v3
+
+processing releases in group 1/5: default//logging, default//front-proxy
+processing releases in group 2/5: default//database, default//servicemesh
+processing releases in group 3/5: default//anotherbackend
+processing releases in group 4/5: default//backend-v2
+processing releases in group 5/5: default//frontend-v3
+
+UPDATED RELEASES:
+NAME             CHART                   VERSION
+logging          charts/fluent-bit         3.1.0
+front-proxy      stable/envoy              3.1.0
+database         charts/mysql              3.1.0
+servicemesh      charts/istio              3.1.0
+anotherbackend   charts/anotherbackend     3.1.0
+backend-v2       charts/backend            3.1.0
+frontend-v3      charts/frontend           3.1.0
+
+
+DELETED RELEASES:
+NAME
+frontend-v1
+backend-v1
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/upgrade_when_bar_needs_foo,_with_ns_override/log
+++ b/pkg/app/testdata/testapply/upgrade_when_bar_needs_foo,_with_ns_override/log
@@ -1,0 +1,54 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: stable/mychart1
+ 4: - name: bar
+ 5:   chart: stable/mychart2
+ 6:   needs:
+ 7:   - foo
+ 8: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: stable/mychart1
+ 4: - name: bar
+ 5:   chart: stable/mychart2
+ 6:   needs:
+ 7:   - foo
+ 8: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) UPDATED
+  foo (stable/mychart1) UPDATED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/testNamespace/foo
+2     default/testNamespace/bar
+
+processing releases in group 1/2: default/testNamespace/foo
+getting deployed release version failed:Failed to get the version for:mychart1
+processing releases in group 2/2: default/testNamespace/bar
+getting deployed release version failed:Failed to get the version for:mychart2
+
+UPDATED RELEASES:
+NAME   CHART             VERSION
+foo    stable/mychart1          
+bar    stable/mychart2          
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/upgrade_when_bar_needs_foo/log
+++ b/pkg/app/testdata/testapply/upgrade_when_bar_needs_foo/log
@@ -1,0 +1,54 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: stable/mychart1
+ 4: - name: bar
+ 5:   chart: stable/mychart2
+ 6:   needs:
+ 7:   - foo
+ 8: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: stable/mychart1
+ 4: - name: bar
+ 5:   chart: stable/mychart2
+ 6:   needs:
+ 7:   - foo
+ 8: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) UPDATED
+  foo (stable/mychart1) UPDATED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//foo
+2     default//bar
+
+processing releases in group 1/2: default//foo
+getting deployed release version failed:Failed to get the version for:mychart1
+processing releases in group 2/2: default//bar
+getting deployed release version failed:Failed to get the version for:mychart2
+
+UPDATED RELEASES:
+NAME   CHART             VERSION
+foo    stable/mychart1          
+bar    stable/mychart2          
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/upgrade_when_foo_needs_bar,_with_ns_override/log
+++ b/pkg/app/testdata/testapply/upgrade_when_foo_needs_bar,_with_ns_override/log
@@ -1,0 +1,54 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4: - name: foo
+ 5:   chart: stable/mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4: - name: foo
+ 5:   chart: stable/mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) UPDATED
+  foo (stable/mychart1) UPDATED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/testNamespace/bar
+2     default/testNamespace/foo
+
+processing releases in group 1/2: default/testNamespace/bar
+getting deployed release version failed:Failed to get the version for:mychart2
+processing releases in group 2/2: default/testNamespace/foo
+getting deployed release version failed:Failed to get the version for:mychart1
+
+UPDATED RELEASES:
+NAME   CHART             VERSION
+bar    stable/mychart2          
+foo    stable/mychart1          
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/upgrade_when_foo_needs_bar/log
+++ b/pkg/app/testdata/testapply/upgrade_when_foo_needs_bar/log
@@ -1,0 +1,54 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4: - name: foo
+ 5:   chart: stable/mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4: - name: foo
+ 5:   chart: stable/mychart1
+ 6:   needs:
+ 7:   - bar
+ 8: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) UPDATED
+  foo (stable/mychart1) UPDATED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default//bar
+2     default//foo
+
+processing releases in group 1/2: default//bar
+getting deployed release version failed:Failed to get the version for:mychart2
+processing releases in group 2/2: default//foo
+getting deployed release version failed:Failed to get the version for:mychart1
+
+UPDATED RELEASES:
+NAME   CHART             VERSION
+bar    stable/mychart2          
+foo    stable/mychart1          
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/upgrade_when_ns1/foo_needs_ns2/bar/log
+++ b/pkg/app/testdata/testapply/upgrade_when_ns1/foo_needs_ns2/bar/log
@@ -1,0 +1,58 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: stable/mychart1
+ 4:   namespace: ns1
+ 5:   needs:
+ 6:   - ns2/bar
+ 7: - name: bar
+ 8:   chart: stable/mychart2
+ 9:   namespace: ns2
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: foo
+ 3:   chart: stable/mychart1
+ 4:   namespace: ns1
+ 5:   needs:
+ 6:   - ns2/bar
+ 7: - name: bar
+ 8:   chart: stable/mychart2
+ 9:   namespace: ns2
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) UPDATED
+  foo (stable/mychart1) UPDATED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/ns2/bar
+2     default/ns1/foo
+
+processing releases in group 1/2: default/ns2/bar
+getting deployed release version failed:Failed to get the version for:mychart2
+processing releases in group 2/2: default/ns1/foo
+getting deployed release version failed:Failed to get the version for:mychart1
+
+UPDATED RELEASES:
+NAME   CHART             VERSION
+bar    stable/mychart2          
+foo    stable/mychart1          
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply/upgrade_when_ns2/bar_needs_ns1/foo/log
+++ b/pkg/app/testdata/testapply/upgrade_when_ns2/bar_needs_ns1/foo/log
@@ -1,0 +1,58 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4:   namespace: ns2
+ 5:   needs:
+ 6:   - ns1/foo
+ 7: - name: foo
+ 8:   chart: stable/mychart1
+ 9:   namespace: ns1
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: bar
+ 3:   chart: stable/mychart2
+ 4:   namespace: ns2
+ 5:   needs:
+ 6:   - ns1/foo
+ 7: - name: foo
+ 8:   chart: stable/mychart1
+ 9:   namespace: ns1
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+Affected releases are:
+  bar (stable/mychart2) UPDATED
+  foo (stable/mychart1) UPDATED
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/ns1/foo
+2     default/ns2/bar
+
+processing releases in group 1/2: default/ns1/foo
+getting deployed release version failed:Failed to get the version for:mychart1
+processing releases in group 2/2: default/ns2/bar
+getting deployed release version failed:Failed to get the version for:mychart2
+
+UPDATED RELEASES:
+NAME   CHART             VERSION
+foo    stable/mychart1          
+bar    stable/mychart2          
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply_2/deduplicate_by_--selector/log
+++ b/pkg/app/testdata/testapply_2/deduplicate_by_--selector/log
@@ -58,10 +58,9 @@ GROUP RELEASES
 1     default/default/foo
 
 processing releases in group 1/1: default/default/foo
-getting deployed release version failed:unexpected list key: {^foo$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME   CHART           VERSION
-foo    incubator/raw          
+foo    incubator/raw     3.1.0
 
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/testapply_2/select_single_release_from_helmfile_with_two_duplicates/log
+++ b/pkg/app/testdata/testapply_2/select_single_release_from_helmfile_with_two_duplicates/log
@@ -62,10 +62,9 @@ GROUP RELEASES
 1     default/default/foo
 
 processing releases in group 1/1: default/default/foo
-getting deployed release version failed:unexpected list key: {^foo$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME   CHART           VERSION
-foo    incubator/raw          
+foo    incubator/raw     3.1.0
 
 changing working directory back to "/path/to"

--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -15,6 +15,10 @@ type ListKey struct {
 	Flags  string
 }
 
+func (k ListKey) String() string {
+	return fmt.Sprintf("listkey(filter=%s,flags=%s)", k.Filter, k.Flags)
+}
+
 type DiffKey struct {
 	Name  string
 	Chart string
@@ -150,7 +154,11 @@ func (helm *Helm) List(context helmexec.HelmContext, filter string, flags ...str
 
 	res, ok := helm.Lists[key]
 	if !ok && helm.FailOnUnexpectedList {
-		return "", fmt.Errorf("unexpected list key: %v", key)
+		var keys []string
+		for k := range helm.Lists {
+			keys = append(keys, k.String())
+		}
+		return "", fmt.Errorf("unexpected list key: %v in %v", key, strings.Join(keys, ", "))
 	}
 	return res, nil
 }

--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -27,6 +27,7 @@ type Helm struct {
 	Releases             []Release
 	Deleted              []Release
 	Linted               []Release
+	Templated            []Release
 	Lists                map[ListKey]string
 	Diffs                map[DiffKey]error
 	Diffed               []Release
@@ -164,6 +165,10 @@ func (helm *Helm) Lint(name, chart string, flags ...string) error {
 	return nil
 }
 func (helm *Helm) TemplateRelease(name, chart string, flags ...string) error {
+	if strings.Contains(name, "error") {
+		return errors.New("error")
+	}
+	helm.Templated = append(helm.Templated, Release{Name: name, Flags: flags})
 	return nil
 }
 func (helm *Helm) ChartPull(chart string, flags ...string) error {

--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -26,6 +26,7 @@ type Helm struct {
 	Repo                 []string
 	Releases             []Release
 	Deleted              []Release
+	Linted               []Release
 	Lists                map[ListKey]string
 	Diffs                map[DiffKey]error
 	Diffed               []Release
@@ -156,6 +157,10 @@ func (helm *Helm) Fetch(chart string, flags ...string) error {
 	return nil
 }
 func (helm *Helm) Lint(name, chart string, flags ...string) error {
+	if strings.Contains(name, "error") {
+		return errors.New("error")
+	}
+	helm.Linted = append(helm.Linted, Release{Name: name, Flags: flags})
 	return nil
 }
 func (helm *Helm) TemplateRelease(name, chart string, flags ...string) error {

--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -115,6 +115,11 @@ func (helm *Helm) DiffRelease(context helmexec.HelmContext, name, chart string, 
 	if helm.DiffMutex != nil {
 		helm.DiffMutex.Unlock()
 	}
+
+	if helm.Diffs == nil {
+		return nil
+	}
+
 	key := DiffKey{Name: name, Chart: chart, Flags: strings.Join(flags, "")}
 	err, ok := helm.Diffs[key]
 	if !ok && helm.FailOnUnexpectedDiff {
@@ -138,6 +143,11 @@ func (helm *Helm) DeleteRelease(context helmexec.HelmContext, name string, flags
 }
 func (helm *Helm) List(context helmexec.HelmContext, filter string, flags ...string) (string, error) {
 	key := ListKey{Filter: filter, Flags: strings.Join(flags, "")}
+
+	if helm.Lists == nil {
+		return "dummy non-empty helm-list output", nil
+	}
+
 	res, ok := helm.Lists[key]
 	if !ok && helm.FailOnUnexpectedList {
 		return "", fmt.Errorf("unexpected list key: %v", key)

--- a/pkg/testhelper/require_log.go
+++ b/pkg/testhelper/require_log.go
@@ -1,0 +1,41 @@
+package testhelper
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func RequireLog(t *testing.T, dir string, bs *bytes.Buffer) {
+	t.Helper()
+
+	testNameComponents := strings.Split(t.Name(), "/")
+	testBaseName := strings.ToLower(
+		strings.ReplaceAll(
+			testNameComponents[len(testNameComponents)-1],
+			" ",
+			"_",
+		),
+	)
+	wantLogFileDir := filepath.Join("testdata", dir)
+	wantLogFile := filepath.Join(wantLogFileDir, testBaseName)
+	wantLogData, err := os.ReadFile(wantLogFile)
+	updateLogFile := err != nil
+	wantLog := string(wantLogData)
+	gotLog := bs.String()
+	if updateLogFile {
+		if err := os.MkdirAll(wantLogFileDir, 0755); err != nil {
+			t.Fatalf("unable to create directory %q: %v", wantLogFileDir, err)
+		}
+		if err := os.WriteFile(wantLogFile, bs.Bytes(), 0644); err != nil {
+			t.Fatalf("unable to update lint log snapshot: %v", err)
+		}
+	}
+
+	diff, exists := Diff(wantLog, gotLog, 3)
+	if exists {
+		t.Errorf("unexpected log:\nDIFF\n%s\nEOD\nPlease remove %s and rerun the test to recapture this test snapshot", diff, wantLogFile)
+	}
+}


### PR DESCRIPTION
I was originally going to fix helmfile-lint to support `--skip-needs` and `--include-needs`, but apparently it also lacked `--include-transitive-needs`.

Furthermore, I compared the support levels of those flags among a few helmfile sub-commands and realized that helmfile-diff and helmfile-template lacked one flag for each, and helmfile-template had an edge-case that results in outputting a misleading error message.

The outcome is that the behaviors on skip/include-needs for `helmfile lint`, `helmfile template`, and `helmfile diff` are consistent with `helmfile apply`. More concretely:

* helmfile-diff adds support for --include-transitive-needs
* helmfile-template adds support for --skip-needs, fixes [the error message emitted on unselected needed release](https://github.com/roboll/helmfile/issues/2055#issuecomment-1114115625)
* helmfile-lint adds support for --skip-needs, --include-needs, and --include-transitive-needs
* `include-transitive-needs` now implies `include-needs` in `helmfile lint`, `helmfile diff`, and `helmfile template` (Probably we need the same enhancement for `helmfile apply` and `helmfile sync` and so on. But I'm deferring that to another pr

Ref https://github.com/roboll/helmfile/issues/2055