### PR TITLE
feat: allow --validate on sync command

### DIFF
--- a/main.go
+++ b/main.go
@@ -443,7 +443,7 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "validate",
-					Usage: "validate your manifests against the Kubernetes cluster you are currently pointing at. Note that this requiers access to a Kubernetes cluster to obtain information necessary for validating, like the list of available API versions",
+					Usage: "ADVANCED CONFIGURATION: When sync is going to involve helm-template as a part of the "chartify" process, it might fail due to missing .Capabilities. This flag makes instructs helmfile to pass --validate to helm-template so it populates .Capabilities and validates your manifests against the Kubernetes cluster you are currently pointing at. Note that this requiers access to a Kubernetes cluster to obtain information necessary for validating, like the list of available API versions",
 				},
 				cli.BoolFlag{
 					Name:  "wait",

--- a/main.go
+++ b/main.go
@@ -442,6 +442,10 @@ func main() {
 					Usage: `like --include-needs, but also includes transitive needs (needs of needs). Does nothing when when --selector/-l flag is not provided. Overrides exclusions of other selectors and conditions.`,
 				},
 				cli.BoolFlag{
+					Name:  "validate",
+					Usage: "validate your manifests against the Kubernetes cluster you are currently pointing at. Note that this requiers access to a Kubernetes cluster to obtain information necessary for validating, like the list of available API versions",
+				},
+				cli.BoolFlag{
 					Name:  "wait",
 					Usage: `Override helmDefaults.wait setting "helm upgrade --install --wait"`,
 				},

--- a/main.go
+++ b/main.go
@@ -443,7 +443,7 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "validate",
-					Usage: "ADVANCED CONFIGURATION: When sync is going to involve helm-template as a part of the "chartify" process, it might fail due to missing .Capabilities. This flag makes instructs helmfile to pass --validate to helm-template so it populates .Capabilities and validates your manifests against the Kubernetes cluster you are currently pointing at. Note that this requiers access to a Kubernetes cluster to obtain information necessary for validating, like the list of available API versions",
+					Usage: `ADVANCED CONFIGURATION: When sync is going to involve helm-template as a part of the "chartify" process, it might fail due to missing .Capabilities. This flag makes instructs helmfile to pass --validate to helm-template so it populates .Capabilities and validates your manifests against the Kubernetes cluster you are currently pointing at. Note that this requiers access to a Kubernetes cluster to obtain information necessary for validating, like the list of available API versions`,
 				},
 				cli.BoolFlag{
 					Name:  "wait",

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -363,6 +363,7 @@ func (a *App) Sync(c SyncConfigProvider) error {
 			WaitForJobs:            c.WaitForJobs(),
 			IncludeCRDs:            &includeCRDs,
 			IncludeTransitiveNeeds: c.IncludeTransitiveNeeds(),
+			Validate:               c.Validate(),
 		}, func() {
 			ok, errs = a.sync(run, c)
 		})

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -85,6 +85,8 @@ type SyncConfigProvider interface {
 	Wait() bool
 	WaitForJobs() bool
 
+	Validate() bool
+
 	SkipNeeds() bool
 	IncludeNeeds() bool
 	IncludeTransitiveNeeds() bool


### PR DESCRIPTION
Chart using `.Capabilities` helm  built-in object cannot be sync as `sync` command does not accept `--validate` Options

This PR permit usage of `--validate` options with sync command

### Failing Chart Example

```yaml
{{- if and .Values.alertmanager.enabled .Values.alertmanager.ingress.enabled }}
{{- $servicePort := 9093 -}}
{{- $ingressPath := .Values.alertmanager.ingress.path -}}
{{- $serviceName := printf "%s-%s" "vmalertmanager" (include "victoria-metrics-k8s-stack.fullname" .) | trunc 63 | trimSuffix "-" }}
{{- $ingressPathType := .Values.alertmanager.ingress.pathType | default "" -}}
{{- $extraPaths := .Values.alertmanager.ingress.extraPaths -}}
{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
{{- if $newAPI -}}
apiVersion: networking.k8s.io/v1
{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
apiVersion: networking.k8s.io/v1beta1
{{- else }}
apiVersion: extensions/v1beta1
{{- end }}
kind: Ingress
metadata:
  name: {{ .Values.alertmanager.name | default $serviceName }}
  namespace: {{ .Release.Namespace }}
  labels:
    app.kubernetes.io/component: {{ include "victoria-metrics-k8s-stack.name" $ }}-alertmanager
{{ include "victoria-metrics-k8s-stack.labels" . | indent 4 }}
{{- if .Values.alertmanager.ingress.labels }}
{{ toYaml .Values.alertmanager.ingress.labels | indent 4 }}
{{- end }}
  {{- if .Values.alertmanager.ingress.annotations }}
  annotations:
    {{- range $key, $value := .Values.alertmanager.ingress.annotations }}
    {{ $key }}: {{ tpl $value $ | quote }}
    {{- end }}
  {{- end }}
spec:
  {{- if .Values.alertmanager.ingress.ingressClassName }}
  ingressClassName: {{ .Values.alertmanager.ingress.ingressClassName }}
  {{- end -}}
{{- if .Values.alertmanager.ingress.tls }}
  tls:
{{ tpl (toYaml .Values.alertmanager.ingress.tls) $ | indent 4 }}
{{- end }}
  rules:
  {{- if .Values.alertmanager.ingress.hosts  }}
  {{- range .Values.alertmanager.ingress.hosts }}
    - host: {{ tpl . $}}
      http:
        paths:
{{- if $extraPaths }}
{{ toYaml $extraPaths | indent 10 }}
{{- end }}
          - path: {{ $ingressPath }}
            {{- if $newAPI }}
            pathType: {{ $ingressPathType }}
            {{- end }}
            backend:
              {{- if $newAPI }}
              service:
                name: {{ $serviceName }}
                port:
                  number: {{ $servicePort }}
              {{- else }}
              serviceName: {{ $serviceName }}
              servicePort: {{ $servicePort }}
              {{- end }}
  {{- end }}
  {{- else }}
    - http:
        paths:
          - backend:
              {{- if $newAPI }}
              service:
                name: {{ $serviceName }}
                port:
                  number: {{ $servicePort }}
            pathType: {{ $ingressPathType }}
              {{- else }}
              serviceName: {{ $serviceName }}
              servicePort: {{ $servicePort }}
              {{- end }}
          {{- if $ingressPath }}
            path: {{ $ingressPath }}
            {{- end }}
  {{- end -}}
{{- end }}
```

In this chart we use `.Capabilities.APIVersions` in order define which APIVersions need to be used based on Kubernetes Cluster where we deploy