### PR TITLE
chore(state): Append Api Versions flags to helm-diff

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2536,6 +2536,8 @@ func (st *HelmState) flagsForDiff(helm helmexec.Interface, release *ReleaseSpec,
 		flags = append(flags, "--disable-validation")
 	}
 
+	flags = st.appendApiVersionsFlags(flags, release)
+
 	flags = st.appendConnectionFlags(flags, helm, release)
 
 	var err error

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2568,12 +2568,21 @@ func (st *HelmState) chartVersionFlags(release *ReleaseSpec) []string {
 }
 
 func (st *HelmState) appendApiVersionsFlags(flags []string, r *ReleaseSpec) []string {
-	for _, a := range r.ApiVersions {
-		flags = append(flags, "--api-versions", a)
+
+	if len(r.ApiVersions) != 0 {
+		for _, a := range r.ApiVersions {
+			flags = append(flags, "--api-versions", a)
+		}
+	} else {
+		for _, a := range st.ApiVersions {
+			flags = append(flags, "--api-versions", a)
+		}
 	}
 
 	if r.KubeVersion != "" {
 		flags = append(flags, "--kube-version", r.KubeVersion)
+	} else if st.KubeVersion != "" {
+		flags = append(flags, "--kube-version", st.KubeVersion)
 	}
 
 	return flags

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2573,7 +2573,7 @@ func (st *HelmState) appendApiVersionsFlags(flags []string, r *ReleaseSpec) []st
 	}
 
 	if r.KubeVersion != "" {
-		flags = append(flags, "--kube-version", st.KubeVersion)
+		flags = append(flags, "--kube-version", r.KubeVersion)
 	}
 
 	return flags


### PR DESCRIPTION
Support for the missing `KubeVersion` flag on Helm-diff was added in this PR: https://github.com/databus23/helm-diff/pull/386.

Helm-diff will append these flags to `helm template`.

Changes:
 * Added unit test for `state.flagsForDiff`
 * Fix `appendApiVersionsFlags` to check `Helmstate` values if `ReleaseSpec` values aren't set.

