### PR TITLE
Fix deprecated chart in Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Suppose the `helmfile.yaml` representing the desired state of your helm releases
 releases:
 - name: prom-norbac-ubuntu
   namespace: prometheus
-  chart: stable/prometheus
+  chart: prometheus-community/prometheus
   set:
   - name: rbac.create
     value: false


### PR DESCRIPTION
`stable/prometheus` is DEPRECATED and moved to `prometheus-community/prometheus`.
see https://github.com/helm/charts/blob/master/stable/prometheus/README.md?plain=1#L3

So, I fixed "Getting Started" in README.md.