### PR TITLE
fix ci test error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,9 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Cache libraries
       uses: actions/cache@v2
       env:


### PR DESCRIPTION
Signed-off-by: yxxhero <aiopsclub@163.com>

fix ci test error


```
make build build-test-tools
  shell: /usr/bin/bash -e {0}
  env:
    GOROOT: /opt/hostedtoolcache/go/1.18.[3](https://github.com/helmfile/helmfile/runs/6953513978?check_suite_focus=true#step:6:3)/x6[4](https://github.com/helmfile/helmfile/runs/6953513978?check_suite_focus=true#step:6:4)
fatal: No names found, cannot describe anything.
go build -ldflags '-X github.com/helmfile/helmfile/pkg/app/version.Version=' 
go build test/diff-yamls/diff-yamls.go
go build test/yamldiff/yamldiff.go
```
version is nil