### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -637,8 +637,7 @@ releases:
 		{label: "name=doesnotexists", expectedReleases: []string{"zipkin", "prometheus", "grafana", "bar", "bar", "grafana", "postgresql"}, expectErr: false},
 	}
 
-	os.Setenv(envvar.Experimental, ExperimentalSelectorExplicit)
-	defer os.Unsetenv(envvar.Experimental)
+	t.Setenv(envvar.Experimental, ExperimentalSelectorExplicit)
 
 	runFilterSubHelmFilesTests(desiredTestcases, files, t, "2nd EmbeddedSelectors")
 
@@ -687,8 +686,7 @@ releases:
 		{label: "name!=grafana", expectedReleases: []string{"grafana", "zipkin", "mongodb"}, expectErr: false},
 	}
 
-	os.Setenv(envvar.Experimental, ExperimentalSelectorExplicit)
-	defer os.Unsetenv(envvar.Experimental)
+	t.Setenv(envvar.Experimental, ExperimentalSelectorExplicit)
 
 	runFilterSubHelmFilesTests(desiredTestcases, files, t, "2nd 3leveldeep")
 
@@ -749,8 +747,7 @@ releases:
 		{label: "select!=foo", expectedReleases: []string{"grafana", "prometheus", "zipkin", "prometheus", "zipkin", "mongodb"}, expectErr: false},
 	}
 
-	os.Setenv(envvar.Experimental, ExperimentalSelectorExplicit)
-	defer os.Unsetenv(envvar.Experimental)
+	t.Setenv(envvar.Experimental, ExperimentalSelectorExplicit)
 
 	runFilterSubHelmFilesTests(desiredTestcases, files, t, "2nd inherits")
 

--- a/pkg/app/constants_test.go
+++ b/pkg/app/constants_test.go
@@ -16,23 +16,20 @@ func TestIsExplicitSelectorInheritanceEnabled(t *testing.T) {
 	require.False(t, isExplicitSelectorInheritanceEnabled())
 
 	//check for env var ExperimentalEnvVar set to true
-	os.Setenv(envvar.Experimental, "true")
+	t.Setenv(envvar.Experimental, "true")
 	require.True(t, isExplicitSelectorInheritanceEnabled())
 
 	//check for env var ExperimentalEnvVar set to anything
-	os.Setenv(envvar.Experimental, "anything")
+	t.Setenv(envvar.Experimental, "anything")
 	require.False(t, isExplicitSelectorInheritanceEnabled())
 
 	//check for env var ExperimentalEnvVar set to ExperimentalSelectorExplicit
-	os.Setenv(envvar.Experimental, ExperimentalSelectorExplicit)
+	t.Setenv(envvar.Experimental, ExperimentalSelectorExplicit)
 	require.True(t, isExplicitSelectorInheritanceEnabled())
 
 	// check for env var ExperimentalEnvVar set to a string that contains ExperimentalSelectorExplicit and ExperimentalEnvVar set to true
-	os.Setenv(envvar.Experimental, fmt.Sprintf("%s-%s-%s", "a", ExperimentalSelectorExplicit, "b"))
+	t.Setenv(envvar.Experimental, fmt.Sprintf("%s-%s-%s", "a", ExperimentalSelectorExplicit, "b"))
 	require.True(t, isExplicitSelectorInheritanceEnabled())
-
-	// reset env var
-	defer os.Unsetenv(envvar.Experimental)
 }
 
 // TestExperimentalModeEnabled tests the experimentalModeEnabled function
@@ -42,13 +39,10 @@ func TestExperimentalModeEnabled(t *testing.T) {
 	require.False(t, experimentalModeEnabled())
 
 	//check for env var ExperimentalEnvVar set to anything
-	os.Setenv(envvar.Experimental, "anything")
+	t.Setenv(envvar.Experimental, "anything")
 	require.False(t, experimentalModeEnabled())
 
 	//check for env var ExperimentalEnvVar set to true
-	os.Setenv(envvar.Experimental, "true")
+	t.Setenv(envvar.Experimental, "true")
 	require.True(t, experimentalModeEnabled())
-
-	// reset env var
-	defer os.Unsetenv(envvar.Experimental)
 }

--- a/pkg/helmexec/context_test.go
+++ b/pkg/helmexec/context_test.go
@@ -94,11 +94,9 @@ func TestGetTillerlessEnv(t *testing.T) {
 		hc := &HelmContext{
 			Tillerless: test.tillerless,
 		}
-		os.Setenv(kubeconfigEnv, test.kubeconfig)
+		t.Setenv(kubeconfigEnv, test.kubeconfig)
 		result := hc.getTillerlessEnv()
 		require.Equalf(t, test.expected, result, "expected result %s, received result %s", test.expected, result)
 
 	}
-	defer os.Unsetenv(kubeconfigEnv)
-
 }

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -736,14 +736,13 @@ func Test_getTillerlessEnv(t *testing.T) {
 		t.Errorf("getTillerlessEnv() KUBECONFIG\nactual = %s\nexpect = nil", val)
 	}
 
-	os.Setenv("KUBECONFIG", "toto")
+	t.Setenv("KUBECONFIG", "toto")
 	actual = context.getTillerlessEnv()
 	cwd, _ := os.Getwd()
 	expected := path.Join(cwd, "toto")
 	if val, found := actual["KUBECONFIG"]; !found || val != expected {
 		t.Errorf("getTillerlessEnv() KUBECONFIG\nactual = %s\nexpect = %s", val, expected)
 	}
-	os.Unsetenv("KUBECONFIG")
 }
 
 func Test_mergeEnv(t *testing.T) {
@@ -795,13 +794,12 @@ func Test_IsHelm3(t *testing.T) {
 		t.Error("helmexec.IsHelm3() - Failed to detect Helm 3")
 	}
 
-	os.Setenv(envvar.Helm3, "1")
+	t.Setenv(envvar.Helm3, "1")
 	helm2Runner = mockRunner{output: []byte("Client: v2.16.0+ge13bc94\n")}
 	helm = New("helm", NewLogger(os.Stdout, "info"), "dev", &helm2Runner)
 	if !helm.IsHelm3() {
 		t.Errorf("helmexec.IsHelm3() - Helm3 not detected when %s is set", envvar.Helm3)
 	}
-	os.Setenv(envvar.Helm3, "")
 }
 
 func Test_GetVersion(t *testing.T) {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -987,10 +987,7 @@ func TestHelmState_SyncRepos(t *testing.T) {
 		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.envs {
-				err := os.Setenv(k, v)
-				if err != nil {
-					t.Error("HelmState.SyncRepos() could not set env var for testing")
-				}
+				t.Setenv(k, v)
 			}
 			state := &HelmState{
 				ReleaseSetSpec: ReleaseSetSpec{

--- a/pkg/tmpl/context_funcs_test.go
+++ b/pkg/tmpl/context_funcs_test.go
@@ -3,7 +3,6 @@ package tmpl
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -286,7 +285,7 @@ func TestRequiredEnv(t *testing.T) {
 	require.Emptyf(t, envVal, "Expected empty string to be returned when environment variable %s is not set", envKey)
 
 	// test that the environment variable is set to an empty string
-	os.Setenv(envKey, "")
+	t.Setenv(envKey, "")
 	envVal, err = RequiredEnv(envKey)
 
 	require.NotNilf(t, err, "Expected error to be returned when environment variable %s is set to an empty string", envKey)
@@ -294,10 +293,8 @@ func TestRequiredEnv(t *testing.T) {
 
 	// test that the environment variable is set to a non-empty string
 	expected := "helmfile"
-	os.Setenv(envKey, expected)
+	t.Setenv(envKey, expected)
 
-	// Unset the environment variable
-	defer os.Unsetenv(envKey)
 	envVal, err = RequiredEnv(envKey)
 	require.Nilf(t, err, "Expected no error to be returned when environment variable %s is set to a non-empty string", envKey)
 	require.Equalf(t, expected, envVal, "Expected %s to be returned when environment variable %s is set to a non-empty string", expected, envKey)
@@ -348,8 +345,7 @@ func TestEnvExec(t *testing.T) {
 	require.Emptyf(t, output, "Expected empty string to be returned when executing command with no environment variables")
 
 	// test that the command is executed with os environment variables
-	os.Setenv(testKey, "foo")
-	defer os.Unsetenv(testKey)
+	t.Setenv(testKey, "foo")
 	output, err = ctx.EnvExec(nil, "bash", []interface{}{"-c", fmt.Sprintf("echo -n $%s", testKey)}, "")
 
 	require.Nilf(t, err, "Expected no error to be returned when executing command with environment variables")

--- a/pkg/tmpl/context_tmpl_test.go
+++ b/pkg/tmpl/context_tmpl_test.go
@@ -2,7 +2,6 @@ package tmpl
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 )
@@ -234,10 +233,7 @@ func Test_renderTemplateToString(t *testing.T) {
 		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.args.envs {
-				err := os.Setenv(k, v)
-				if err != nil {
-					t.Error("renderTemplateToString() could not set env var for testing")
-				}
+				t.Setenv(k, v)
 			}
 			got, err := renderTemplateToString(tt.args.s, tt.args.data)
 			if (err != nil) != tt.wantErr {

--- a/test/e2e/template/helmfile/tmpl_test.go
+++ b/test/e2e/template/helmfile/tmpl_test.go
@@ -26,16 +26,9 @@ type tmplTestCase struct {
 }
 
 // setEnvs sets the environment variables for the test case
-func (t *tmplTestCase) setEnvs() {
+func (t *tmplTestCase) setEnvs(tt *testing.T) {
 	for k, v := range t.envs {
-		os.Setenv(k, v)
-	}
-}
-
-// unSetEnvs unsets the environment variables for the test case
-func (t *tmplTestCase) unSetEnvs() {
-	for k := range t.envs {
-		os.Unsetenv(k)
+		tt.Setenv(k, v)
 	}
 }
 
@@ -235,8 +228,7 @@ func TestTmplStrings(t *testing.T) {
 
 	for _, tc := range tmplE2eTest.tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.setEnvs()
-			defer tc.unSetEnvs()
+			tc.setEnvs(t)
 			tmpl, err := tmpl.Parse(tc.tmplString)
 			require.Nilf(t, err, "error parsing template: %v", err)
 


### PR DESCRIPTION
This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv