### PR TITLE
E2E helmfile-template testing with local chart repo server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
 	github.com/urfave/cli v1.22.9
-	github.com/variantdev/chartify v0.10.0
+	github.com/variantdev/chartify v0.10.2
 	github.com/variantdev/dag v1.1.0
 	github.com/variantdev/vals v0.18.0
 	go.uber.org/multierr v1.6.0
@@ -140,6 +140,8 @@ require (
 require (
 	cloud.google.com/go/secretmanager v1.3.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/containerd/containerd v1.5.9 // indirect
@@ -150,24 +152,54 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/frankban/quicktest v1.14.3 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
+	github.com/go-logr/logr v1.2.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/btree v1.0.1 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/term v0.0.0-20210610120745-9d4ed1856297 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4 v2.3.0+incompatible // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
 	helm.sh/helm/v3 v3.8.1 // indirect
+	k8s.io/api v0.23.4 // indirect
+	k8s.io/cli-runtime v0.23.4 // indirect
 	k8s.io/client-go v0.23.4 // indirect
+	k8s.io/klog/v2 v2.30.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
+	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
 	oras.land/oras-go v1.1.0 // indirect
+	sigs.k8s.io/kustomize/api v0.10.1 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.13.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1243,8 +1243,8 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.9 h1:cv3/KhXGBGjEXLC4bH0sLuJ9BewaAbpk5oyMOveu4pw=
 github.com/urfave/cli v1.22.9/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/variantdev/chartify v0.10.0 h1:Sxf07QBoZ54WlAyw35fcFA0lSyMtv62SQah0JPGrvI0=
-github.com/variantdev/chartify v0.10.0/go.mod h1:A0nQmb+ihiBJrrbgofs1t7QVeit+/llT0vJhvkj7U0Q=
+github.com/variantdev/chartify v0.10.2 h1:CAMlSE4kBl8ft/Xl4ob+eyFZ2KV5evkiMEI43M4CaKs=
+github.com/variantdev/chartify v0.10.2/go.mod h1:A0nQmb+ihiBJrrbgofs1t7QVeit+/llT0vJhvkj7U0Q=
 github.com/variantdev/dag v1.1.0 h1:xodYlSng33KWGvIGMpKUyLcIZRXKiNUx612mZJqYrDg=
 github.com/variantdev/dag v1.1.0/go.mod h1:pH1TQsNSLj2uxMo9NNl9zdGy01Wtn+/2MT96BrKmVyE=
 github.com/variantdev/vals v0.18.0 h1:25eOKvHVPoU9fLA3Du0chT8d6iJybCkc/9ixg1cZwHA=

--- a/test/e2e/template/helmfile/snapshot_test.go
+++ b/test/e2e/template/helmfile/snapshot_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/variantdev/chartify/helmtesting"
 	"gopkg.in/yaml.v3"
 )
 
@@ -21,6 +22,10 @@ func TestHelmfileTemplateWithBuildCommand(t *testing.T) {
 			Enabled bool `yaml:"enabled"`
 			Port    int  `yaml:"port"`
 		} `yaml:"localDockerRegistry"`
+		LocalChartRepoServer struct {
+			Enabled bool `yaml:"enabled"`
+			Port    int  `yaml:"port"`
+		} `yaml:"localChartRepoServer"`
 		ChartifyTempDir string   `yaml:"chartifyTempDir"`
 		HelmfileArgs    []string `yaml:"helmfileArgs"`
 	}
@@ -122,10 +127,17 @@ func TestHelmfileTemplateWithBuildCommand(t *testing.T) {
 				}
 			}
 
+			if config.LocalChartRepoServer.Enabled {
+				helmtesting.StartChartRepoServer(t, helmtesting.ChartRepoServerConfig{
+					Port:      config.LocalChartRepoServer.Port,
+					ChartsDir: chartsDir,
+				})
+			}
+
 			inputFile := filepath.Join(testdataDir, name, "input.yaml")
 			outputFile := filepath.Join(testdataDir, name, "output.yaml")
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 			defer cancel()
 
 			args := []string{"-f", inputFile}

--- a/test/e2e/template/helmfile/testdata/snapshot/chart_need/config.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/chart_need/config.yaml
@@ -1,0 +1,6 @@
+localChartRepoServer:
+  enabled: true
+  port: 18080
+chartifyTempDir: temp1
+helmfileArgs:
+- template

--- a/test/e2e/template/helmfile/testdata/snapshot/chart_need/input.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/chart_need/input.yaml
@@ -1,0 +1,31 @@
+repositories:
+- name: myrepo
+  url: http://localhost:18080/
+
+releases:
+- name: foo
+  chart: ../../charts/raw
+  values:
+  - templates:
+    - |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: {{`{{ .Release.Name }}`}}-1
+        namespace: {{`{{ .Release.Namespace }}`}}
+      data:
+        foo: FOO
+    dep:
+      templates:
+      - |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: {{`{{ .Release.Name }}`}}-2
+          namespace: {{`{{ .Release.Namespace }}`}}
+        data:
+          bar: BAR
+  dependencies:
+  - alias: dep
+    chart: myrepo/raw
+    version: 0.1.0

--- a/test/e2e/template/helmfile/testdata/snapshot/chart_need/output.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/chart_need/output.yaml
@@ -1,0 +1,26 @@
+Adding repo myrepo http://localhost:18080/
+"myrepo" has been added to your repositories
+
+Building dependency release=foo, chart=$WD/temp1/foo
+Templating release=foo, chart=$WD/temp1/foo
+---
+# Source: raw/templates/charts/dep/templates/resources.yaml
+# Source: raw/charts/dep/templates/resources.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo-2
+  namespace: default
+data:
+  bar: BAR
+---
+# Source: raw/templates/resources.yaml
+# Source: raw/templates/resources.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo-1
+  namespace: default
+data:
+  foo: FOO
+


### PR DESCRIPTION
This similar to #239, but different in that it involves a local helm chart repo server instead of a local OCI registry as the container of the chart used in tests.

This also adds a new `localChartRepoServer.enabled` config to the `config.yaml` of each test case directory to enable the local helm repo server in the test, which might be useful when you want to add another test case that involes a remote chart(which is hosted in the local chart repo server).