### PR TITLE
remove selector override in cmd/apply

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -30,7 +30,6 @@ func NewApplyCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringSliceVar(&applyImpl.ApplyOptions.Set, "selector", []string{}, "additional values to be merged into the command")
 	f.StringSliceVar(&applyImpl.ApplyOptions.Values, "values", []string{}, "additional value files to be merged into the command")
 	f.IntVar(&applyImpl.ApplyOptions.Concurrency, "concurrency", 0, "maximum number of concurrent helm processes to run, 0 is unlimited")
 	f.BoolVar(&applyImpl.ApplyOptions.Validate, "validate", false, "validate your manifests against the Kubernetes cluster you are currently pointing at. Note that this requires access to a Kubernetes cluster to obtain information necessary for validating, like the list of available API versions")


### PR DESCRIPTION
fix #265 

selector flag defined in cmd/apply.go overrides the one from cmd/root.go