### PR TITLE
fix: needs error with context that includes slash

### DIFF
--- a/pkg/app/testdata/app_diff_test_1/upgrade_when_foo_needs_bar_with_context_override
+++ b/pkg/app/testdata/app_diff_test_1/upgrade_when_foo_needs_bar_with_context_override
@@ -1,0 +1,50 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: helmDefaults:
+ 2:   kubeContext: hello/world
+ 3: releases:
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6: - name: foo
+ 7:   chart: mychart1
+ 8:   needs:
+ 9:   - bar
+10: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: helmDefaults:
+ 2:   kubeContext: hello/world
+ 3: releases:
+ 4: - name: bar
+ 5:   chart: mychart2
+ 6: - name: foo
+ 7:   chart: mychart1
+ 8:   needs:
+ 9:   - bar
+10: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     hello/world//bar
+2     hello/world//foo
+
+processing releases in group 1/2: hello/world//bar
+processing releases in group 2/2: hello/world//foo
+Affected releases are:
+  bar (mychart2) UPDATED
+  foo (mychart1) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_diff_test_1/upgrade_when_releaseb_needs_releasea_with_aws_context
+++ b/pkg/app/testdata/app_diff_test_1/upgrade_when_releaseb_needs_releasea_with_aws_context
@@ -1,0 +1,54 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+first-pass rendering starting for "helmfile.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: releaseA
+ 3:   chart: mychart1
+ 4:   namespace: namespaceA
+ 5:   kubeContext: arn:aws:eks:us-east-1:1234567890:cluster/myekscluster
+ 6: - name: releaseB
+ 7:   chart: mychart2
+ 8:   namespace: namespaceA
+ 9:   kubeContext: arn:aws:eks:us-east-1:1234567890:cluster/myekscluster
+10:   needs:
+11:     - arn:aws:eks:us-east-1:1234567890:cluster/myekscluster/namespaceA/releaseA
+12: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: releaseA
+ 3:   chart: mychart1
+ 4:   namespace: namespaceA
+ 5:   kubeContext: arn:aws:eks:us-east-1:1234567890:cluster/myekscluster
+ 6: - name: releaseB
+ 7:   chart: mychart2
+ 8:   namespace: namespaceA
+ 9:   kubeContext: arn:aws:eks:us-east-1:1234567890:cluster/myekscluster
+10:   needs:
+11:     - arn:aws:eks:us-east-1:1234567890:cluster/myekscluster/namespaceA/releaseA
+12: 
+
+merged environment: &{default map[] map[]}
+2 release(s) found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     arn:aws:eks:us-east-1:1234567890:cluster/myekscluster/namespaceA/releaseA
+2     arn:aws:eks:us-east-1:1234567890:cluster/myekscluster/namespaceA/releaseB
+
+processing releases in group 1/2: arn:aws:eks:us-east-1:1234567890:cluster/myekscluster/namespaceA/releaseA
+processing releases in group 2/2: arn:aws:eks:us-east-1:1234567890:cluster/myekscluster/namespaceA/releaseB
+Affected releases are:
+  releaseA (mychart1) UPDATED
+  releaseB (mychart2) UPDATED
+
+changing working directory back to "/path/to"

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -399,7 +399,9 @@ func (st *HelmState) ApplyOverrides(spec *ReleaseSpec) {
 		}
 
 		if len(components) > 2 {
-			kubecontext = components[len(components)-3]
+			// Join all ID components except last 2 (namespace and name) into kubecontext.
+			// Should be safe because resource names do not contain slashes.
+			kubecontext = strings.Join(components[:len(components)-2], "/")
 		} else {
 			kubecontext = spec.KubeContext
 		}


### PR DESCRIPTION
Fix an issue that causes `needs:` dependency errors when using kube context with slashes in it. This works by joining all components of ID except last two (`namespace` and `name`).

Assumes `namespace` and `name` cannot contain slashes.

Fixes https://github.com/helmfile/helmfile/issues/203