### PR TITLE
Fix Inclusion of Releases for Other Environments

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -985,7 +985,7 @@ func (a *App) visitStatesWithSelectorsAndRemoteSupport(fileOrDir string, converg
 		envvals = append(envvals, v)
 	}
 
-	if a.Set != nil {
+	if len(a.Set) > 0 {
 		envvals = append(envvals, a.Set)
 	}
 

--- a/pkg/app/app_list_test.go
+++ b/pkg/app/app_list_test.go
@@ -1,0 +1,249 @@
+package app
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/variantdev/vals"
+
+	"github.com/helmfile/helmfile/pkg/helmexec"
+	"github.com/helmfile/helmfile/pkg/testhelper"
+	"github.com/helmfile/helmfile/pkg/testutil"
+)
+
+func TestListWithEnvironment(t *testing.T) {
+	type testcase struct {
+		environment string
+		ns          string
+		error       string
+		selectors   []string
+		expected    string
+	}
+
+	check := func(t *testing.T, tc testcase) {
+		t.Helper()
+
+		bs := &bytes.Buffer{}
+
+		func() {
+			t.Helper()
+
+			logReader, logWriter := io.Pipe()
+
+			logFlushed := &sync.WaitGroup{}
+			// Ensure all the log is consumed into `bs` by calling `logWriter.Close()` followed by `logFlushed.Wait()`
+			logFlushed.Add(1)
+			go func() {
+				scanner := bufio.NewScanner(logReader)
+				for scanner.Scan() {
+					bs.Write(scanner.Bytes())
+					bs.WriteString("\n")
+				}
+				logFlushed.Done()
+			}()
+
+			defer func() {
+				// This is here to avoid data-trace on bytes buffer `bs` to capture logs
+				if err := logWriter.Close(); err != nil {
+					panic(err)
+				}
+				logFlushed.Wait()
+			}()
+
+			logger := helmexec.NewLogger(logWriter, "debug")
+
+			valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
+			if err != nil {
+				t.Errorf("unexpected error creating vals runtime: %v", err)
+			}
+
+			files := map[string]string{
+				"/path/to/helmfile.d/helmfile_1.yaml": `
+environments:
+  development: {}
+  shared: {}
+
+releases:
+- name: logging
+  chart: incubator/raw
+  namespace: kube-system
+
+- name: kubernetes-external-secrets
+  chart: incubator/raw
+  namespace: kube-system
+  needs:
+  - kube-system/logging
+
+- name: external-secrets
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - kube-system/kubernetes-external-secrets
+
+- name: my-release
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - default/external-secrets
+
+
+# Disabled releases are treated as missing
+- name: disabled
+  chart: incubator/raw
+  namespace: kube-system
+  installed: false
+
+- name: test2
+  chart: incubator/raw
+  needs:
+  - kube-system/disabled
+
+- name: test3
+  chart: incubator/raw
+  needs:
+  - test2
+`,
+				"/path/to/helmfile.d/helmfile_2.yaml": `
+environments:
+  test: {}
+  shared: {}
+
+repositories:
+- name: bitnami
+  url: https://charts.bitnami.com/bitnami
+
+releases:
+- name: cache
+  namespace: my-app
+  chart: bitnami/redis
+  version: 17.0.7
+  labels:
+    app: test
+
+- name: database
+  namespace: my-app
+  chart: bitnami/postgres
+  version: 11.6.22
+`,
+				"/path/to/helmfile.d/helmfile_3.yaml": `
+releases:
+- name: global
+  chart: incubator/raw
+  namespace: kube-system
+`,
+			}
+
+			app := appWithFs(&App{
+				OverrideHelmBinary:  DefaultHelmBinary,
+				glob:                filepath.Glob,
+				abs:                 filepath.Abs,
+				OverrideKubeContext: "default",
+				Env:                 tc.environment,
+				Logger:              logger,
+				valsRuntime:         valsRuntime,
+			}, files)
+
+			expectNoCallsToHelm(app)
+
+			if tc.ns != "" {
+				app.Namespace = tc.ns
+			}
+
+			if tc.selectors != nil {
+				app.Selectors = tc.selectors
+			}
+
+			var listErr error
+			out := testutil.CaptureStdout(func() {
+				listErr = app.ListReleases(configImpl{})
+			})
+
+			var gotErr string
+			if listErr != nil {
+				gotErr = listErr.Error()
+			}
+
+			if d := cmp.Diff(tc.error, gotErr); d != "" {
+				t.Fatalf("unexpected error: want (-), got (+): %s", d)
+			}
+
+			assert.Equal(t, tc.expected, out)
+		}()
+
+		testhelper.RequireLog(t, "app_list_test", bs)
+	}
+
+	t.Run("default environment includes all releases", func(t *testing.T) {
+		check(t, testcase{
+			environment: "default",
+			expected: `NAME                       	NAMESPACE  	ENABLED	INSTALLED	LABELS  	CHART           	VERSION
+logging                    	kube-system	true   	true     	        	incubator/raw   	       
+kubernetes-external-secrets	kube-system	true   	true     	        	incubator/raw   	       
+external-secrets           	default    	true   	true     	app:test	incubator/raw   	       
+my-release                 	default    	true   	true     	app:test	incubator/raw   	       
+disabled                   	kube-system	true   	false    	        	incubator/raw   	       
+test2                      	           	true   	true     	        	incubator/raw   	       
+test3                      	           	true   	true     	        	incubator/raw   	       
+cache                      	my-app     	true   	true     	app:test	bitnami/redis   	17.0.7 
+database                   	my-app     	true   	true     	        	bitnami/postgres	11.6.22
+global                     	kube-system	true   	true     	        	incubator/raw   	       
+`,
+		})
+	})
+
+	t.Run("fail on unknown environment", func(t *testing.T) {
+		check(t, testcase{
+			environment: "staging",
+			error:       `err: no releases found that matches specified selector() and environment(staging), in any helmfile`,
+		})
+	})
+
+	t.Run("list releases matching selector and environment", func(t *testing.T) {
+		check(t, testcase{
+			environment: "development",
+			selectors:   []string{"app=test"},
+			expected: `NAME            	NAMESPACE	ENABLED	INSTALLED	LABELS                                                    	CHART        	VERSION
+external-secrets	default  	true   	true     	app:test,chart:raw,name:external-secrets,namespace:default	incubator/raw	       
+my-release      	default  	true   	true     	app:test,chart:raw,name:my-release,namespace:default      	incubator/raw	       
+`,
+		})
+	})
+
+	t.Run("filters releases for environment used in one file only", func(t *testing.T) {
+		check(t, testcase{
+			environment: "test",
+			expected: `NAME    	NAMESPACE	ENABLED	INSTALLED	LABELS  	CHART           	VERSION
+cache   	my-app   	true   	true     	app:test	bitnami/redis   	17.0.7 
+database	my-app   	true   	true     	        	bitnami/postgres	11.6.22
+`,
+		})
+	})
+
+	t.Run("filters releases for environment used in multiple files", func(t *testing.T) {
+		check(t, testcase{
+			environment: "shared",
+			// 'global' release has no environments, so is still excluded
+			expected: `NAME                       	NAMESPACE  	ENABLED	INSTALLED	LABELS  	CHART           	VERSION
+logging                    	kube-system	true   	true     	        	incubator/raw   	       
+kubernetes-external-secrets	kube-system	true   	true     	        	incubator/raw   	       
+external-secrets           	default    	true   	true     	app:test	incubator/raw   	       
+my-release                 	default    	true   	true     	app:test	incubator/raw   	       
+disabled                   	kube-system	true   	false    	        	incubator/raw   	       
+test2                      	           	true   	true     	        	incubator/raw   	       
+test3                      	           	true   	true     	        	incubator/raw   	       
+cache                      	my-app     	true   	true     	app:test	bitnami/redis   	17.0.7 
+database                   	my-app     	true   	true     	        	bitnami/postgres	11.6.22
+`,
+		})
+	})
+}

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -39,6 +39,12 @@ func appWithFs(app *App, files map[string]string) *App {
 }
 
 func injectFs(app *App, fs *testhelper.TestFs) *App {
+	if app.Set == nil {
+		// Consistent behavior with NewGlobalImpl.
+		// Doesn't really belong here, but simplest place for it until some refactoring happens
+		app.Set = make(map[string]interface{})
+	}
+
 	app.readFile = fs.ReadFile
 	app.glob = fs.Glob
 	app.abs = fs.Abs

--- a/pkg/app/testdata/app_list_test/default_environment_includes_all_releases
+++ b/pkg/app/testdata/app_list_test/default_environment_includes_all_releases
@@ -1,0 +1,199 @@
+processing file "helmfile_1.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_1.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile_1.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   development: {}
+ 3:   shared: {}
+ 4: 
+ 5: releases:
+ 6: - name: logging
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9: 
+10: - name: kubernetes-external-secrets
+11:   chart: incubator/raw
+12:   namespace: kube-system
+13:   needs:
+14:   - kube-system/logging
+15: 
+16: - name: external-secrets
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - kube-system/kubernetes-external-secrets
+23: 
+24: - name: my-release
+25:   chart: incubator/raw
+26:   namespace: default
+27:   labels:
+28:     app: test
+29:   needs:
+30:   - default/external-secrets
+31: 
+32: 
+33: # Disabled releases are treated as missing
+34: - name: disabled
+35:   chart: incubator/raw
+36:   namespace: kube-system
+37:   installed: false
+38: 
+39: - name: test2
+40:   chart: incubator/raw
+41:   needs:
+42:   - kube-system/disabled
+43: 
+44: - name: test3
+45:   chart: incubator/raw
+46:   needs:
+47:   - test2
+48: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile_1.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_1.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   development: {}
+ 3:   shared: {}
+ 4: 
+ 5: releases:
+ 6: - name: logging
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9: 
+10: - name: kubernetes-external-secrets
+11:   chart: incubator/raw
+12:   namespace: kube-system
+13:   needs:
+14:   - kube-system/logging
+15: 
+16: - name: external-secrets
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - kube-system/kubernetes-external-secrets
+23: 
+24: - name: my-release
+25:   chart: incubator/raw
+26:   namespace: default
+27:   labels:
+28:     app: test
+29:   needs:
+30:   - default/external-secrets
+31: 
+32: 
+33: # Disabled releases are treated as missing
+34: - name: disabled
+35:   chart: incubator/raw
+36:   namespace: kube-system
+37:   installed: false
+38: 
+39: - name: test2
+40:   chart: incubator/raw
+41:   needs:
+42:   - kube-system/disabled
+43: 
+44: - name: test3
+45:   chart: incubator/raw
+46:   needs:
+47:   - test2
+48: 
+
+merged environment: &{default map[] map[]}
+changing working directory back to "/path/to"
+processing file "helmfile_2.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_2.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile_2.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   test: {}
+ 3:   shared: {}
+ 4: 
+ 5: repositories:
+ 6: - name: bitnami
+ 7:   url: https://charts.bitnami.com/bitnami
+ 8: 
+ 9: releases:
+10: - name: cache
+11:   namespace: my-app
+12:   chart: bitnami/redis
+13:   version: 17.0.7
+14:   labels:
+15:     app: test
+16: 
+17: - name: database
+18:   namespace: my-app
+19:   chart: bitnami/postgres
+20:   version: 11.6.22
+21: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile_2.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_2.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   test: {}
+ 3:   shared: {}
+ 4: 
+ 5: repositories:
+ 6: - name: bitnami
+ 7:   url: https://charts.bitnami.com/bitnami
+ 8: 
+ 9: releases:
+10: - name: cache
+11:   namespace: my-app
+12:   chart: bitnami/redis
+13:   version: 17.0.7
+14:   labels:
+15:     app: test
+16: 
+17: - name: database
+18:   namespace: my-app
+19:   chart: bitnami/postgres
+20:   version: 11.6.22
+21: 
+
+merged environment: &{default map[] map[]}
+changing working directory back to "/path/to"
+processing file "helmfile_3.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_3.yaml.part.0": inherited=&{default map[] map[]}, overrode=<nil>
+first-pass uses: &{default map[] map[]}
+first-pass rendering output of "helmfile_3.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: global
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+
+first-pass produced: &{default map[] map[]}
+first-pass rendering result of "helmfile_3.yaml.part.0": {default map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_3.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: global
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+
+merged environment: &{default map[] map[]}
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_list_test/fail_on_unknown_environment
+++ b/pkg/app/testdata/app_list_test/fail_on_unknown_environment
@@ -1,0 +1,196 @@
+processing file "helmfile_1.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_1.yaml.part.0": inherited=&{staging map[] map[]}, overrode=<nil>
+first-pass uses: &{staging map[] map[]}
+first-pass rendering output of "helmfile_1.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   development: {}
+ 3:   shared: {}
+ 4: 
+ 5: releases:
+ 6: - name: logging
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9: 
+10: - name: kubernetes-external-secrets
+11:   chart: incubator/raw
+12:   namespace: kube-system
+13:   needs:
+14:   - kube-system/logging
+15: 
+16: - name: external-secrets
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - kube-system/kubernetes-external-secrets
+23: 
+24: - name: my-release
+25:   chart: incubator/raw
+26:   namespace: default
+27:   labels:
+28:     app: test
+29:   needs:
+30:   - default/external-secrets
+31: 
+32: 
+33: # Disabled releases are treated as missing
+34: - name: disabled
+35:   chart: incubator/raw
+36:   namespace: kube-system
+37:   installed: false
+38: 
+39: - name: test2
+40:   chart: incubator/raw
+41:   needs:
+42:   - kube-system/disabled
+43: 
+44: - name: test3
+45:   chart: incubator/raw
+46:   needs:
+47:   - test2
+48: 
+
+first-pass produced: &{staging map[] map[]}
+first-pass rendering result of "helmfile_1.yaml.part.0": {staging map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_1.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   development: {}
+ 3:   shared: {}
+ 4: 
+ 5: releases:
+ 6: - name: logging
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9: 
+10: - name: kubernetes-external-secrets
+11:   chart: incubator/raw
+12:   namespace: kube-system
+13:   needs:
+14:   - kube-system/logging
+15: 
+16: - name: external-secrets
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - kube-system/kubernetes-external-secrets
+23: 
+24: - name: my-release
+25:   chart: incubator/raw
+26:   namespace: default
+27:   labels:
+28:     app: test
+29:   needs:
+30:   - default/external-secrets
+31: 
+32: 
+33: # Disabled releases are treated as missing
+34: - name: disabled
+35:   chart: incubator/raw
+36:   namespace: kube-system
+37:   installed: false
+38: 
+39: - name: test2
+40:   chart: incubator/raw
+41:   needs:
+42:   - kube-system/disabled
+43: 
+44: - name: test3
+45:   chart: incubator/raw
+46:   needs:
+47:   - test2
+48: 
+
+changing working directory back to "/path/to"
+processing file "helmfile_2.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_2.yaml.part.0": inherited=&{staging map[] map[]}, overrode=<nil>
+first-pass uses: &{staging map[] map[]}
+first-pass rendering output of "helmfile_2.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   test: {}
+ 3:   shared: {}
+ 4: 
+ 5: repositories:
+ 6: - name: bitnami
+ 7:   url: https://charts.bitnami.com/bitnami
+ 8: 
+ 9: releases:
+10: - name: cache
+11:   namespace: my-app
+12:   chart: bitnami/redis
+13:   version: 17.0.7
+14:   labels:
+15:     app: test
+16: 
+17: - name: database
+18:   namespace: my-app
+19:   chart: bitnami/postgres
+20:   version: 11.6.22
+21: 
+
+first-pass produced: &{staging map[] map[]}
+first-pass rendering result of "helmfile_2.yaml.part.0": {staging map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_2.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   test: {}
+ 3:   shared: {}
+ 4: 
+ 5: repositories:
+ 6: - name: bitnami
+ 7:   url: https://charts.bitnami.com/bitnami
+ 8: 
+ 9: releases:
+10: - name: cache
+11:   namespace: my-app
+12:   chart: bitnami/redis
+13:   version: 17.0.7
+14:   labels:
+15:     app: test
+16: 
+17: - name: database
+18:   namespace: my-app
+19:   chart: bitnami/postgres
+20:   version: 11.6.22
+21: 
+
+changing working directory back to "/path/to"
+processing file "helmfile_3.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_3.yaml.part.0": inherited=&{staging map[] map[]}, overrode=<nil>
+first-pass uses: &{staging map[] map[]}
+first-pass rendering output of "helmfile_3.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: global
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+
+first-pass produced: &{staging map[] map[]}
+first-pass rendering result of "helmfile_3.yaml.part.0": {staging map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_3.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: global
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_list_test/filters_releases_for_environment_used_in_multiple_files
+++ b/pkg/app/testdata/app_list_test/filters_releases_for_environment_used_in_multiple_files
@@ -1,0 +1,198 @@
+processing file "helmfile_1.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_1.yaml.part.0": inherited=&{shared map[] map[]}, overrode=<nil>
+first-pass uses: &{shared map[] map[]}
+first-pass rendering output of "helmfile_1.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   development: {}
+ 3:   shared: {}
+ 4: 
+ 5: releases:
+ 6: - name: logging
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9: 
+10: - name: kubernetes-external-secrets
+11:   chart: incubator/raw
+12:   namespace: kube-system
+13:   needs:
+14:   - kube-system/logging
+15: 
+16: - name: external-secrets
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - kube-system/kubernetes-external-secrets
+23: 
+24: - name: my-release
+25:   chart: incubator/raw
+26:   namespace: default
+27:   labels:
+28:     app: test
+29:   needs:
+30:   - default/external-secrets
+31: 
+32: 
+33: # Disabled releases are treated as missing
+34: - name: disabled
+35:   chart: incubator/raw
+36:   namespace: kube-system
+37:   installed: false
+38: 
+39: - name: test2
+40:   chart: incubator/raw
+41:   needs:
+42:   - kube-system/disabled
+43: 
+44: - name: test3
+45:   chart: incubator/raw
+46:   needs:
+47:   - test2
+48: 
+
+first-pass produced: &{shared map[] map[]}
+first-pass rendering result of "helmfile_1.yaml.part.0": {shared map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_1.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   development: {}
+ 3:   shared: {}
+ 4: 
+ 5: releases:
+ 6: - name: logging
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9: 
+10: - name: kubernetes-external-secrets
+11:   chart: incubator/raw
+12:   namespace: kube-system
+13:   needs:
+14:   - kube-system/logging
+15: 
+16: - name: external-secrets
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - kube-system/kubernetes-external-secrets
+23: 
+24: - name: my-release
+25:   chart: incubator/raw
+26:   namespace: default
+27:   labels:
+28:     app: test
+29:   needs:
+30:   - default/external-secrets
+31: 
+32: 
+33: # Disabled releases are treated as missing
+34: - name: disabled
+35:   chart: incubator/raw
+36:   namespace: kube-system
+37:   installed: false
+38: 
+39: - name: test2
+40:   chart: incubator/raw
+41:   needs:
+42:   - kube-system/disabled
+43: 
+44: - name: test3
+45:   chart: incubator/raw
+46:   needs:
+47:   - test2
+48: 
+
+merged environment: &{shared map[] map[]}
+changing working directory back to "/path/to"
+processing file "helmfile_2.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_2.yaml.part.0": inherited=&{shared map[] map[]}, overrode=<nil>
+first-pass uses: &{shared map[] map[]}
+first-pass rendering output of "helmfile_2.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   test: {}
+ 3:   shared: {}
+ 4: 
+ 5: repositories:
+ 6: - name: bitnami
+ 7:   url: https://charts.bitnami.com/bitnami
+ 8: 
+ 9: releases:
+10: - name: cache
+11:   namespace: my-app
+12:   chart: bitnami/redis
+13:   version: 17.0.7
+14:   labels:
+15:     app: test
+16: 
+17: - name: database
+18:   namespace: my-app
+19:   chart: bitnami/postgres
+20:   version: 11.6.22
+21: 
+
+first-pass produced: &{shared map[] map[]}
+first-pass rendering result of "helmfile_2.yaml.part.0": {shared map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_2.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   test: {}
+ 3:   shared: {}
+ 4: 
+ 5: repositories:
+ 6: - name: bitnami
+ 7:   url: https://charts.bitnami.com/bitnami
+ 8: 
+ 9: releases:
+10: - name: cache
+11:   namespace: my-app
+12:   chart: bitnami/redis
+13:   version: 17.0.7
+14:   labels:
+15:     app: test
+16: 
+17: - name: database
+18:   namespace: my-app
+19:   chart: bitnami/postgres
+20:   version: 11.6.22
+21: 
+
+merged environment: &{shared map[] map[]}
+changing working directory back to "/path/to"
+processing file "helmfile_3.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_3.yaml.part.0": inherited=&{shared map[] map[]}, overrode=<nil>
+first-pass uses: &{shared map[] map[]}
+first-pass rendering output of "helmfile_3.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: global
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+
+first-pass produced: &{shared map[] map[]}
+first-pass rendering result of "helmfile_3.yaml.part.0": {shared map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_3.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: global
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_list_test/filters_releases_for_environment_used_in_one_file_only
+++ b/pkg/app/testdata/app_list_test/filters_releases_for_environment_used_in_one_file_only
@@ -1,0 +1,197 @@
+processing file "helmfile_1.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_1.yaml.part.0": inherited=&{test map[] map[]}, overrode=<nil>
+first-pass uses: &{test map[] map[]}
+first-pass rendering output of "helmfile_1.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   development: {}
+ 3:   shared: {}
+ 4: 
+ 5: releases:
+ 6: - name: logging
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9: 
+10: - name: kubernetes-external-secrets
+11:   chart: incubator/raw
+12:   namespace: kube-system
+13:   needs:
+14:   - kube-system/logging
+15: 
+16: - name: external-secrets
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - kube-system/kubernetes-external-secrets
+23: 
+24: - name: my-release
+25:   chart: incubator/raw
+26:   namespace: default
+27:   labels:
+28:     app: test
+29:   needs:
+30:   - default/external-secrets
+31: 
+32: 
+33: # Disabled releases are treated as missing
+34: - name: disabled
+35:   chart: incubator/raw
+36:   namespace: kube-system
+37:   installed: false
+38: 
+39: - name: test2
+40:   chart: incubator/raw
+41:   needs:
+42:   - kube-system/disabled
+43: 
+44: - name: test3
+45:   chart: incubator/raw
+46:   needs:
+47:   - test2
+48: 
+
+first-pass produced: &{test map[] map[]}
+first-pass rendering result of "helmfile_1.yaml.part.0": {test map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_1.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   development: {}
+ 3:   shared: {}
+ 4: 
+ 5: releases:
+ 6: - name: logging
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9: 
+10: - name: kubernetes-external-secrets
+11:   chart: incubator/raw
+12:   namespace: kube-system
+13:   needs:
+14:   - kube-system/logging
+15: 
+16: - name: external-secrets
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - kube-system/kubernetes-external-secrets
+23: 
+24: - name: my-release
+25:   chart: incubator/raw
+26:   namespace: default
+27:   labels:
+28:     app: test
+29:   needs:
+30:   - default/external-secrets
+31: 
+32: 
+33: # Disabled releases are treated as missing
+34: - name: disabled
+35:   chart: incubator/raw
+36:   namespace: kube-system
+37:   installed: false
+38: 
+39: - name: test2
+40:   chart: incubator/raw
+41:   needs:
+42:   - kube-system/disabled
+43: 
+44: - name: test3
+45:   chart: incubator/raw
+46:   needs:
+47:   - test2
+48: 
+
+changing working directory back to "/path/to"
+processing file "helmfile_2.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_2.yaml.part.0": inherited=&{test map[] map[]}, overrode=<nil>
+first-pass uses: &{test map[] map[]}
+first-pass rendering output of "helmfile_2.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   test: {}
+ 3:   shared: {}
+ 4: 
+ 5: repositories:
+ 6: - name: bitnami
+ 7:   url: https://charts.bitnami.com/bitnami
+ 8: 
+ 9: releases:
+10: - name: cache
+11:   namespace: my-app
+12:   chart: bitnami/redis
+13:   version: 17.0.7
+14:   labels:
+15:     app: test
+16: 
+17: - name: database
+18:   namespace: my-app
+19:   chart: bitnami/postgres
+20:   version: 11.6.22
+21: 
+
+first-pass produced: &{test map[] map[]}
+first-pass rendering result of "helmfile_2.yaml.part.0": {test map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_2.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   test: {}
+ 3:   shared: {}
+ 4: 
+ 5: repositories:
+ 6: - name: bitnami
+ 7:   url: https://charts.bitnami.com/bitnami
+ 8: 
+ 9: releases:
+10: - name: cache
+11:   namespace: my-app
+12:   chart: bitnami/redis
+13:   version: 17.0.7
+14:   labels:
+15:     app: test
+16: 
+17: - name: database
+18:   namespace: my-app
+19:   chart: bitnami/postgres
+20:   version: 11.6.22
+21: 
+
+merged environment: &{test map[] map[]}
+changing working directory back to "/path/to"
+processing file "helmfile_3.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_3.yaml.part.0": inherited=&{test map[] map[]}, overrode=<nil>
+first-pass uses: &{test map[] map[]}
+first-pass rendering output of "helmfile_3.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: global
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+
+first-pass produced: &{test map[] map[]}
+first-pass rendering result of "helmfile_3.yaml.part.0": {test map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_3.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: global
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_list_test/list_releases_matching_selector_and_environment
+++ b/pkg/app/testdata/app_list_test/list_releases_matching_selector_and_environment
@@ -1,0 +1,197 @@
+processing file "helmfile_1.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_1.yaml.part.0": inherited=&{development map[] map[]}, overrode=<nil>
+first-pass uses: &{development map[] map[]}
+first-pass rendering output of "helmfile_1.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   development: {}
+ 3:   shared: {}
+ 4: 
+ 5: releases:
+ 6: - name: logging
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9: 
+10: - name: kubernetes-external-secrets
+11:   chart: incubator/raw
+12:   namespace: kube-system
+13:   needs:
+14:   - kube-system/logging
+15: 
+16: - name: external-secrets
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - kube-system/kubernetes-external-secrets
+23: 
+24: - name: my-release
+25:   chart: incubator/raw
+26:   namespace: default
+27:   labels:
+28:     app: test
+29:   needs:
+30:   - default/external-secrets
+31: 
+32: 
+33: # Disabled releases are treated as missing
+34: - name: disabled
+35:   chart: incubator/raw
+36:   namespace: kube-system
+37:   installed: false
+38: 
+39: - name: test2
+40:   chart: incubator/raw
+41:   needs:
+42:   - kube-system/disabled
+43: 
+44: - name: test3
+45:   chart: incubator/raw
+46:   needs:
+47:   - test2
+48: 
+
+first-pass produced: &{development map[] map[]}
+first-pass rendering result of "helmfile_1.yaml.part.0": {development map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_1.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   development: {}
+ 3:   shared: {}
+ 4: 
+ 5: releases:
+ 6: - name: logging
+ 7:   chart: incubator/raw
+ 8:   namespace: kube-system
+ 9: 
+10: - name: kubernetes-external-secrets
+11:   chart: incubator/raw
+12:   namespace: kube-system
+13:   needs:
+14:   - kube-system/logging
+15: 
+16: - name: external-secrets
+17:   chart: incubator/raw
+18:   namespace: default
+19:   labels:
+20:     app: test
+21:   needs:
+22:   - kube-system/kubernetes-external-secrets
+23: 
+24: - name: my-release
+25:   chart: incubator/raw
+26:   namespace: default
+27:   labels:
+28:     app: test
+29:   needs:
+30:   - default/external-secrets
+31: 
+32: 
+33: # Disabled releases are treated as missing
+34: - name: disabled
+35:   chart: incubator/raw
+36:   namespace: kube-system
+37:   installed: false
+38: 
+39: - name: test2
+40:   chart: incubator/raw
+41:   needs:
+42:   - kube-system/disabled
+43: 
+44: - name: test3
+45:   chart: incubator/raw
+46:   needs:
+47:   - test2
+48: 
+
+merged environment: &{development map[] map[]}
+changing working directory back to "/path/to"
+processing file "helmfile_2.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_2.yaml.part.0": inherited=&{development map[] map[]}, overrode=<nil>
+first-pass uses: &{development map[] map[]}
+first-pass rendering output of "helmfile_2.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   test: {}
+ 3:   shared: {}
+ 4: 
+ 5: repositories:
+ 6: - name: bitnami
+ 7:   url: https://charts.bitnami.com/bitnami
+ 8: 
+ 9: releases:
+10: - name: cache
+11:   namespace: my-app
+12:   chart: bitnami/redis
+13:   version: 17.0.7
+14:   labels:
+15:     app: test
+16: 
+17: - name: database
+18:   namespace: my-app
+19:   chart: bitnami/postgres
+20:   version: 11.6.22
+21: 
+
+first-pass produced: &{development map[] map[]}
+first-pass rendering result of "helmfile_2.yaml.part.0": {development map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_2.yaml.part.0":
+ 0: 
+ 1: environments:
+ 2:   test: {}
+ 3:   shared: {}
+ 4: 
+ 5: repositories:
+ 6: - name: bitnami
+ 7:   url: https://charts.bitnami.com/bitnami
+ 8: 
+ 9: releases:
+10: - name: cache
+11:   namespace: my-app
+12:   chart: bitnami/redis
+13:   version: 17.0.7
+14:   labels:
+15:     app: test
+16: 
+17: - name: database
+18:   namespace: my-app
+19:   chart: bitnami/postgres
+20:   version: 11.6.22
+21: 
+
+changing working directory back to "/path/to"
+processing file "helmfile_3.yaml" in directory "/path/to/helmfile.d"
+changing working directory to "/path/to/helmfile.d"
+first-pass rendering starting for "helmfile_3.yaml.part.0": inherited=&{development map[] map[]}, overrode=<nil>
+first-pass uses: &{development map[] map[]}
+first-pass rendering output of "helmfile_3.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: global
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+
+first-pass produced: &{development map[] map[]}
+first-pass rendering result of "helmfile_3.yaml.part.0": {development map[] map[]}
+vals:
+map[]
+defaultVals:[]
+second-pass rendering result of "helmfile_3.yaml.part.0":
+ 0: 
+ 1: releases:
+ 2: - name: global
+ 3:   chart: incubator/raw
+ 4:   namespace: kube-system
+ 5: 
+
+changing working directory back to "/path/to"


### PR DESCRIPTION
Fixing releases being included which do not match the environment requested, which is a regression introduced by #234. The issue remains when Helmfile state values are supplied, which is not a regression and will be addressed separately.

Partial resolution for #271