### PR TITLE
Fix for readDir selection, currently any template that uses readDir* functions seems to break

### DIFF
--- a/pkg/tmpl/file_renderer.go
+++ b/pkg/tmpl/file_renderer.go
@@ -19,7 +19,7 @@ func NewFileRenderer(readFile func(filename string) ([]byte, error), basePath st
 		Context: &Context{
 			basePath: basePath,
 			readFile: readFile,
-            readDir:  os.ReadDir,
+			readDir:  os.ReadDir,
 		},
 		Data: data,
 	}
@@ -32,7 +32,7 @@ func NewFirstPassRenderer(basePath string, data interface{}) *FileRenderer {
 			preRender: true,
 			basePath:  basePath,
 			readFile:  os.ReadFile,
-            readDir:   os.ReadDir,
+			readDir:   os.ReadDir,
 		},
 		Data: data,
 	}

--- a/pkg/tmpl/file_renderer.go
+++ b/pkg/tmpl/file_renderer.go
@@ -19,6 +19,7 @@ func NewFileRenderer(readFile func(filename string) ([]byte, error), basePath st
 		Context: &Context{
 			basePath: basePath,
 			readFile: readFile,
+            readDir:  os.ReadDir,
 		},
 		Data: data,
 	}
@@ -31,6 +32,7 @@ func NewFirstPassRenderer(basePath string, data interface{}) *FileRenderer {
 			preRender: true,
 			basePath:  basePath,
 			readFile:  os.ReadFile,
+            readDir:   os.ReadDir,
 		},
 		Data: data,
 	}

--- a/test/e2e/template/helmfile/tmpl_test.go
+++ b/test/e2e/template/helmfile/tmpl_test.go
@@ -266,11 +266,9 @@ func (t *tmplE2e) load() {
 var tmplE2eTest = tmplE2e{}
 
 func TestFileRendering(t *testing.T) {
-
 	tmplE2eTest.load()
 
 	for _, tc := range tmplE2eTest.tcs {
-
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setEnvs(t)
 			tempDir, _ := os.MkdirTemp("./testdata", "test")

--- a/test/e2e/template/helmfile/tmpl_test.go
+++ b/test/e2e/template/helmfile/tmpl_test.go
@@ -1,8 +1,8 @@
 package helmfile
 
 import (
-    "fmt"
 	"bytes"
+	"fmt"
 	"os"
 	"testing"
 	"text/template"
@@ -265,32 +265,31 @@ func (t *tmplE2e) load() {
 
 var tmplE2eTest = tmplE2e{}
 
-
 func TestFileRendering(t *testing.T) {
 
 	tmplE2eTest.load()
 
 	for _, tc := range tmplE2eTest.tcs {
 
-        t.Run(tc.name, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			tc.setEnvs(t)
-            tempDir, _ := os.MkdirTemp("./testdata", "test")
-            defer os.RemoveAll(tempDir)
+			tempDir, _ := os.MkdirTemp("./testdata", "test")
+			defer os.RemoveAll(tempDir)
 
-            filename := fmt.Sprintf("%s/%s.gotmpl", tempDir, tc.name)
-            os.WriteFile(filename, []byte(tc.tmplString), 0644)
-            fileRenderer := tmpl.NewFileRenderer(os.ReadFile, ".", tc.data)
-            tmpl_bytes, err := fileRenderer.RenderToBytes(filename);
+			filename := fmt.Sprintf("%s/%s.gotmpl", tempDir, tc.name)
+			os.WriteFile(filename, []byte(tc.tmplString), 0644)
+			fileRenderer := tmpl.NewFileRenderer(os.ReadFile, ".", tc.data)
+			tmpl_bytes, err := fileRenderer.RenderToBytes(filename)
 
 			if tc.wantErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 			}
-            tmpl := string(tmpl_bytes);
+			tmpl := string(tmpl_bytes)
 			require.Equal(t, tc.output, tmpl)
 		})
-    }
+	}
 }
 
 // TestTmplStrings tests the template string


### PR DESCRIPTION
I just created a naked helmfile.yaml with readDirEntries and it crashed.
```
environments:
  {{ range $index,$item := readDirEntries "./environments" }}
  {{$item}}:
  {{ end }}
```
```
Error: in ./helmfile.yaml: error during helmfile.yaml.part.0 parsing: template: stringTemplate:2:27: executing "stringTemplate" at <readDirEntries "./environments">: error calling readDirEntries: runtime error: invalid memory address or nil pointer dereference
```

I added the template tests at `test/e2e/template/helmfile/tmpl_test.go` to a full FileRenderer test and it crashed in a similar way.

Basically when a new FileRenderer is created nothing is set in the Contexts readDir pointer so it is a dangling pointer there.
I just set the default to `os.ReadDir`

