### PR TITLE
fix: return diff context config value

### DIFF
--- a/pkg/config/diff.go
+++ b/pkg/config/diff.go
@@ -108,7 +108,7 @@ func (t *DiffImpl) Values() []string {
 
 // Context returns the context
 func (t *DiffImpl) Context() int {
-	return 0
+	return t.DiffOptions.Context
 }
 
 // DetailedExitCode returns the detailed exit code


### PR DESCRIPTION
As part of the Cobra upgrade, the diff `context` option had been hard coded to a value of `0`. This fixes the issue by using the value in the struct.

Signed-off-by: Michael Lorant <michael.lorant@fairfaxmedia.com.au>