### PR TITLE
fix: return diff output config value

### DIFF
--- a/pkg/config/diff.go
+++ b/pkg/config/diff.go
@@ -118,7 +118,7 @@ func (t *DiffImpl) DetailedExitcode() bool {
 
 // Output returns the output
 func (t *DiffImpl) DiffOutput() string {
-	return ""
+	return t.DiffOptions.Output
 }
 
 // IncludeTests returns the include tests


### PR DESCRIPTION
As part of the Cobra upgrade, the diff output option had been hard coded return an empty string. This fixes the issue by using the value in the struct.

Signed-off-by: Michael Lorant <michael.lorant@fairfaxmedia.com.au>