### PR TITLE
Fix NewFileRenderer args along with testfs for mocking ReadDir in tests

### DIFF
--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 
 	"github.com/imdario/mergo"
@@ -29,6 +30,7 @@ type desiredStateLoader struct {
 	chart     string
 
 	readFile          func(string) ([]byte, error)
+	readDir           func(string) ([]fs.DirEntry, error)
 	deleteFile        func(string) error
 	fileExists        func(string) (bool, error)
 	abs               func(string) (string, error)
@@ -51,7 +53,7 @@ func (ld *desiredStateLoader) Load(f string, opts LoadOpts) (*state.HelmState, e
 			return nil, fmt.Errorf("bug: opts.CalleePath was nil: f=%s, opts=%v", f, opts)
 		}
 		storage := state.NewStorage(opts.CalleePath, ld.logger, ld.glob)
-		envld := state.NewEnvironmentValuesLoader(storage, ld.readFile, ld.logger, ld.remote)
+		envld := state.NewEnvironmentValuesLoader(storage, ld.readFile, ld.readDir, ld.logger, ld.remote)
 		handler := state.MissingFileHandlerError
 		vals, err := envld.LoadEnvironmentValues(&handler, args, &environment.EmptyEnvironment)
 		if err != nil {

--- a/pkg/app/two_pass_renderer.go
+++ b/pkg/app/two_pass_renderer.go
@@ -124,7 +124,7 @@ func (r *desiredStateLoader) twoPassRenderTemplateToYaml(inherited, overrode *en
 	}
 
 	tmplData := state.NewEnvironmentTemplateData(*finalEnv, r.namespace, vals)
-	secondPassRenderer := tmpl.NewFileRenderer(r.readFile, baseDir, tmplData)
+	secondPassRenderer := tmpl.NewFileRenderer(r.readFile, r.readDir, baseDir, tmplData)
 	yamlBuf, err := secondPassRenderer.RenderTemplateContentToBuffer(content)
 	if err != nil {
 		if r.logger != nil {

--- a/pkg/app/two_pass_renderer_test.go
+++ b/pkg/app/two_pass_renderer_test.go
@@ -23,6 +23,7 @@ func makeLoader(files map[string]string, env string) (*desiredStateLoader, *test
 		namespace:  "namespace",
 		logger:     helmexec.NewLogger(os.Stdout, "debug"),
 		readFile:   testfs.ReadFile,
+		readDir:    testfs.ReadDir,
 		fileExists: testfs.FileExists,
 		abs:        testfs.Abs,
 		glob:       testfs.Glob,

--- a/pkg/state/create.go
+++ b/pkg/state/create.go
@@ -367,7 +367,7 @@ func (st *HelmState) loadValuesEntries(missingFileHandler *string, entries []int
 	var envVals map[string]interface{}
 
 	valuesEntries := append([]interface{}{}, entries...)
-	ld := NewEnvironmentValuesLoader(st.storage(), st.readFile, st.logger, remote)
+	ld := NewEnvironmentValuesLoader(st.storage(), st.readFile, st.readDir, st.logger, remote)
 	var err error
 	envVals, err = ld.LoadEnvironmentValues(missingFileHandler, valuesEntries, ctxEnv)
 	if err != nil {

--- a/pkg/state/envvals_loader_test.go
+++ b/pkg/state/envvals_loader_test.go
@@ -29,7 +29,7 @@ func newLoader() *EnvironmentValuesLoader {
 	readFile := func(s string) ([]byte, error) { return []byte{}, nil }
 	dirExists := func(d string) bool { return false }
 	fileExists := func(f string) bool { return false }
-	return NewEnvironmentValuesLoader(storage, os.ReadFile, sugar, remote.NewRemote(sugar, "/tmp", readFile, dirExists, fileExists))
+	return NewEnvironmentValuesLoader(storage, os.ReadFile, os.ReadDir, sugar, remote.NewRemote(sugar, "/tmp", readFile, dirExists, fileExists))
 }
 
 // See https://github.com/roboll/helmfile/pull/1169

--- a/pkg/state/state_exec_tmpl.go
+++ b/pkg/state/state_exec_tmpl.go
@@ -110,7 +110,7 @@ func (st *HelmState) ExecuteTemplates() (*HelmState, error) {
 		successFlag := false
 		for it, prev := 0, &release; it < 6; it++ {
 			tmplData := st.createReleaseTemplateData(prev, vals)
-			renderer := tmpl.NewFileRenderer(st.readFile, st.basePath, tmplData)
+			renderer := tmpl.NewFileRenderer(st.readFile, st.readDir, st.basePath, tmplData)
 			r, err := release.ExecuteTemplateExpressions(renderer)
 			if err != nil {
 				return nil, fmt.Errorf("failed executing templates in release \"%s\".\"%s\": %v", st.FilePath, release.Name, err)

--- a/pkg/tmpl/file_renderer.go
+++ b/pkg/tmpl/file_renderer.go
@@ -3,6 +3,7 @@ package tmpl
 import (
 	"bytes"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 )
@@ -13,13 +14,13 @@ type FileRenderer struct {
 	Data     interface{}
 }
 
-func NewFileRenderer(readFile func(filename string) ([]byte, error), basePath string, data interface{}) *FileRenderer {
+func NewFileRenderer(readFile func(filename string) ([]byte, error), readDir func(string) ([]fs.DirEntry, error), basePath string, data interface{}) *FileRenderer {
 	return &FileRenderer{
 		ReadFile: readFile,
 		Context: &Context{
 			basePath: basePath,
 			readFile: readFile,
-			readDir:  os.ReadDir,
+			readDir:  readDir,
 		},
 		Data: data,
 	}

--- a/pkg/tmpl/file_renderer_test.go
+++ b/pkg/tmpl/file_renderer_test.go
@@ -2,6 +2,7 @@ package tmpl
 
 import (
 	"fmt"
+	"io/fs"
 	"reflect"
 	"testing"
 
@@ -31,6 +32,9 @@ func TestRenderToBytes_Gotmpl(t *testing.T) {
 			return []byte(dataFileContent), nil
 		}
 		return nil, fmt.Errorf("unexpected filename: expected=%v or %v, actual=%s", dataFile, valuesTmplFile, filename)
+	}, func(path string) ([]fs.DirEntry, error) {
+		t.Fatalf("This test is supposed to NOT call readDir")
+		return nil, nil
 	}, "", emptyEnvTmplData)
 	buf, err := r.RenderToBytes(valuesTmplFile)
 	if err != nil {
@@ -55,6 +59,9 @@ func TestRenderToBytes_Yaml(t *testing.T) {
 			return []byte(valuesYamlContent), nil
 		}
 		return nil, fmt.Errorf("unexpected filename: expected=%v, actual=%s", valuesFile, filename)
+	}, func(s string) ([]fs.DirEntry, error) {
+		t.Fatalf("This test is supposed to NOT call readDir")
+		return nil, nil
 	}, "", emptyEnvTmplData)
 	buf, err := r.RenderToBytes(valuesFile)
 	if err != nil {

--- a/test/e2e/template/helmfile/tmpl_test.go
+++ b/test/e2e/template/helmfile/tmpl_test.go
@@ -276,7 +276,7 @@ func TestFileRendering(t *testing.T) {
 
 			filename := fmt.Sprintf("%s/%s.gotmpl", tempDir, tc.name)
 			os.WriteFile(filename, []byte(tc.tmplString), 0644)
-			fileRenderer := tmpl.NewFileRenderer(os.ReadFile, ".", tc.data)
+			fileRenderer := tmpl.NewFileRenderer(os.ReadFile, os.ReadDir, ".", tc.data)
 			tmpl_bytes, err := fileRenderer.RenderToBytes(filename)
 
 			if tc.wantErr {


### PR DESCRIPTION
Follow-up for #297
Ref https://github.com/helmfile/helmfile/pull/297#issuecomment-1217609669

I believe I need to update a few more places in the code like StateCreator, DesiredStateLoader and so on. So, this needs a bit more work and manual testing before getting merged.