### PR TITLE
chore: remove 'OSS' from Jenkins name

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Helmfile has been used by many users in production:
 
 * [gitlab.com](https://gitlab.com)
 * [reddit.com](https://reddit.com)
-* [Jenkins OSS](https://jenkins.io)
+* [Jenkins](https://jenkins.io)
 * ...
 
 For more users, please see: [Users](https://helmfile.readthedocs.io/en/latest/users/)

--- a/USERS.md
+++ b/USERS.md
@@ -25,7 +25,7 @@ information to this file.
 | [American Express](https://www.americanexpress.com) | proof-of-concept | Orchestration of both internal cluster workloads and local developer environments. | London, GB | January 2020 |
 | [Sportradar](https://www.sportradar.com) | production | Since mid-2019, we've been deploying our core infrastructure and several application stacks with Helmfile. | St. Gallen, Switzerland | March 2020 |
 | [PedidosYa](https://www.pedidosya.com) | production | | Montevideo, Uruguay | June 2020 |
-| [Jenkins OSS](https://jenkins.io) | production | [jenkins-infra/kubernetes-management](https://github.com/jenkins-infra/kubernetes-management) | * | July 2020 |
+| [Jenkins](https://jenkins.io) | production | [jenkins-infra/kubernetes-management](https://github.com/jenkins-infra/kubernetes-management) | * | July 2020 |
 | [SettleMint](https://settlemint.com) | production | The SettleMint platform allows enterprises to spin up k8s clusters and deploy production grade blockchain networks and additional services. Helmfile is in charge of deploying these networks and services on demand out of the self service management ui. | Belgium, Singapore, UAE, India | October 2020 |
 | [AutoTrader (UK)](https://www.autotrader.co.uk) | production | We've used Helmfile for 2+ years to deploy 400+ services | UK | October 2020 |
 | [Trend Micro](https://www.trendmicro.com) | production | We manage 9 k8s clusters in a mono git repository with Helmfile | Taipei, Taiwan |  December 2019 |


### PR DESCRIPTION
I've noticed a bit late that there isn't any "OSS" in Jenkins name.

Signed-off-by: Hervé Le Meur <hlemeur@cloudbees.com>