### PR TITLE
feat: dont prepare on list

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,6 +9,7 @@ import (
 
 // NewListCmd returns list subcmd
 func NewListCmd(globalCfg *config.GlobalImpl) *cobra.Command {
+	var skipCharts bool
 	listOptions := config.NewListOptions()
 	listImpl := config.NewListImpl(globalCfg, listOptions)
 
@@ -16,6 +17,8 @@ func NewListCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 		Use:   "list",
 		Short: "List releases defined in state file",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			listOptions.WithPreparedCharts = !skipCharts
+
 			err := config.NewCLIConfigImpl(listImpl.GlobalImpl)
 			if err != nil {
 				return err
@@ -32,7 +35,7 @@ func NewListCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 
 	f := cmd.Flags()
 	f.BoolVar(&listOptions.KeepTempDir, "keep-temp-dir", false, "Keep temporary directory")
-	f.BoolVar(&listOptions.WithPreparedCharts, "with-prepared-charts", true, "prepare charts when listing releases")
+	f.BoolVar(&skipCharts, "skip-charts", false, "don't prepare charts when listing releases")
 	f.StringVar(&listOptions.Output, "output", "", "output releases list as a json string")
 
 	return cmd

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -9,7 +9,6 @@ import (
 
 // NewListCmd returns list subcmd
 func NewListCmd(globalCfg *config.GlobalImpl) *cobra.Command {
-	var skipCharts bool
 	listOptions := config.NewListOptions()
 	listImpl := config.NewListImpl(globalCfg, listOptions)
 
@@ -17,8 +16,6 @@ func NewListCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 		Use:   "list",
 		Short: "List releases defined in state file",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			listOptions.WithPreparedCharts = !skipCharts
-
 			err := config.NewCLIConfigImpl(listImpl.GlobalImpl)
 			if err != nil {
 				return err
@@ -35,7 +32,7 @@ func NewListCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 
 	f := cmd.Flags()
 	f.BoolVar(&listOptions.KeepTempDir, "keep-temp-dir", false, "Keep temporary directory")
-	f.BoolVar(&skipCharts, "skip-charts", false, "don't prepare charts when listing releases")
+	f.BoolVar(&listOptions.SkipCharts, "skip-charts", false, "don't prepare charts when listing releases")
 	f.StringVar(&listOptions.Output, "output", "", "output releases list as a json string")
 
 	return cmd

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -32,6 +32,7 @@ func NewListCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 
 	f := cmd.Flags()
 	f.BoolVar(&listOptions.KeepTempDir, "keep-temp-dir", false, "Keep temporary directory")
+	f.BoolVar(&listOptions.WithPreparedCharts, "with-prepared-charts", true, "prepare charts when listing releases")
 	f.StringVar(&listOptions.Output, "output", "", "output releases list as a json string")
 
 	return cmd

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -552,8 +552,9 @@ func (a *App) ListReleases(c ListConfigProvider) error {
 
 		if c.WithPreparedCharts() {
 			err = run.withPreparedCharts("list", state.ChartPrepareOptions{
-				SkipRepos: true,
-				SkipDeps:  true,
+				SkipRepos:   true,
+				SkipDeps:    true,
+				Concurrency: 2,
 			}, func() {
 				rel, err := a.list(run)
 				if err != nil {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -550,7 +550,7 @@ func (a *App) ListReleases(c ListConfigProvider) error {
 		var stateReleases []*HelmRelease
 		var err error
 
-		if c.WithPreparedCharts() {
+		if !c.SkipCharts() {
 			err = run.withPreparedCharts("list", state.ChartPrepareOptions{
 				SkipRepos:   true,
 				SkipDeps:    true,

--- a/pkg/app/app_list_test.go
+++ b/pkg/app/app_list_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/helmfile/helmfile/pkg/testutil"
 )
 
-func testListWithConfig(t *testing.T, cfg configImpl) {
+func testListWithEnvironment(t *testing.T, cfg configImpl) {
 	type testcase struct {
 		environment string
 		ns          string
@@ -249,9 +249,9 @@ database                   	my-app     	true   	true     	        	bitnami/postg
 
 func TestListWithEnvironment(t *testing.T) {
 	t.Run("with prepared charts", func(t *testing.T) {
-		testListWithConfig(t, configImpl{withPreparedCharts: true})
+		testListWithEnvironment(t, configImpl{withPreparedCharts: true})
 	})
 	t.Run("without prepared charts", func(t *testing.T) {
-		testListWithConfig(t, configImpl{withPreparedCharts: false})
+		testListWithEnvironment(t, configImpl{withPreparedCharts: false})
 	})
 }

--- a/pkg/app/app_list_test.go
+++ b/pkg/app/app_list_test.go
@@ -249,11 +249,11 @@ database                   	my-app     	true   	true     	        	bitnami/postg
 }
 
 func TestListWithEnvironment(t *testing.T) {
-	t.Run("with prepared charts", func(t *testing.T) {
-		testListWithEnvironment(t, configImpl{withPreparedCharts: true})
+	t.Run("with skipCharts=false", func(t *testing.T) {
+		testListWithEnvironment(t, configImpl{skipCharts: false})
 	})
-	t.Run("without prepared charts", func(t *testing.T) {
-		testListWithEnvironment(t, configImpl{withPreparedCharts: false})
+	t.Run("with skipCharts=true", func(t *testing.T) {
+		testListWithEnvironment(t, configImpl{skipCharts: true})
 	})
 }
 
@@ -316,10 +316,10 @@ releases:
 }
 
 func TestListWithJSONOutput(t *testing.T) {
-	t.Run("with prepared charts", func(t *testing.T) {
-		testListWithJSONOutput(t, configImpl{withPreparedCharts: true})
+	t.Run("with skipCharts=false", func(t *testing.T) {
+		testListWithJSONOutput(t, configImpl{skipCharts: false})
 	})
-	t.Run("without prepared charts", func(t *testing.T) {
-		testListWithJSONOutput(t, configImpl{withPreparedCharts: false})
+	t.Run("with skipCharts=true", func(t *testing.T) {
+		testListWithJSONOutput(t, configImpl{skipCharts: true})
 	})
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -4627,64 +4627,6 @@ myrelease4	         	true   	true     	id:myrelease1             	mychart1
 	assert.Equal(t, expected, out)
 }
 
-func TestListWithJsonOutput(t *testing.T) {
-	files := map[string]string{
-		"/path/to/helmfile.d/first.yaml": `
-environments:
-  default:
-    values:
-     - myrelease2:
-         enabled: false
-releases:
-- name: myrelease1
-  chart: mychart1
-  installed: no
-  labels:
-    id: myrelease1
-- name: myrelease2
-  chart: mychart1
-  condition: myrelease2.enabled
-`,
-		"/path/to/helmfile.d/second.yaml": `
-releases:
-- name: myrelease3
-  chart: mychart1
-  installed: yes
-- name: myrelease4
-  chart: mychart1
-  labels:
-    id: myrelease1
-`,
-	}
-	stdout := os.Stdout
-	defer func() { os.Stdout = stdout }()
-
-	var buffer bytes.Buffer
-	logger := helmexec.NewLogger(&buffer, "debug")
-
-	app := appWithFs(&App{
-		OverrideHelmBinary:  DefaultHelmBinary,
-		fs:                  ffs.DefaultFileSystem(),
-		OverrideKubeContext: "default",
-		Env:                 "default",
-		Logger:              logger,
-		Namespace:           "testNamespace",
-	}, files)
-
-	expectNoCallsToHelm(app)
-
-	out := testutil.CaptureStdout(func() {
-		err := app.ListReleases(configImpl{
-			output: "json",
-		})
-		assert.Nil(t, err)
-	})
-
-	expected := `[{"name":"myrelease1","namespace":"","enabled":true,"installed":false,"labels":"id:myrelease1","chart":"mychart1","version":""},{"name":"myrelease2","namespace":"","enabled":false,"installed":true,"labels":"","chart":"mychart1","version":""},{"name":"myrelease3","namespace":"","enabled":true,"installed":true,"labels":"","chart":"mychart1","version":""},{"name":"myrelease4","namespace":"","enabled":true,"installed":true,"labels":"id:myrelease1","chart":"mychart1","version":""}]
-`
-	assert.Equal(t, expected, out)
-}
-
 func TestSetValuesTemplate(t *testing.T) {
 	files := map[string]string{
 		"/path/to/helmfile.yaml": `

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2220,6 +2220,7 @@ type configImpl struct {
 	skipNeeds              bool
 	includeNeeds           bool
 	includeTransitiveNeeds bool
+	withPreparedCharts     bool
 }
 
 func (c configImpl) Selectors() []string {
@@ -2292,6 +2293,10 @@ func (c configImpl) EmbedValues() bool {
 
 func (c configImpl) Output() string {
 	return c.output
+}
+
+func (c configImpl) WithPreparedCharts() bool {
+	return c.withPreparedCharts
 }
 
 type applyConfig struct {

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2220,7 +2220,7 @@ type configImpl struct {
 	skipNeeds              bool
 	includeNeeds           bool
 	includeTransitiveNeeds bool
-	withPreparedCharts     bool
+	skipCharts             bool
 }
 
 func (c configImpl) Selectors() []string {
@@ -2295,8 +2295,8 @@ func (c configImpl) Output() string {
 	return c.output
 }
 
-func (c configImpl) WithPreparedCharts() bool {
-	return c.withPreparedCharts
+func (c configImpl) SkipCharts() bool {
+	return c.skipCharts
 }
 
 type applyConfig struct {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -236,6 +236,7 @@ type interactive interface {
 
 type ListConfigProvider interface {
 	Output() string
+	WithPreparedCharts() bool
 }
 
 type CacheConfigProvider interface{}

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -236,7 +236,7 @@ type interactive interface {
 
 type ListConfigProvider interface {
 	Output() string
-	WithPreparedCharts() bool
+	SkipCharts() bool
 }
 
 type CacheConfigProvider interface{}

--- a/pkg/config/list.go
+++ b/pkg/config/list.go
@@ -6,6 +6,8 @@ type ListOptions struct {
 	Output string
 	// KeepTempDir is the keep temp dir flag
 	KeepTempDir bool
+	// WithPreparedCharts makes list call `withPreparedCharts` when listing
+	WithPreparedCharts bool
 }
 
 // NewListOptions creates a new Apply
@@ -35,4 +37,9 @@ func (c *ListImpl) Args() string {
 // Output returns the output
 func (c *ListImpl) Output() string {
 	return c.ListOptions.Output
+}
+
+// WithPreparedCharts returns withPreparedCharts flag
+func (c *ListImpl) WithPreparedCharts() bool {
+	return c.ListOptions.WithPreparedCharts
 }

--- a/pkg/config/list.go
+++ b/pkg/config/list.go
@@ -6,8 +6,8 @@ type ListOptions struct {
 	Output string
 	// KeepTempDir is the keep temp dir flag
 	KeepTempDir bool
-	// WithPreparedCharts makes list call `withPreparedCharts` when listing
-	WithPreparedCharts bool
+	// SkipCharts makes List skip `withPreparedCharts`
+	SkipCharts bool
 }
 
 // NewListOptions creates a new Apply
@@ -39,7 +39,7 @@ func (c *ListImpl) Output() string {
 	return c.ListOptions.Output
 }
 
-// WithPreparedCharts returns withPreparedCharts flag
-func (c *ListImpl) WithPreparedCharts() bool {
-	return c.ListOptions.WithPreparedCharts
+// SkipCharts returns skipCharts flag
+func (c *ListImpl) SkipCharts() bool {
+	return c.ListOptions.SkipCharts
 }


### PR DESCRIPTION
This changes list command so it doesn't run withPreparedCharts, and just lists releases instead.

See discussion https://github.com/helmfile/helmfile/discussions/344 for reasoning.

This might break environments which relied on `list` having to build everything - I can add a backwards compatible opt flag if that's an issue

## changelog note for this PR
Add `--skip-charts` flag to `list` subcommand, to only list releases without preparing and templating charts for them