### PR TITLE
Support helm-secrets v4.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,9 @@ jobs:
           - v3.7.2
           - v3.8.2
           - v3.9.0
+        plugin-secrets-version:
+          - 3.15.0
+          - 4.0.0
     steps:
     - uses: actions/checkout@v2
     - name: Cache libraries
@@ -96,6 +99,7 @@ jobs:
       uses: medyagh/setup-minikube@master
     - name: Execute integration tests
       env:
+        HELM_SECRETS_VERSION: ${{ matrix.plugin-secrets-version }}
         HELMFILE_HELM3: 1
         TERM: xterm
       run: make integration

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -14,6 +14,8 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/plugin"
 
 	"github.com/helmfile/helmfile/pkg/envvar"
 )
@@ -82,6 +84,20 @@ func getHelmVersion(helmBinary string, runner Runner) (semver.Version, error) {
 	}
 
 	return parseHelmVersion(string(outBytes))
+}
+
+func GetPluginVersion(name, pluginsDir string) (*semver.Version, error) {
+	plugins, err := plugin.FindPlugins(pluginsDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, plugin := range plugins {
+		if plugin.Metadata.Name == name {
+			return semver.NewVersion(plugin.Metadata.Version)
+		}
+	}
+
+	return nil, fmt.Errorf("plugin %s not installed", name)
 }
 
 func redactedURL(chart string) string {
@@ -281,7 +297,18 @@ func (helm *execer) DecryptSecret(context HelmContext, name string, flags ...str
 		helm.logger.Infof("Decrypting secret %v", absPath)
 		preArgs := context.GetTillerlessArgs(helm)
 		env := context.getTillerlessEnv()
-		secretBytes, err := helm.exec(append(append(preArgs, "secrets", "view", absPath), flags...), env)
+		settings := cli.New()
+		pluginVersion, err := GetPluginVersion("secrets", settings.PluginsDirectory)
+		if err != nil {
+			secret.err = err
+			return "", err
+		}
+		secretArg := "view"
+		// helm secret view command. The helm secret decrypt command is a drop-in replacement in 4.0.0 version
+		if pluginVersion.Major() > 3 {
+			secretArg = "decrypt"
+		}
+		secretBytes, err := helm.exec(append(append(preArgs, "secrets", secretArg, absPath), flags...), env)
 		if err != nil {
 			secret.err = err
 			return "", err

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -25,8 +25,9 @@ export HELM_DATA_HOME="${helm_dir}/data"
 export HELM_HOME="${HELM_DATA_HOME}"
 export HELM_PLUGINS="${HELM_DATA_HOME}/plugins"
 export HELM_CONFIG_HOME="${helm_dir}/config"
-HELM_SECRETS_VERSION=3.5.0
 HELM_DIFF_VERSION=3.3.1
+HELM_SECRETS_DEFAULT_VERSION=3.15.0
+HELM_SECRETS_VERSION="${HELM_SECRETS_VERSION:-$HELM_SECRETS_DEFAULT_VERSION}"
 export GNUPGHOME="${PWD}/${dir}/.gnupg"
 export SOPS_PGP_FP="B2D6D7BBEC03B2E66571C8C00AD18E16CFDEF700"
 
@@ -194,7 +195,7 @@ if [[ helm_major_version -eq 3 ]]; then
   test_start "secretssops.2 - should succeed with secrets plugin"
 
   info "Ensure helm-secrets is installed"
-  ${helm} plugin install https://github.com/jkroepke/helm-secrets --version v3.5.0
+  ${helm} plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION}
 
   info "Ensure helmfile succeed when helm-secrets is installed"
   ${helmfile} -f ${dir}/secretssops.yaml -e direct build || fail "\"helmfile build\" shouldn't fail"

--- a/test/plugins/secrets/3.15.0/helm-secrets/plugin.yaml
+++ b/test/plugins/secrets/3.15.0/helm-secrets/plugin.yaml
@@ -1,0 +1,21 @@
+name: "secrets"
+version: "3.15.0"
+usage: "Secrets encryption in Helm for Git storing"
+description: |-
+  This plugin provides secrets values encryption for Helm charts secure storing
+useTunnel: false
+command: "$HELM_PLUGIN_DIR/scripts/run.sh"
+platformCommand:
+  - os: windows
+    command: "cmd /c $HELM_PLUGIN_DIR\\scripts\\wrapper\\sh.cmd $HELM_PLUGIN_DIR\\scripts\\run.sh"
+
+downloaders:
+  - command: "scripts/run.sh downloader"
+    protocols:
+      - "sops"
+      - "secret"
+      - "secrets"
+      - "secrets+gpg-import"
+      - "secrets+gpg-import-kubernetes"
+      - "secrets+age-import"
+      - "secrets+age-import-kubernetes"

--- a/test/plugins/secrets/4.0.0/helm-secrets/plugin.yaml
+++ b/test/plugins/secrets/4.0.0/helm-secrets/plugin.yaml
@@ -1,0 +1,19 @@
+name: "secrets"
+version: "4.0.0"
+usage: "Secrets encryption in Helm for Git storing"
+description: |-
+  This plugin provides secrets values encryption for Helm charts secure storing
+useTunnel: false
+command: "$HELM_PLUGIN_DIR/scripts/run.sh"
+platformCommand:
+  - os: windows
+    command: "cmd /c $HELM_PLUGIN_DIR\\scripts\\wrapper\\sh.cmd $HELM_PLUGIN_DIR\\scripts\\run.sh"
+
+downloaders:
+  - command: "scripts/run.sh downloader"
+    protocols:
+      - "secrets"
+      - "secrets+gpg-import"
+      - "secrets+gpg-import-kubernetes"
+      - "secrets+age-import"
+      - "secrets+age-import-kubernetes"


### PR DESCRIPTION
Helm-secrets has been released to v4.0.0 and the secret view command has been deprecated.
[Helm-secrets change log](https://github.com/jkroepke/helm-secrets/blob/v4.0.0/CHANGELOG.md), Helm secret view command. The helm secret decrypt command is a drop-in replacement.
