### PR TITLE
remove flags.Parse in cobra

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,16 +68,8 @@ func NewRootCmd(globalConfig *config.GlobalOptions, args []string) (*cobra.Comma
 	// Set the global options for the root command.
 	setGlobalOptionsForRootCmd(flags, globalConfig)
 
-	// We can safely ignore any errors that flags.Parse encounters since
-	// those errors will be caught later during the call to cmd.Execution.
-	// This call is required to gather configuration information prior to
-	// execution.
 	flags.ParseErrorsWhitelist.UnknownFlags = true
 
-	err := flags.Parse(args)
-	if err != nil {
-		return nil, err
-	}
 	globalImpl := config.NewGlobalImpl(globalConfig)
 	cmd.AddCommand(
 		NewApplyCmd(globalImpl),

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
+	helm.sh/helm/v3 v3.8.1
 	k8s.io/apimachinery v0.24.4
 )
 
@@ -188,7 +189,6 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	helm.sh/helm/v3 v3.8.1 // indirect
 	k8s.io/api v0.23.4 // indirect
 	k8s.io/cli-runtime v0.23.4 // indirect
 	k8s.io/client-go v0.23.4 // indirect


### PR DESCRIPTION
Signed-off-by: yxxhero <aiopsclub@163.com>

remove flags.Parse in cobra

flags. Parse refers to the code of the helm, but I found that some parameter parsing exceptions would occur, so I removed this logic

```bash
[root@devops helmfile]# go run main.go template --args "-s templates/deployment.yaml"
environment will be: mplates/deployment.yaml [it's error]
args will be: -s templates/deployment.yaml
```

fixed: https://github.com/helmfile/helmfile/issues/299
