### PR TITLE
Use helm show chart to identify chart version

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/variantdev/vals"
 	"go.uber.org/zap"
+	"helm.sh/helm/v3/pkg/chart"
 
 	"github.com/helmfile/helmfile/pkg/envvar"
 	"github.com/helmfile/helmfile/pkg/exectest"
@@ -2596,6 +2598,10 @@ func (helm *mockHelmExec) IsVersionAtLeast(versionStr string) bool {
 	return false
 }
 
+func (helm *mockHelmExec) ShowChart(chartPath string) (chart.Metadata, error) {
+	return chart.Metadata{}, errors.New("tests logs rely on this error")
+}
+
 func TestTemplate_SingleStateFile(t *testing.T) {
 	files := map[string]string{
 		"/path/to/helmfile.yaml": `
@@ -3052,7 +3058,7 @@ GROUP RELEASES
 
 processing releases in group 1/2: default//baz, default//bar
 processing releases in group 2/2: default//foo
-getting deployed release version failed:Failed to get the version for:mychart1
+getting deployed release version failed: Failed to get the version for: mychart1
 
 UPDATED RELEASES:
 NAME   CHART             VERSION
@@ -3162,7 +3168,7 @@ GROUP RELEASES
 
 processing releases in group 1/2: default//baz, default//bar
 processing releases in group 2/2: default//foo
-getting deployed release version failed:Failed to get the version for:mychart1
+getting deployed release version failed: Failed to get the version for: mychart1
 
 UPDATED RELEASES:
 NAME   CHART             VERSION

--- a/pkg/app/mocks_test.go
+++ b/pkg/app/mocks_test.go
@@ -1,6 +1,10 @@
 package app
 
-import "github.com/helmfile/helmfile/pkg/helmexec"
+import (
+	"helm.sh/helm/v3/pkg/chart"
+
+	"github.com/helmfile/helmfile/pkg/helmexec"
+)
 
 type noCallHelmExec struct {
 }
@@ -112,4 +116,9 @@ func (helm *noCallHelmExec) GetVersion() helmexec.Version {
 func (helm *noCallHelmExec) IsVersionAtLeast(versionStr string) bool {
 	helm.doPanic()
 	return false
+}
+
+func (helm *noCallHelmExec) ShowChart(chartPath string) (chart.Metadata, error) {
+	helm.doPanic()
+	return chart.Metadata{}, nil
 }

--- a/pkg/app/testdata/testapply/helm2_upgrade_when_tns1/foo_needs_tns2/bar/log
+++ b/pkg/app/testdata/testapply/helm2_upgrade_when_tns1/foo_needs_tns2/bar/log
@@ -50,9 +50,9 @@ GROUP RELEASES
 2     default/tns1/foo
 
 processing releases in group 1/2: default/tns2/bar
-getting deployed release version failed:Failed to get the version for:mychart2
+getting deployed release version failed: Failed to get the version for: mychart2
 processing releases in group 2/2: default/tns1/foo
-getting deployed release version failed:Failed to get the version for:mychart1
+getting deployed release version failed: Failed to get the version for: mychart1
 
 UPDATED RELEASES:
 NAME   CHART             VERSION

--- a/pkg/app/testdata/testapply/install/log
+++ b/pkg/app/testdata/testapply/install/log
@@ -47,10 +47,10 @@ GROUP RELEASES
 2     default//foo
 
 processing releases in group 1/2: default//baz, default//bar
-getting deployed release version failed:unexpected list key: listkey(filter=^baz$,flags=--kube-contextdefault--deleting--deployed--failed--pending) not found in 
-getting deployed release version failed:unexpected list key: listkey(filter=^bar$,flags=--kube-contextdefault--deleting--deployed--failed--pending) not found in 
+getting deployed release version failed: unexpected list key: listkey(filter=^baz$,flags=--kube-contextdefault--deleting--deployed--failed--pending) not found in 
+getting deployed release version failed: unexpected list key: listkey(filter=^bar$,flags=--kube-contextdefault--deleting--deployed--failed--pending) not found in 
 processing releases in group 2/2: default//foo
-getting deployed release version failed:unexpected list key: listkey(filter=^foo$,flags=--kube-contextdefault--deleting--deployed--failed--pending) not found in 
+getting deployed release version failed: unexpected list key: listkey(filter=^foo$,flags=--kube-contextdefault--deleting--deployed--failed--pending) not found in 
 
 UPDATED RELEASES:
 NAME   CHART             VERSION

--- a/pkg/app/testdata/testapply/upgrade_when_bar_needs_foo,_with_ns_override/log
+++ b/pkg/app/testdata/testapply/upgrade_when_bar_needs_foo,_with_ns_override/log
@@ -42,9 +42,9 @@ GROUP RELEASES
 2     default/testNamespace/bar
 
 processing releases in group 1/2: default/testNamespace/foo
-getting deployed release version failed:Failed to get the version for:mychart1
+getting deployed release version failed: Failed to get the version for: mychart1
 processing releases in group 2/2: default/testNamespace/bar
-getting deployed release version failed:Failed to get the version for:mychart2
+getting deployed release version failed: Failed to get the version for: mychart2
 
 UPDATED RELEASES:
 NAME   CHART             VERSION

--- a/pkg/app/testdata/testapply/upgrade_when_bar_needs_foo/log
+++ b/pkg/app/testdata/testapply/upgrade_when_bar_needs_foo/log
@@ -42,9 +42,9 @@ GROUP RELEASES
 2     default//bar
 
 processing releases in group 1/2: default//foo
-getting deployed release version failed:Failed to get the version for:mychart1
+getting deployed release version failed: Failed to get the version for: mychart1
 processing releases in group 2/2: default//bar
-getting deployed release version failed:Failed to get the version for:mychart2
+getting deployed release version failed: Failed to get the version for: mychart2
 
 UPDATED RELEASES:
 NAME   CHART             VERSION

--- a/pkg/app/testdata/testapply/upgrade_when_foo_needs_bar,_with_ns_override/log
+++ b/pkg/app/testdata/testapply/upgrade_when_foo_needs_bar,_with_ns_override/log
@@ -42,9 +42,9 @@ GROUP RELEASES
 2     default/testNamespace/foo
 
 processing releases in group 1/2: default/testNamespace/bar
-getting deployed release version failed:Failed to get the version for:mychart2
+getting deployed release version failed: Failed to get the version for: mychart2
 processing releases in group 2/2: default/testNamespace/foo
-getting deployed release version failed:Failed to get the version for:mychart1
+getting deployed release version failed: Failed to get the version for: mychart1
 
 UPDATED RELEASES:
 NAME   CHART             VERSION

--- a/pkg/app/testdata/testapply/upgrade_when_foo_needs_bar/log
+++ b/pkg/app/testdata/testapply/upgrade_when_foo_needs_bar/log
@@ -42,9 +42,9 @@ GROUP RELEASES
 2     default//foo
 
 processing releases in group 1/2: default//bar
-getting deployed release version failed:Failed to get the version for:mychart2
+getting deployed release version failed: Failed to get the version for: mychart2
 processing releases in group 2/2: default//foo
-getting deployed release version failed:Failed to get the version for:mychart1
+getting deployed release version failed: Failed to get the version for: mychart1
 
 UPDATED RELEASES:
 NAME   CHART             VERSION

--- a/pkg/app/testdata/testapply/upgrade_when_ns1/foo_needs_ns2/bar/log
+++ b/pkg/app/testdata/testapply/upgrade_when_ns1/foo_needs_ns2/bar/log
@@ -46,9 +46,9 @@ GROUP RELEASES
 2     default/ns1/foo
 
 processing releases in group 1/2: default/ns2/bar
-getting deployed release version failed:Failed to get the version for:mychart2
+getting deployed release version failed: Failed to get the version for: mychart2
 processing releases in group 2/2: default/ns1/foo
-getting deployed release version failed:Failed to get the version for:mychart1
+getting deployed release version failed: Failed to get the version for: mychart1
 
 UPDATED RELEASES:
 NAME   CHART             VERSION

--- a/pkg/app/testdata/testapply/upgrade_when_ns2/bar_needs_ns1/foo/log
+++ b/pkg/app/testdata/testapply/upgrade_when_ns2/bar_needs_ns1/foo/log
@@ -46,9 +46,9 @@ GROUP RELEASES
 2     default/ns2/bar
 
 processing releases in group 1/2: default/ns1/foo
-getting deployed release version failed:Failed to get the version for:mychart1
+getting deployed release version failed: Failed to get the version for: mychart1
 processing releases in group 2/2: default/ns2/bar
-getting deployed release version failed:Failed to get the version for:mychart2
+getting deployed release version failed: Failed to get the version for: mychart2
 
 UPDATED RELEASES:
 NAME   CHART             VERSION

--- a/pkg/app/testdata/testapply_2/apply_release_with_preapply_hook/log
+++ b/pkg/app/testdata/testapply_2/apply_release_with_preapply_hook/log
@@ -60,7 +60,7 @@ GROUP RELEASES
 1     default/default/foo
 
 processing releases in group 1/1: default/default/foo
-getting deployed release version failed:unexpected list key: {^foo$ --kube-contextdefault--deleting--deployed--failed--pending}
+getting deployed release version failed: unexpected list key: {^foo$ --kube-contextdefault--deleting--deployed--failed--pending}
 
 UPDATED RELEASES:
 NAME   CHART           VERSION

--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
+	"helm.sh/helm/v3/pkg/chart"
 
 	"github.com/helmfile/helmfile/pkg/helmexec"
 )
@@ -226,4 +227,13 @@ func (helm *Helm) sync(m *sync.Mutex, f func()) {
 	}
 
 	f()
+}
+
+func (helm *Helm) ShowChart(chartPath string) (chart.Metadata, error) {
+	switch chartPath {
+	case "../../foo-bar":
+		return chart.Metadata{Version: "3.2.0"}, nil
+	default:
+		return chart.Metadata{}, errors.New("fake test error")
+	}
 }

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -1008,3 +1008,32 @@ func Test_resolveOciChart(t *testing.T) {
 		})
 	}
 }
+
+func Test_ShowChart(t *testing.T) {
+	helm2Runner := mockRunner{output: []byte("Client: v2.16.1+ge13bc94\n")}
+	helm := New("helm", false, NewLogger(os.Stdout, "info"), "dev", &helm2Runner)
+	_, err := helm.ShowChart("fake-chart")
+	if err == nil {
+		t.Error("helmexec.ShowChart() - helm show isn't supported in helm2")
+	}
+
+	showChartRunner := mockRunner{output: []byte("name: my-chart\nversion: 3.2.0\n")}
+	helm = &execer{
+		helmBinary:  "helm",
+		version:     *semver.MustParse("3.3.2"),
+		logger:      NewLogger(os.Stdout, "info"),
+		kubeContext: "dev",
+		runner:      &showChartRunner,
+	}
+
+	metadata, err := helm.ShowChart("my-chart")
+	if err != nil {
+		t.Errorf("helmexec.ShowChart() - unexpected error: %v", err)
+	}
+	if metadata.Name != "my-chart" {
+		t.Errorf("helmexec.ShowChart() - expected chart name was %s, received: %s", "my-chart", metadata.Name)
+	}
+	if metadata.Version != "3.2.0" {
+		t.Errorf("helmexec.ShowChart() - expected chart version was %s, received: %s", "3.2.0", metadata.Version)
+	}
+}

--- a/pkg/helmexec/helmexec.go
+++ b/pkg/helmexec/helmexec.go
@@ -1,5 +1,7 @@
 package helmexec
 
+import "helm.sh/helm/v3/pkg/chart"
+
 // Version represents the version of helm
 type Version struct {
 	Major int
@@ -33,6 +35,7 @@ type Interface interface {
 	IsHelm3() bool
 	GetVersion() Version
 	IsVersionAtLeast(versionStr string) bool
+	ShowChart(chart string) (chart.Metadata, error)
 }
 
 type DependencyUpdater interface {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -867,7 +867,7 @@ func (st *HelmState) SyncReleases(affectedReleases *AffectedReleases, helm helme
 					m.Unlock()
 					installedVersion, err := st.getDeployedVersion(context, helm, release)
 					if err != nil { // err is not really impacting so just log it
-						st.logger.Debugf("getting deployed release version failed:%v", err)
+						st.logger.Debugf("getting deployed release version failed: %v", err)
 					} else {
 						release.installedVersion = installedVersion
 					}
@@ -938,8 +938,11 @@ func (st *HelmState) getDeployedVersion(context helmexec.HelmContext, helm helme
 		if len(versions) > 0 {
 			return versions[1], nil
 		} else {
-			//fails to find the version
-			return "failed to get version", errors.New("Failed to get the version for:" + chartName)
+			chartMetadata, err := helm.ShowChart(release.Chart)
+			if err != nil {
+				return "failed to get version", errors.New("Failed to get the version for: " + chartName)
+			}
+			return chartMetadata.Version, nil
 		}
 	} else {
 		return "failed to get version", err

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -1455,6 +1455,16 @@ func TestGetDeployedVersion(t *testing.T) {
 										foo-bar-release	1       	Wed Apr 17 17:39:04 2019	DEPLOYED	foo-bar-1.0.0-alpha+001	0.1.0      	default`,
 			installedVersion: "1.0.0-alpha+001",
 		},
+		{
+			name: "chart version from helm show chart",
+			release: ReleaseSpec{
+				Name:  "foo",
+				Chart: "../../foo-bar",
+			},
+			listResult: `NAME 	REVISION	UPDATED                 	STATUS  	CHART                      	APP VERSION	NAMESPACE
+										foo	1       	Wed Apr 17 17:39:04 2019	DEPLOYED	foo-bar      	0.1.0      	default`,
+			installedVersion: "3.2.0",
+		},
 	}
 	for i := range tests {
 		tt := tests[i]
@@ -1467,6 +1477,7 @@ func TestGetDeployedVersion(t *testing.T) {
 				valsRuntime:    valsRuntime,
 				RenderedValues: map[string]interface{}{},
 			}
+
 			helm := &exectest.Helm{
 				Lists: map[exectest.ListKey]string{},
 			}


### PR DESCRIPTION
Test:

```console
$ helm fetch https://github.com/jenkinsci/helm-charts/releases/download/jenkins-4.2.6/jenkins-4.2.6.tgz
$ mv -f jenkins-4.2.6.tgz jenkins.tgz

$ helmfile sync
UPDATED RELEASES:
NAME      CHART           VERSION
jenkins   ./jenkins.tgz          

$ ./helmfile sync
UPDATED RELEASES:
NAME      CHART           VERSION
jenkins   ./jenkins.tgz     4.2.6

```