### PR TITLE
imprv: convert hyphen included in repo name to underbar with gatherOCIUsernamePassword.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1498,6 +1498,20 @@ export MYOCIREGISTRY_USERNAME=spongebob
 export MYOCIREGISTRY_PASSWORD=squarepants
 ```
 
+If `<registryName>` contains hyphens, the environment variable to be read is the hyphen replaced by an underscore., e.g.
+
+```yaml
+repositories:
+  - name: my-oci-registry
+    url: myregistry.azurecr.io
+    oci: true
+```
+
+```shell
+export MY_OCI_REGISTRY_USERNAME=spongebob
+export MY_OCI_REGISTRY_PASSWORD=squarepants
+```
+
 ## Attribution
 
 We use:

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -455,15 +455,16 @@ func (st *HelmState) SyncRepos(helm RepoUpdater, shouldSkip map[string]bool) ([]
 func gatherOCIUsernamePassword(repoName string, username string, password string) (string, string) {
 	var user, pass string
 
+	replacedRepoName := strings.ToUpper(strings.Replace(repoName, "-", "_", -1))
 	if username != "" {
 		user = username
-	} else if u := os.Getenv(fmt.Sprintf("%s_USERNAME", strings.ToUpper(repoName))); u != "" {
+	} else if u := os.Getenv(fmt.Sprintf("%s_USERNAME", replacedRepoName)); u != "" {
 		user = u
 	}
 
 	if password != "" {
 		pass = password
-	} else if p := os.Getenv(fmt.Sprintf("%s_PASSWORD", strings.ToUpper(repoName))); p != "" {
+	} else if p := os.Getenv(fmt.Sprintf("%s_PASSWORD", replacedRepoName)); p != "" {
 		pass = p
 	}
 


### PR DESCRIPTION
Most shells do not support hyphens in environment variables.

However, there are cases where you may want to include hyphens in the repository name.

Therefore, I have included a process in `gatherOCIUsernamePassword` to replace hyphens with underbar.

Signed-off-by: mugioka <okamugi0722@gmail.com>
