### PR TITLE
feat: retrieve repository's username/password from environment

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -148,7 +148,9 @@ repositories:
   url: http://roboll.io/charts
   certFile: optional_client_cert
   keyFile: optional_client_key
+  # username is retrieve from the environment with the format <registryNameUpperCase>_USERNAME for CI usage, here ROBOLL_USERNAME
   username: optional_username
+  # username is retrieve from the environment with the format <registryNameUpperCase>_PASSWORD for CI usage, here ROBOLL_PASSWORD
   password: optional_password
   oci: true
   passCredentials: true

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -433,14 +433,14 @@ func (st *HelmState) SyncRepos(helm RepoUpdater, shouldSkip map[string]bool) ([]
 		if shouldSkip[repo.Name] {
 			continue
 		}
+		username, password := gatherUsernamePassword(repo.Name, repo.Username, repo.Password)
 		var err error
 		if repo.OCI {
-			username, password := gatherOCIUsernamePassword(repo.Name, repo.Username, repo.Password)
 			if username != "" && password != "" {
 				err = helm.RegistryLogin(repo.URL, username, password)
 			}
 		} else {
-			err = helm.AddRepo(repo.Name, repo.URL, repo.CaFile, repo.CertFile, repo.KeyFile, repo.Username, repo.Password, repo.Managed, repo.PassCredentials, repo.SkipTLSVerify)
+			err = helm.AddRepo(repo.Name, repo.URL, repo.CaFile, repo.CertFile, repo.KeyFile, username, password, repo.Managed, repo.PassCredentials, repo.SkipTLSVerify)
 		}
 
 		if err != nil {
@@ -453,7 +453,7 @@ func (st *HelmState) SyncRepos(helm RepoUpdater, shouldSkip map[string]bool) ([]
 	return updated, nil
 }
 
-func gatherOCIUsernamePassword(repoName string, username string, password string) (string, string) {
+func gatherUsernamePassword(repoName string, username string, password string) (string, string) {
 	var user, pass string
 
 	replacedRepoName := strings.ToUpper(strings.Replace(repoName, "-", "_", -1))

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -965,6 +965,48 @@ func TestHelmState_SyncRepos(t *testing.T) {
 			want: []string{"name", "http://example.com/", "", "", "", "example_user", "example_password", "", "true", ""},
 		},
 		{
+			name: "repository without username and password and environment with username and password",
+			repos: []RepositorySpec{
+				{
+					Name:            "name",
+					URL:             "http://example.com/",
+					CertFile:        "",
+					KeyFile:         "",
+					Username:        "",
+					Password:        "",
+					PassCredentials: "",
+					SkipTLSVerify:   "",
+				},
+			},
+			envs: map[string]string{
+				"NAME_USERNAME": "example_user",
+				"NAME_PASSWORD": "example_password",
+			},
+			helm: &exectest.Helm{},
+			want: []string{"name", "http://example.com/", "", "", "", "example_user", "example_password", "", "", ""},
+		},
+		{
+			name: "repository with username and password and environment with username and password",
+			repos: []RepositorySpec{
+				{
+					Name:            "name",
+					URL:             "http://example.com/",
+					CertFile:        "",
+					KeyFile:         "",
+					Username:        "example_user1",
+					Password:        "example_password1",
+					PassCredentials: "",
+					SkipTLSVerify:   "",
+				},
+			},
+			envs: map[string]string{
+				"NAME_USERNAME": "example_user2",
+				"NAME_PASSWORD": "example_password2",
+			},
+			helm: &exectest.Helm{},
+			want: []string{"name", "http://example.com/", "", "", "", "example_user1", "example_password1", "", "", ""},
+		},
+		{
 			name: "repository with skip-tls-verify",
 			repos: []RepositorySpec{
 				{
@@ -2432,7 +2474,7 @@ func TestReverse(t *testing.T) {
 	}
 }
 
-func Test_gatherOCIUsernamePassword(t *testing.T) {
+func Test_gatherUsernamePassword(t *testing.T) {
 	type args struct {
 		repoName string
 		username string
@@ -2451,7 +2493,7 @@ func Test_gatherOCIUsernamePassword(t *testing.T) {
 		{
 			name: "pass username/password from args",
 			args: args{
-				repoName: "myOCIRegistry",
+				repoName: "myRegistry",
 				username: "username1",
 				password: "password1",
 			},
@@ -2461,11 +2503,11 @@ func Test_gatherOCIUsernamePassword(t *testing.T) {
 		{
 			name: "repoName does not contain hyphen, read username/password from environment variables",
 			args: args{
-				repoName: "myOCIRegistry",
+				repoName: "myRegistry",
 			},
-			envUsernameKey:   "MYOCIREGISTRY_USERNAME",
+			envUsernameKey:   "MYREGISTRY_USERNAME",
 			envUsernameValue: "username2",
-			envPasswordKey:   "MYOCIREGISTRY_PASSWORD",
+			envPasswordKey:   "MYREGISTRY_PASSWORD",
 			envPasswordValue: "password2",
 			wantUsername:     "username2",
 			wantPassword:     "password2",
@@ -2473,11 +2515,11 @@ func Test_gatherOCIUsernamePassword(t *testing.T) {
 		{
 			name: "repoName contain hyphen, read username/password from environment variables",
 			args: args{
-				repoName: "my-oci-registry",
+				repoName: "my-registry",
 			},
-			envUsernameKey:   "MY_OCI_REGISTRY_USERNAME",
+			envUsernameKey:   "MY_REGISTRY_USERNAME",
 			envUsernameValue: "username3",
-			envPasswordKey:   "MY_OCI_REGISTRY_PASSWORD",
+			envPasswordKey:   "MY_REGISTRY_PASSWORD",
 			envPasswordValue: "password3",
 			wantUsername:     "username3",
 			wantPassword:     "password3",
@@ -2493,9 +2535,9 @@ func Test_gatherOCIUsernamePassword(t *testing.T) {
 				t.Setenv(tt.envPasswordKey, tt.envPasswordValue)
 			}
 
-			gotUsername, gotPassword := gatherOCIUsernamePassword(tt.args.repoName, tt.args.username, tt.args.password)
+			gotUsername, gotPassword := gatherUsernamePassword(tt.args.repoName, tt.args.username, tt.args.password)
 			if gotUsername != tt.wantUsername || gotPassword != tt.wantPassword {
-				t.Errorf("gatherOCIUsernamePassword() = got username/password %v/%v, want username/password %v/%v", gotUsername, gotPassword, tt.wantUsername, tt.wantPassword)
+				t.Errorf("gatherUsernamePassword() = got username/password %v/%v, want username/password %v/%v", gotUsername, gotPassword, tt.wantUsername, tt.wantPassword)
 			}
 		})
 	}


### PR DESCRIPTION
Make possible to retrieve username/password from the environment for Helm repositories, like it is done for OCI registries.

Related to https://github.com/roboll/helmfile/pull/1629