### PR TITLE
Add `--skip-refresh` flag to the build command

### DIFF
--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -218,7 +218,17 @@ func (helm *execer) RegistryLogin(repository string, username string, password s
 
 func (helm *execer) BuildDeps(name, chart string) error {
 	helm.logger.Infof("Building dependency release=%v, chart=%v", name, chart)
-	out, err := helm.exec([]string{"dependency", "build", chart}, map[string]string{}, nil)
+	args := []string{
+		"dependency",
+		"build",
+		chart,
+	}
+
+	if helm.IsHelm3() {
+		args = append(args, "--skip-refresh")
+	}
+
+	out, err := helm.exec(args, map[string]string{}, nil)
 	helm.info(out)
 	return err
 }


### PR DESCRIPTION
Discussion: https://github.com/helmfile/helmfile/discussions/426

---

This improves the `helmfile sync` performance.

From the code: `BuildDeps` is used only by `runHelmDepBuilds`, which only is used by `PrepareCharts` which is finally only used by `withPreparedCharts`.

`withPreparedCharts` already does `SyncReposOnce` which means we do not have to refresh the local repository cache on each chart build.

This is only supported in Helm v3.

This seems to be mostly affecting helmfiles which have a lot of releases and those release charts use sub dependencies.

I saw significant performance improvements for a helmfile with 45 releases, 2 repositories, and most of the charts also had their own dependencies. Results:

Before the patch:
* real  9m10.565s
* real  9m38.335s
* real  9m14.941s
* real  5m13.106s (with cache)

After the patch:
* real  6m51.965s
* real  6m36.605s
* real  6m31.685s
* real  3m0.271s (with cache)

These were tested with:
```
rm -rf ~/.cache/helmfile ~/.cache/helm ~/.config/helm/repositories.* && helmfile sync ...
```

The result with `(with cache)` was without deleting the caches first.

From these metrics it seems that the sync duration decreased 20-45% depending on the run, release count, dependencies and if the cache was used or not.

As far as I understand, this should be backward-compatible change.