### PR TITLE
use curl instead of wget & update helm to 3.10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ LABEL org.opencontainers.image.source https://github.com/helmfile/helmfile
 
 RUN apk add --no-cache ca-certificates git bash curl jq openssh-client
 
-ARG HELM_VERSION="v3.10.0"
-ARG HELM_SHA256="bf56beb418bb529b5e0d6d43d56654c5a03f89c98400b409d1013a33d9586474"
+ARG HELM_VERSION="v3.10.1"
+ARG HELM_SHA256="c12d2cd638f2d066fec123d0bd7f010f32c643afdf288d39a4610b1f9cb32af3"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
 
 RUN set -x && \
-    wget ${HELM_LOCATION}/${HELM_FILENAME} && \
+    curl --retry 5 --retry-connrefused -LO ${HELM_LOCATION}/${HELM_FILENAME} && \
     echo Verifying ${HELM_FILENAME}... && \
     sha256sum ${HELM_FILENAME} | grep -q "${HELM_SHA256}" && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -21,13 +21,13 @@ RUN apt update -qq && \
       git bash curl jq wget openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
-ARG HELM_VERSION="v3.10.0"
-ARG HELM_SHA256="bf56beb418bb529b5e0d6d43d56654c5a03f89c98400b409d1013a33d9586474"
+ARG HELM_VERSION="v3.10.1"
+ARG HELM_SHA256="c12d2cd638f2d066fec123d0bd7f010f32c643afdf288d39a4610b1f9cb32af3"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
 
 RUN set -x && \
-    wget "${HELM_LOCATION}/${HELM_FILENAME}" && \
+    curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo "Verifying ${HELM_FILENAME}..." && \
     sha256sum "${HELM_FILENAME}" | grep -q "${HELM_SHA256}" && \
     echo "Extracting ${HELM_FILENAME}..." && \
@@ -42,7 +42,7 @@ RUN set -x && \
 ENV KUBECTL_VERSION="v1.25.2"
 ENV KUBECTL_SHA256="8639f2b9c33d38910d706171ce3d25be9b19fc139d0e3d4627f38ce84f9040eb"
 RUN set -x && \
-    wget "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    curl --retry 5 --retry-connrefused -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     sha256sum kubectl | grep ${KUBECTL_SHA256} && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -21,13 +21,13 @@ RUN apt-get update && \
       git bash curl jq wget openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
-ARG HELM_VERSION="v3.10.0"
-ARG HELM_SHA256="bf56beb418bb529b5e0d6d43d56654c5a03f89c98400b409d1013a33d9586474"
+ARG HELM_VERSION="v3.10.1"
+ARG HELM_SHA256="c12d2cd638f2d066fec123d0bd7f010f32c643afdf288d39a4610b1f9cb32af3"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
 
 RUN set -x && \
-    wget ${HELM_LOCATION}/${HELM_FILENAME} && \
+    curl --retry 5 --retry-connrefused -LO ${HELM_LOCATION}/${HELM_FILENAME} && \
     echo Verifying ${HELM_FILENAME}... && \
     sha256sum ${HELM_FILENAME} | grep -q "${HELM_SHA256}" && \
     echo Extracting ${HELM_FILENAME}... && \


### PR DESCRIPTION
To avoid wget output / progress. and uniformise usage between curl / wget