### PR TITLE
use fs.Getwd() to get working dir for sub helmfile

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -543,7 +543,8 @@ func (a *App) PrintState(c StateConfigProvider) error {
 				return
 			}
 
-			fmt.Printf("---\n#  Source: %s\n\n%+v", run.state.FullFilePath(), stateYaml)
+			sourceFile, _ := run.state.FullFilePath()
+			fmt.Printf("---\n#  Source: %s\n\n%+v", sourceFile, stateYaml)
 
 			errs = []error{}
 		})

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -543,7 +543,11 @@ func (a *App) PrintState(c StateConfigProvider) error {
 				return
 			}
 
-			sourceFile, _ := run.state.FullFilePath()
+			sourceFile, err := run.state.FullFilePath()
+			if err != nil {
+				errs = []error{err}
+				return
+			}
 			fmt.Printf("---\n#  Source: %s\n\n%+v", sourceFile, stateYaml)
 
 			errs = []error{}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -3358,5 +3358,9 @@ func (st *HelmState) getOCIChart(release *ReleaseSpec, tempDir string, helm helm
 }
 
 func (st *HelmState) FullFilePath() string {
-	return filepath.Join(st.basePath, st.FilePath)
+	var wd string
+	if st.fs != nil {
+		wd, _ = st.fs.Getwd()
+	}
+	return filepath.Join(wd, st.basePath, st.FilePath)
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -3357,10 +3357,11 @@ func (st *HelmState) getOCIChart(release *ReleaseSpec, tempDir string, helm helm
 	return &chartPath, nil
 }
 
-func (st *HelmState) FullFilePath() string {
+func (st *HelmState) FullFilePath() (string, error) {
 	var wd string
+	var err error
 	if st.fs != nil {
-		wd, _ = st.fs.Getwd()
+		wd, err = st.fs.Getwd()
 	}
-	return filepath.Join(wd, st.basePath, st.FilePath)
+	return filepath.Join(wd, st.basePath, st.FilePath), err
 }

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -2737,8 +2737,9 @@ func TestFullFilePath(t *testing.T) {
 				FilePath: tt.filePath,
 				fs:       tt.fs,
 			}
-			actual := st.FullFilePath()
+			actual, err := st.FullFilePath()
 			require.Equalf(t, actual, tt.expected, "FullFilePath() got = %v, want %v", actual, tt.expected)
+			require.Equalf(t, err, nil, "error %v", err)
 		})
 	}
 }

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -2694,9 +2694,11 @@ func TestGenerateOutputFilePath(t *testing.T) {
 }
 
 func TestFullFilePath(t *testing.T) {
+	fs := testhelper.NewTestFs(map[string]string{})
 	tests := []struct {
 		basePath string
 		filePath string
+		fs       *filesystem.FileSystem
 		expected string
 	}{
 		{
@@ -2714,6 +2716,18 @@ func TestFullFilePath(t *testing.T) {
 			filePath: "helmfile.yaml",
 			expected: "/test-2/helmfile.yaml",
 		},
+		{
+			basePath: "./test-3/",
+			filePath: "helmfile.yaml",
+			fs:       fs.ToFileSystem(),
+			expected: "/path/to/test-3/helmfile.yaml",
+		},
+		{
+			basePath: "/test-4/",
+			filePath: "helmfile.yaml",
+			fs:       fs.ToFileSystem(),
+			expected: "/path/to/test-4/helmfile.yaml",
+		},
 	}
 
 	for _, tt := range tests {
@@ -2721,6 +2735,7 @@ func TestFullFilePath(t *testing.T) {
 			st := &HelmState{
 				basePath: tt.basePath,
 				FilePath: tt.filePath,
+				fs:       tt.fs,
 			}
 			actual := st.FullFilePath()
 			require.Equalf(t, actual, tt.expected, "FullFilePath() got = %v, want %v", actual, tt.expected)

--- a/test/e2e/template/helmfile/testdata/snapshot/issue_2098_release_template_needs/output.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/issue_2098_release_template_needs/output.yaml
@@ -1,5 +1,5 @@
 ---
-#  Source: input.yaml
+#  Source: /home/runner/work/helmfile/helmfile/test/e2e/template/helmfile/testdata/snapshot/issue_2098_release_template_needs/input.yaml
 
 filepath: input.yaml
 helmBinary: helm


### PR DESCRIPTION
related to #460

basepath is "." in each subhelmfile state. so the previous PR could not get the full path to subhelmfile.
This PR change the `# Source: <subhelmfile>` in the build command, so no risk.