### PR TITLE
Introduce a new test helper for easier log snapshot testing

### DIFF
--- a/pkg/app/app_apply_nokubectx_test.go
+++ b/pkg/app/app_apply_nokubectx_test.go
@@ -1,14 +1,12 @@
 package app
 
 import (
-	"bufio"
-	"bytes"
-	"io"
 	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/variantdev/vals"
+	"go.uber.org/zap"
 
 	"github.com/helmfile/helmfile/pkg/exectest"
 	"github.com/helmfile/helmfile/pkg/filesystem"
@@ -54,34 +52,8 @@ func TestApply_3(t *testing.T) {
 			ReleasesMutex:        &sync.Mutex{},
 		}
 
-		bs := &bytes.Buffer{}
-
-		func() {
+		bs := runWithLogCapture(t, func(t *testing.T, logger *zap.SugaredLogger) {
 			t.Helper()
-
-			logReader, logWriter := io.Pipe()
-
-			logFlushed := &sync.WaitGroup{}
-			// Ensure all the log is consumed into `bs` by calling `logWriter.Close()` followed by `logFlushed.Wait()`
-			logFlushed.Add(1)
-			go func() {
-				scanner := bufio.NewScanner(logReader)
-				for scanner.Scan() {
-					bs.Write(scanner.Bytes())
-					bs.WriteString("\n")
-				}
-				logFlushed.Done()
-			}()
-
-			defer func() {
-				// This is here to avoid data-trace on bytes buffer `bs` to capture logs
-				if err := logWriter.Close(); err != nil {
-					panic(err)
-				}
-				logFlushed.Wait()
-			}()
-
-			logger := helmexec.NewLogger(logWriter, "debug")
 
 			valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
 			if err != nil {
@@ -156,7 +128,7 @@ func TestApply_3(t *testing.T) {
 					}
 				}
 			}
-		}()
+		})
 
 		if tc.log != "" {
 			actual := bs.String()


### PR DESCRIPTION
Use the new runWithLogCapture helper instead of the long boilerplate to capture the log for snapshot testing.
We have a bunch of same boilerplates over many test sources. I'll convert those to use the new helper in follow-up PRs.