### PR TITLE
Enhance `make fmt` to cover running gci for golangci-lint compat

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: Build
       run: make build build-test-tools
     - name: Test
-      run: make check pristine test
+      run: make check test
 
     - name: Prepare tar to upload built binaries
       run: tar -cvf built-binaries.tar helmfile diff-yamls yamldiff

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ generate:
 
 fmt:
 	go fmt ${PKGS}
+	gci write --skip-generated -s standard -s default -s 'prefix(github.com/helmfile/helmfile)' .
 .PHONY: fmt
 
 check:


### PR DESCRIPTION
I have used `make fmt` for formatting code before submitting a pull request. It turned out not to work in some cases where you added a new import because the default go-fmt does not organize imports as the golangci-lint and gci expect.

This fixes that, by adding a gci command to the `make fmt` target.

Please note that this does not cover installing gci. If you need it, please submit another pull request to add something like a `make install-gci` and make the `make fmt` dependent on that target, so that one can get automatic gci installation when running `make fmt` for the first time.