### PR TITLE
Allow running images with users other than root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ LABEL org.opencontainers.image.source https://github.com/helmfile/helmfile
 RUN apk add --no-cache ca-certificates git bash curl jq openssh-client
 
 # Set Helm home variables so that also non-root users can use plugins etc.
-ARG HOME="/root"
+ARG HOME="/helm"
 ENV HOME="${HOME}"
 ARG HELM_CACHE_HOME="${HOME}/.cache/helm"
 ENV HELM_CACHE_HOME="${HELM_CACHE_HOME}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,16 @@ LABEL org.opencontainers.image.source https://github.com/helmfile/helmfile
 
 RUN apk add --no-cache ca-certificates git bash curl jq openssh-client
 
+# Set Helm home variables so that also non-root users can use plugins etc.
+ARG HOME="/root"
+ENV HOME="${HOME}"
+ARG HELM_CACHE_HOME="${HOME}/.cache/helm"
+ENV HELM_CACHE_HOME="${HELM_CACHE_HOME}"
+ARG HELM_CONFIG_HOME="${HOME}/.config/helm"
+ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
+ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
+ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
+
 ARG HELM_VERSION="v3.10.2"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_SHA256="2315941a13291c277dac9f65e75ead56386440d3907e0540bf157ae70f188347"
@@ -74,10 +84,10 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.6.0 
     helm plugin install https://github.com/jkroepke/helm-secrets --version v4.1.1 && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.14.0 && \
     helm plugin install https://github.com/aslafy-z/helm-git.git --version v0.12.0 && \
-    rm -rf /root/.cache/helm/plugins
+    rm -rf ${HELM_CACHE_HOME}/plugins
 
 # Allow users other than root to use helm plugins located in root home
-RUN chmod 751 /root
+RUN chmod 751 ${HOME}
 
 COPY --from=builder /workspace/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
 

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -21,6 +21,16 @@ RUN apt update -qq && \
       git bash curl jq wget openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
+# Set Helm home variables so that also non-root users can use plugins etc.
+ARG HOME="/root"
+ENV HOME="${HOME}"
+ARG HELM_CACHE_HOME="${HOME}/.cache/helm"
+ENV HELM_CACHE_HOME="${HELM_CACHE_HOME}"
+ARG HELM_CONFIG_HOME="${HOME}/.config/helm"
+ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
+ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
+ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
+
 ARG HELM_VERSION="v3.10.2"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_SHA256="2315941a13291c277dac9f65e75ead56386440d3907e0540bf157ae70f188347"
@@ -78,10 +88,10 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.6.0 
     helm plugin install https://github.com/jkroepke/helm-secrets --version v4.1.1 && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.14.0 && \
     helm plugin install https://github.com/aslafy-z/helm-git.git --version v0.12.0 && \
-    rm -rf /root/.cache/helm/plugins
+    rm -rf ${HELM_CACHE_HOME}/plugins
 
 # Allow users other than root to use helm plugins located in root home
-RUN chmod 751 /root
+RUN chmod 751 ${HOME}
 
 COPY --from=builder /workspace/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
 

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -22,7 +22,7 @@ RUN apt update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 # Set Helm home variables so that also non-root users can use plugins etc.
-ARG HOME="/root"
+ARG HOME="/helm"
 ENV HOME="${HOME}"
 ARG HELM_CACHE_HOME="${HOME}/.cache/helm"
 ENV HELM_CACHE_HOME="${HELM_CACHE_HOME}"

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -21,6 +21,16 @@ RUN apt update -qq && \
       git bash curl jq wget openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
+# Set Helm home variables so that also non-root users can use plugins etc.
+ARG HOME="/root"
+ENV HOME="${HOME}"
+ARG HELM_CACHE_HOME="${HOME}/.cache/helm"
+ENV HELM_CACHE_HOME="${HELM_CACHE_HOME}"
+ARG HELM_CONFIG_HOME="${HOME}/.config/helm"
+ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
+ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
+ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
+
 ARG HELM_VERSION="v3.10.2"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_SHA256="2315941a13291c277dac9f65e75ead56386440d3907e0540bf157ae70f188347"
@@ -78,10 +88,10 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.6.0 
     helm plugin install https://github.com/jkroepke/helm-secrets --version v4.1.1 && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.14.0 && \
     helm plugin install https://github.com/aslafy-z/helm-git.git --version v0.12.0 && \
-    rm -rf /root/.cache/helm/plugins
+    rm -rf ${HELM_CACHE_HOME}/plugins
 
 # Allow users other than root to use helm plugins located in root home
-RUN chmod 751 /root
+RUN chmod 751 ${HOME}
 
 COPY --from=builder /workspace/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -22,7 +22,7 @@ RUN apt update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 # Set Helm home variables so that also non-root users can use plugins etc.
-ARG HOME="/root"
+ARG HOME="/helm"
 ENV HOME="${HOME}"
 ARG HELM_CACHE_HOME="${HOME}/.cache/helm"
 ENV HELM_CACHE_HOME="${HELM_CACHE_HOME}"


### PR DESCRIPTION
This PR is the late follow-up for https://github.com/helmfile/helmfile/discussions/296

As already described there, other users than root currently cannot use e.g. the Helm plugins (without setting necessary environment variables) - only chmod'ing the /root dir for other users is not enough.