### PR TITLE
feat: Helmfile V1 mode

### DIFF
--- a/.github/workflows/publish_v1_binaries.yml
+++ b/.github/workflows/publish_v1_binaries.yml
@@ -1,4 +1,4 @@
-name: Publish v0.x Binaries
+name: Publish v1.x Binaries
 
 on:
   push:

--- a/.github/workflows/publish_v1_binaries.yml
+++ b/.github/workflows/publish_v1_binaries.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - "!*"
     tags:
-      - "v0*"
+      - "v1*"
+
+env:
+  # This is referenced from .goreleaser.yml
+  HELMFILE_V1MODE: "true"
 
 jobs:
   goreleaser:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,7 @@
 project_name: helmfile
+env:
+  # We default to non-v1 mode (=helmfile v0.x behavior) when HELMFILE_V1MODE is not set
+  - HELMFILE_V1MODE={{ if index .Env "HELMFILE_V1MODE"  }}{{ .Env.HELMFILE_V1MODE }}{{ else }}false{{ end }}
 builds:
   - id: helmfile
     main: .
@@ -11,6 +14,7 @@ builds:
       - -X go.szostok.io/version.commit={{.FullCommit}}
       - -X go.szostok.io/version.commitDate={{.CommitDate}}
       - -X go.szostok.io/version.dirtyBuild=false
+      - -X github.com/helmfile/helmfile/pkg/runtime.v1Mode={{.Env.HELMFILE_V1MODE}}
     goos:
       - darwin
       - linux

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ build:
 	go build -ldflags="$(GO_BUILD_VERSION_LDFLAGS)" ${TARGETS}
 .PHONY: build
 
+build-v1:
+	go build -ldflags="$(GO_BUILD_VERSION_LDFLAGS) -X github.com/helmfile/helmfile/pkg/runtime.v1Mode=true" ${TARGETS}
+.PHONY: build-v1
+
 generate:
 	go generate ${PKGS}
 .PHONY: generate

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,10 +15,11 @@ import (
 	"github.com/helmfile/helmfile/pkg/envvar"
 	"github.com/helmfile/helmfile/pkg/errors"
 	"github.com/helmfile/helmfile/pkg/helmexec"
+	"github.com/helmfile/helmfile/pkg/runtime"
 )
 
 var logger *zap.SugaredLogger
-var globalUsage = "Declaratively deploy your Kubernetes manifests, Kustomize configs, and Charts as Helm releases in one shot"
+var globalUsage = "Declaratively deploy your Kubernetes manifests, Kustomize configs, and Charts as Helm releases in one shot\n" + runtime.Info()
 
 func toCLIError(g *config.GlobalImpl, err error) error {
 	if err != nil {

--- a/pkg/envvar/const.go
+++ b/pkg/envvar/const.go
@@ -9,4 +9,5 @@ const (
 	TempDir                       = "HELMFILE_TEMPDIR"
 	Helm3                         = "HELMFILE_HELM3"
 	UpgradeNoticeDisabled         = "HELMFILE_UPGRADE_NOTICE_DISABLED"
+	V1Mode                        = "HELMFILE_V1MODE"
 )

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,0 +1,37 @@
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/helmfile/helmfile/pkg/envvar"
+)
+
+// V1Mode is false by default for Helmfile v0.x and
+// true by default for Helmfile v1.x
+var (
+	V1Mode bool
+
+	// We set this via ldflags at build-time so that we can use the
+	// value specified at the build time as the runtime default.
+	v1Mode string
+)
+
+func Info() string {
+	return fmt.Sprintf("V1 mode = %v", V1Mode)
+}
+
+func init() {
+	// You can toggle the V1 mode at runtime via an envvar:
+	// - Helmfile v1.x behaves like v0.x by running it with HELMFILE_V1MODE=false
+	// - Helmfile v0.x behaves like v1.x by with HELMFILE_V1MODE=true
+	switch os.Getenv(envvar.V1Mode) {
+	case "true":
+		V1Mode = true
+	case "false":
+		V1Mode = false
+	default:
+		V1Mode, _ = strconv.ParseBool(v1Mode)
+	}
+}


### PR DESCRIPTION
We add a new "V1 mode" to Helmfile so that you can seemlessly upgrade Helmfile from the current v0.x to the upcoming v1.0.

The idea is that we build both v0 and v1 binaries from the same tagged commit within the main branch, with different defaults for the "V1 mode"- the V1 mode is disabled by default for v0.x binaries, while it is enabled by default for v1.x binaries.

The V1 mode can be overrode at runtime via envvar. That is, even after upgrading the binary to v1, you will not see any backward-incompatible changes while you explicitly set an envvar, `HELMFILE_V1MODE=true`, at runtime.

Signed-off-by: Yusuke Kuoka <ykuoka@gmail.com>