### PR TITLE
Prepare for bringing back go-yaml v2 to Helmfile v0.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/term v0.3.0
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.10.3
 	k8s.io/apimachinery v0.26.0
@@ -206,7 +207,6 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/api v0.25.2 // indirect
 	k8s.io/cli-runtime v0.25.2 // indirect
 	k8s.io/client-go v0.25.2 // indirect

--- a/pkg/maputil/yamlutil.go
+++ b/pkg/maputil/yamlutil.go
@@ -13,6 +13,28 @@ var (
 	GoYamlV3 bool = true
 )
 
+// YamlDecoder creates and returns a function that is used to decode a YAML document
+// contained within the YAML document stream per each call.
+// When strict is true, this function ensures that every field found in the YAML document
+// to have the corresponding field in the decoded Go struct.
+func YamlDecoder(data []byte, strict bool) func(interface{}) error {
+	if GoYamlV3 {
+		decoder := yaml.NewDecoder(bytes.NewReader(data))
+		decoder.KnownFields(strict)
+
+		return func(v interface{}) error {
+			return decoder.Decode(v)
+		}
+	}
+
+	decoder := v2.NewDecoder(bytes.NewReader(data))
+	decoder.SetStrict(strict)
+
+	return func(v interface{}) error {
+		return decoder.Decode(v)
+	}
+}
+
 func YamlMarshal(v interface{}) ([]byte, error) {
 	if GoYamlV3 {
 		var b bytes.Buffer

--- a/pkg/maputil/yamlutil.go
+++ b/pkg/maputil/yamlutil.go
@@ -3,16 +3,27 @@ package maputil
 import (
 	"bytes"
 
+	v2 "gopkg.in/yaml.v2"
 	"gopkg.in/yaml.v3"
 )
 
+var (
+	// We'll derive the default from the build once
+	// is merged
+	GoYamlV3 bool = true
+)
+
 func YamlMarshal(v interface{}) ([]byte, error) {
-	var b bytes.Buffer
-	yamlEncoder := yaml.NewEncoder(&b)
-	yamlEncoder.SetIndent(2)
-	err := yamlEncoder.Encode(v)
-	defer func() {
-		_ = yamlEncoder.Close()
-	}()
-	return b.Bytes(), err
+	if GoYamlV3 {
+		var b bytes.Buffer
+		yamlEncoder := yaml.NewEncoder(&b)
+		yamlEncoder.SetIndent(2)
+		err := yamlEncoder.Encode(v)
+		defer func() {
+			_ = yamlEncoder.Close()
+		}()
+		return b.Bytes(), err
+	}
+
+	return v2.Marshal(v)
 }

--- a/pkg/state/create.go
+++ b/pkg/state/create.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -89,9 +88,7 @@ func (c *StateCreator) Parse(content []byte, baseDir, file string) (*HelmState, 
 
 	state.LockFile = c.lockFile
 
-	decoder := yaml.NewDecoder(bytes.NewReader(content))
-
-	decoder.KnownFields(c.Strict)
+	decode := maputil.YamlDecoder(content, c.Strict)
 
 	i := 0
 	for {
@@ -99,7 +96,7 @@ func (c *StateCreator) Parse(content []byte, baseDir, file string) (*HelmState, 
 
 		var intermediate HelmState
 
-		err := decoder.Decode(&intermediate)
+		err := decode(&intermediate)
 		if err == io.EOF {
 			break
 		} else if err != nil {


### PR DESCRIPTION
This is a preparation or an initial step towards bringing back go-yaml v2 for Helmfile v0.x to retain pre-v0.147.0 behavior while keeping the go-yaml v3 behavior for the upcoming Helmfile v1.x.

Merging this pull request doesn't immediately make Helmfile use go-yaml v2. Merging this doesn't break anything.

Ref #435