### PR TITLE
feat: Add missingFileHandlerConfig.ignoreMissingGitBranch

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -236,6 +236,10 @@ releases:
     version: ~1.24.1                       # the semver of the chart. range constraint is supported
     condition: vault.enabled               # The values lookup key for filtering releases. Corresponds to the boolean value of `vault.enabled`, where `vault` is an arbitrary value
     missingFileHandler: Warn # set to either "Error" or "Warn". "Error" instructs helmfile to fail when unable to find a values or secrets file. When "Warn", it prints the file and continues.
+    missingFileHandlerConfig:
+      # Ignores missing git branch error so that the Debug/Info/Warn handler can treat a missing branch as non-error.
+      # See https://github.com/helmfile/helmfile/issues/392
+      ignoreMissingGitBranch: true
     # Values files used for rendering the chart
     values:
       # Value files passed via --values
@@ -400,6 +404,10 @@ environments:
     # Use "Warn", "Info", or "Debug" if you want helmfile to not fail when a values file is missing, while just leaving
     # a message about the missing file at the log-level.
     missingFileHandler: Error
+    missingFileHandlerConfig:
+      # Ignores missing git branch error so that the Debug/Info/Warn handler can treat a missing branch as non-error.
+      # See https://github.com/helmfile/helmfile/issues/392
+      ignoreMissingGitBranch: true
     # kubeContext to use for this environment
     kubeContext: kube-context
 

--- a/pkg/state/create.go
+++ b/pkg/state/create.go
@@ -227,7 +227,7 @@ func (c *StateCreator) loadEnvValues(st *HelmState, name string, failOnMissingEn
 		if len(envSpec.Secrets) > 0 {
 			var envSecretFiles []string
 			for _, urlOrPath := range envSpec.Secrets {
-				resolved, skipped, err := st.storage().resolveFile(envSpec.MissingFileHandler, "environment values", urlOrPath)
+				resolved, skipped, err := st.storage().resolveFile(envSpec.MissingFileHandler, "environment values", urlOrPath, envSpec.MissingFileHandlerConfig.resolveFileOptions()...)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/state/environment.go
+++ b/pkg/state/environment.go
@@ -13,4 +13,6 @@ type EnvironmentSpec struct {
 	// Use "Warn", "Info", or "Debug" if you want helmfile to not fail when a values file is missing, while just leaving
 	// a message about the missing file at the log-level.
 	MissingFileHandler *string `yaml:"missingFileHandler,omitempty"`
+	// MissingFileHandlerConfig is composed of various settings for the MissingFileHandler
+	MissingFileHandlerConfig MissingFileHandlerConfig `yaml:"missingFileHandlerConfig,omitempty"`
 }


### PR DESCRIPTION
This enables you to specify missingFileHandlerConfig along with the existing missingFileHandler per release and per environment to fine-tune how the missing file handler works.

The first and the only supported setting is `ignoreMissingGitBranch,` which makes the handler treat Git command errors like `pathspec 'develop' did not match any file(s) known to git` as non-errors, so that missing branches are handled same as missing files.

Resolves #392