### PR TITLE
Do not load the legacy default charts.yaml in v1

### DIFF
--- a/docs/proposals/towards-1.0.md
+++ b/docs/proposals/towards-1.0.md
@@ -69,6 +69,8 @@ Note that every breaking change should have an easy alternative way to achieve t
   - This option didn't make much sense in practical. Generally, you'd want to disable all the insecure features altogether to make your deployment secure, or not disable any features. Disabling all is already possible via `HELMFILE_DISABLE_INSECURE_FEATURES `. In addition, `HELMFILE_SKIP_INSECURE_TEMPLATE_FUNCTIONS` literally made every insecure template function to silently skipped without any error or warning, which made debugging unnecessarily hard when the user accidentally used an insecure function.
   - See https://github.com/helmfile/helmfile/pull/564 for more context.
 
+5. Helmfile used to load `helmfile.yaml` or `charts.yaml` when you omitted the `-f` flag. `charts.yaml` has been deprecated for a long time but never been removed. We take v1 as a change to finally remove it.
+
 ## After 1.0
 
 We won't add any backward-incompatible changes while in 1.x, as long as it's inevitable to fix unseen important bug(s).

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -19,6 +19,7 @@ import (
 	"github.com/helmfile/helmfile/pkg/helmexec"
 	"github.com/helmfile/helmfile/pkg/plugins"
 	"github.com/helmfile/helmfile/pkg/remote"
+	"github.com/helmfile/helmfile/pkg/runtime"
 	"github.com/helmfile/helmfile/pkg/state"
 )
 
@@ -1161,8 +1162,8 @@ func (a *App) findDesiredStateFiles(specifiedPath string, opts LoadOpts) ([]stri
 		if a.fs.FileExistsAt(DefaultHelmfile) {
 			defaultFile = DefaultHelmfile
 
-			// TODO: Remove this function once Helmfile v0.x
-		} else if a.fs.FileExistsAt(DeprecatedHelmfile) {
+			// TODO: Remove this block when we remove v0 code
+		} else if !runtime.V1Mode && a.fs.FileExistsAt(DeprecatedHelmfile) {
 			log.Printf(
 				"warn: %s is being loaded: %s is deprecated in favor of %s. See https://github.com/roboll/helmfile/issues/25 for more information",
 				DeprecatedHelmfile,


### PR DESCRIPTION
Helmfile used to load helmfile.yaml or charts.yaml by default. It seems like we intended to remove charts.yaml from the defaults in v1 so this commit adds a condition to let Helmfile load the default charts.yaml only in v0 mode.

Signed-off-by: Yusuke Kuoka <ykuoka@gmail.com>