### PR TITLE
breaking: Fix the inherit feature to support multi-inheritance

### DIFF
--- a/pkg/app/app_template_test.go
+++ b/pkg/app/app_template_test.go
@@ -435,23 +435,23 @@ func TestTemplate_CyclicInheritance(t *testing.T) {
 templates:
   a:
     inherit:
-      template: b
+    - template: b
     values:
     - a.yaml
   b:
     inherit:
-      template: c
+    - template: c
     values:
     - b.yaml
   c:
     inherit:
-      template: a
+    - template: a
     values:
     - c.yaml
 releases:
 - name: app1
   inherit:
-    template: a
+  - template: a
   chart: incubator/raw
 `,
 			}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -213,6 +213,8 @@ type Inherit struct {
 	Except   []string `yaml:"except,omitempty"`
 }
 
+type Inherits []Inherit
+
 // ReleaseSpec defines the structure of a helm release
 type ReleaseSpec struct {
 	// Chart is the name of the chart being installed to create this release
@@ -353,7 +355,22 @@ type ReleaseSpec struct {
 	PostRenderer *string `yaml:"postRenderer,omitempty"`
 
 	// Inherit is used to inherit a release template from a release or another release template
-	Inherit []Inherit `yaml:"inherit,omitempty"`
+	Inherit Inherits `yaml:"inherit,omitempty"`
+}
+
+func (r *Inherits) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var v0151 []Inherit
+	if err := unmarshal(&v0151); err != nil {
+		var v0150 Inherit
+		if err := unmarshal(&v0150); err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "releases[].inherit of map(%+v) has been deprecated and will be removed in v0.152.0. Wrap it into an array: %v\n", v0150, err)
+		*r = []Inherit{v0150}
+		return nil
+	}
+	*r = v0151
+	return nil
 }
 
 // ChartPathOrName returns ChartPath if it is non-empty, and returns Chart otherwise.

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -353,7 +353,7 @@ type ReleaseSpec struct {
 	PostRenderer *string `yaml:"postRenderer,omitempty"`
 
 	// Inherit is used to inherit a release template from a release or another release template
-	Inherit Inherit `yaml:"inherit,omitempty"`
+	Inherit []Inherit `yaml:"inherit,omitempty"`
 }
 
 // ChartPathOrName returns ChartPath if it is non-empty, and returns Chart otherwise.

--- a/pkg/state/temp_test.go
+++ b/pkg/state/temp_test.go
@@ -38,39 +38,39 @@ func TestGenerateID(t *testing.T) {
 	run(testcase{
 		subject: "baseline",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
-		want:    "foo-values-5f85db5d67",
+		want:    "foo-values-7cd4757dfd",
 	})
 
 	run(testcase{
 		subject: "different bytes content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    []byte(`{"k":"v"}`),
-		want:    "foo-values-5bcdd4588",
+		want:    "foo-values-7bb85f848f",
 	})
 
 	run(testcase{
 		subject: "different map content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    map[string]interface{}{"k": "v"},
-		want:    "foo-values-fdc8cb8f4",
+		want:    "foo-values-c57649655",
 	})
 
 	run(testcase{
 		subject: "different chart",
 		release: ReleaseSpec{Name: "foo", Chart: "stable/envoy"},
-		want:    "foo-values-7c79cc5786",
+		want:    "foo-values-bf798c8f",
 	})
 
 	run(testcase{
 		subject: "different name",
 		release: ReleaseSpec{Name: "bar", Chart: "incubator/raw"},
-		want:    "bar-values-588cd594fd",
+		want:    "bar-values-5465f47b4f",
 	})
 
 	run(testcase{
 		subject: "specific ns",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw", Namespace: "myns"},
-		want:    "myns-foo-values-57d85d47b",
+		want:    "myns-foo-values-55f77767f5",
 	})
 
 	for id, n := range ids {

--- a/pkg/state/temp_test.go
+++ b/pkg/state/temp_test.go
@@ -38,39 +38,39 @@ func TestGenerateID(t *testing.T) {
 	run(testcase{
 		subject: "baseline",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
-		want:    "foo-values-5d85cdbb5d",
+		want:    "foo-values-5f85db5d67",
 	})
 
 	run(testcase{
 		subject: "different bytes content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    []byte(`{"k":"v"}`),
-		want:    "foo-values-9548bdcd9",
+		want:    "foo-values-5bcdd4588",
 	})
 
 	run(testcase{
 		subject: "different map content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    map[string]interface{}{"k": "v"},
-		want:    "foo-values-5db884fb87",
+		want:    "foo-values-fdc8cb8f4",
 	})
 
 	run(testcase{
 		subject: "different chart",
 		release: ReleaseSpec{Name: "foo", Chart: "stable/envoy"},
-		want:    "foo-values-6596c997cc",
+		want:    "foo-values-7c79cc5786",
 	})
 
 	run(testcase{
 		subject: "different name",
 		release: ReleaseSpec{Name: "bar", Chart: "incubator/raw"},
-		want:    "bar-values-5ccfd9f8b5",
+		want:    "bar-values-588cd594fd",
 	})
 
 	run(testcase{
 		subject: "specific ns",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw", Namespace: "myns"},
-		want:    "myns-foo-values-bc7cd5b87",
+		want:    "myns-foo-values-57d85d47b",
 	})
 
 	for id, n := range ids {

--- a/test/e2e/template/helmfile/testdata/snapshot/release_template_inheritance/input.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/release_template_inheritance/input.yaml
@@ -17,7 +17,7 @@ templates:
     labels:
       template1: template1
     inherit:
-      template: base
+    - template: base
       except:
       - labels
   template2:
@@ -29,14 +29,14 @@ templates:
     labels:
       template2: template2
     inherit:
-      template: base
+    - template: base
       except:
       - valuesTemplate
 
 releases:
 - name: foo1
   inherit:
-    template: template1
+  - template: template1
   values:
   - templates:
     - |
@@ -49,7 +49,7 @@ releases:
         {{` {{ (unset .Values "templates") | toYaml | nindent 2 }} `}}
 - name: foo2
   inherit:
-    template: template2
+  - template: template2
   values:
   - templates:
     - |


### PR DESCRIPTION
It's only 1 minor release since we introduced `inherit` via #435. Assuming not many folks are using this feature, let me break and complete it earlier so that we are fully prepared to Helmfile v1 without leaving any tech debt.

This enhances `inherit` to support multi-inheritance:

BEFORE:

```
releases:
- name: myapp
  inherit:
    template: foo
```

```
releases:
- name: myapp
  <<: [*foo, *bar]
```

AFTER:

```
releases:
- name: myapp
  inherit:
  - template: foo
  - template: bar
```

This enhancement should allow folks relying on the YAML 1.1's `<<: [*foo, *bar]` syntax to migrate to the new `inherit` feature before upgrading to Helmfile v1 (or the v0's v1 mode).

The merge-key yaml syntax is born to deprecate and is no longer present in YAML 1.2.

Helmfile v1 is going to support YAML 1.2 only so we need this before v1 to enable folks to migrate way from the deprecated YAML syntax in favor of the new `inherit` feature.

Follow-up for #435
Addresses https://github.com/helmfile/helmfile/discussions/656#discussioncomment-4877360 towards Helmfile v1

Signed-off-by: Yusuke Kuoka <ykuoka@gmail.com>