### PR TITLE
Use goccy/go-yaml fork to not break dynamic values on helmfile v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,8 @@ require (
 
 replace gopkg.in/yaml.v3 => github.com/colega/go-yaml-yaml v0.0.0-20220720070545-aaba007ebc22
 
+replace github.com/goccy/go-yaml => github.com/helmfile/go-yaml v0.0.0-20230206025945-259d2ed450ae
+
 require (
 	cloud.google.com/go v0.102.1 // indirect
 	cloud.google.com/go/compute v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -328,8 +328,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
 github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
-github.com/goccy/go-yaml v1.9.8 h1:5gMyLUeU1/6zl+WFfR1hN7D2kf+1/eRGa7DFtToiBvQ=
-github.com/goccy/go-yaml v1.9.8/go.mod h1:JubOolP3gh0HpiBc4BLRD4YmjEjHAmIIB2aaXKkTfoE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -520,6 +518,8 @@ github.com/hashicorp/vault/sdk v0.1.14-0.20200215224050-f6547fa8e820 h1:TmDZ1sS6
 github.com/hashicorp/vault/sdk v0.1.14-0.20200215224050-f6547fa8e820/go.mod h1:WX57W2PwkrOPQ6rVQk+dy5/htHIaB4aBM70EwKThu10=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/helmfile/go-yaml v0.0.0-20230206025945-259d2ed450ae h1:7A1UNvxMfzQWGTEKKfj3k+m4Vjfd+PZnZkCs9iL7o/U=
+github.com/helmfile/go-yaml v0.0.0-20230206025945-259d2ed450ae/go.mod h1:JubOolP3gh0HpiBc4BLRD4YmjEjHAmIIB2aaXKkTfoE=
 github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
 github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=

--- a/pkg/yaml/yaml_test.go
+++ b/pkg/yaml/yaml_test.go
@@ -20,8 +20,9 @@ func testYamlMarshal(t *testing.T, goccyGoYaml bool) {
 	tests := []struct {
 		Name string `yaml:"name"`
 		Info []struct {
-			Age     int    `yaml:"age"`
-			Address string `yaml:"address"`
+			Age        int    `yaml:"age"`
+			Address    string `yaml:"address"`
+			Annotation string `yaml:"annotation"`
 		} `yaml:"info"`
 
 		expected string
@@ -29,10 +30,18 @@ func testYamlMarshal(t *testing.T, goccyGoYaml bool) {
 		{
 			Name: "John",
 			Info: []struct {
-				Age     int    `yaml:"age"`
-				Address string `yaml:"address"`
-			}{{Age: 20, Address: "New York"}},
-			expected: "name: John\ninfo:\n- age: 20\n  address: New York\n",
+				Age        int    `yaml:"age"`
+				Address    string `yaml:"address"`
+				Annotation string `yaml:"annotation"`
+			}{{
+				Age:     20,
+				Address: "New York",
+				// See:
+				// - https://github.com/helmfile/helmfile/discussions/656
+				// - https://github.com/helmfile/helmfile/pull/675
+				Annotation: "on",
+			}},
+			expected: "name: John\ninfo:\n- age: 20\n  address: New York\n  annotation: \"on\"\n",
 		},
 	}
 


### PR DESCRIPTION
I forked goccy/go-yaml to https://github.com/helmfile/go-yaml and added a commit https://github.com/helmfile/go-yaml/commit/259d2ed450aed2aa1d6f05139f99a8b01f87633a to let it produce YAML data compatible with other legacy YAML parsers that do not support YAML 1.2.

Ref https://github.com/helmfile/helmfile/discussions/656

Signed-off-by: Yusuke Kuoka <ykuoka@gmail.com>