### PR TITLE
fix: Make the forbid-env-with-releases policy strict on v1

### DIFF
--- a/pkg/policy/checker.go
+++ b/pkg/policy/checker.go
@@ -3,6 +3,8 @@ package policy
 
 import (
 	"errors"
+
+	"github.com/helmfile/helmfile/pkg/runtime"
 )
 
 var (
@@ -17,7 +19,7 @@ func forbidEnvironmentsWithReleases(releaseState map[string]interface{}) (bool, 
 	_, hasEnvironments := releaseState["environments"]
 	_, hasReleases := releaseState["releases"]
 	if hasEnvironments && hasReleases {
-		return false, EnvironmentsAndReleasesWithinSameYamlPartErr
+		return runtime.V1Mode, EnvironmentsAndReleasesWithinSameYamlPartErr
 	}
 	return false, nil
 }


### PR DESCRIPTION
Currently, both v0 and v1 warns any usage of environments with releases within the same helmfile part.

It should rather be an error for v1, as proposed in https://github.com/helmfile/helmfile/blob/main/docs/proposals/towards-1.0.md#forbid-the-use-of-environments-and-releases-within-a-single-helmfileyaml-part.

Follow-up for #592

Signed-off-by: Yusuke Kuoka <ykuoka@gmail.com>