### PR TITLE
fix: repos command help message

### DIFF
--- a/cmd/repos.go
+++ b/cmd/repos.go
@@ -13,7 +13,7 @@ func NewReposCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "repos",
-		Short: "Repos releases defined in state file",
+		Short: "Add chart repositories defined in state file",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reposImpl := config.NewReposImpl(globalCfg, reposOptions)
 			err := config.NewCLIConfigImpl(reposImpl.GlobalImpl)

--- a/docs/index.md
+++ b/docs/index.md
@@ -522,7 +522,7 @@ Available Commands:
   init         Initialize the helmfile, includes version checking and installation of helm and plug-ins
   lint         Lint charts from state file (helm lint)
   list         List releases defined in state file
-  repos        Repos releases defined in state file
+  repos        Add chart repositories defined in state file
   status       Retrieve status of releases in state file
   sync         Sync releases defined in state file
   template     Template releases defined in state file


### PR DESCRIPTION
I do not change any logic of helmfile and only fix help message of `helmfile repos` command.

The help message was unclear, so I rewrote it as follows.
```
before: 
    repos        Repos releases defined in state file

after:
    repos        Add chart repositories defined in state file
```

Help message of `helm repo add` command, "add a chart repository" is used as a reference.