### PR TITLE
Use Masterminds/semver/v3 instead of hashicorp/go-version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/gosuri/uitable v0.0.4
 	github.com/hashicorp/go-getter v1.7.0
-	github.com/hashicorp/go-version v1.6.0
 	github.com/helmfile/vals v0.22.0
 	github.com/imdario/mergo v0.3.13
 	github.com/spf13/cobra v1.6.1
@@ -172,6 +171,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f // indirect
 	github.com/howeyc/gopass v0.0.0-20190910152052-7cb4b85ec19c // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/pkg/state/chart_dependency.go
+++ b/pkg/state/chart_dependency.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	goversion "github.com/hashicorp/go-version"
 	"go.uber.org/zap"
 
 	"github.com/helmfile/helmfile/pkg/app/version"
@@ -384,13 +383,13 @@ func (m *chartDependencyManager) Resolve(unresolved *UnresolvedDependencies) (*R
 
 	// Make sure go run main.go works and compatible with old lock files.
 	if version.Version() != "" && lockedReqs.Version != "" {
-		lockedVersion, err := goversion.NewVersion(lockedReqs.Version)
+		lockedVersion, err := semver.NewVersion(lockedReqs.Version)
 
 		if err != nil {
 			return nil, false, err
 		}
 
-		currentVersion, err := goversion.NewVersion(version.Version())
+		currentVersion, err := semver.NewVersion(version.Version())
 
 		if err != nil {
 			return nil, false, err


### PR DESCRIPTION
go-version still exists in indirect because go-getter depends on it.