### PR TITLE
clean: optimize postrenderer code

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1413,7 +1413,6 @@ Do you really want to apply?
 		}
 
 		r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
-		r.helm.SetPostRenderer(c.PostRenderer())
 
 		// We deleted releases by traversing the DAG in reverse order
 		if len(releasesToBeDeleted) > 0 {
@@ -1569,7 +1568,6 @@ func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) 
 		helm := r.helm
 
 		helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
-		helm.SetPostRenderer(c.PostRenderer())
 
 		var errs []error
 
@@ -1799,7 +1797,6 @@ Do you really want to sync?
 	var errs []error
 
 	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
-	r.helm.SetPostRenderer(c.PostRenderer())
 
 	// Traverse DAG of all the releases so that we don't suffer from false-positive missing dependencies
 	st.Releases = selectedAndNeededReleases
@@ -1873,8 +1870,6 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 		if len(args) > 0 {
 			helm.SetExtraArgs(args...)
 		}
-
-		helm.SetPostRenderer(c.PostRenderer())
 
 		opts := &state.TemplateOpts{
 			Set:               c.Set(),

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1347,6 +1347,7 @@ func (a *App) apply(r *Run, c ApplyConfigProvider) (bool, bool, []error) {
 		SkipDiffOnInstall: c.SkipDiffOnInstall(),
 		ReuseValues:       c.ReuseValues(),
 		ResetValues:       c.ResetValues(),
+		PostRenderer:      c.PostRenderer(),
 	}
 
 	infoMsg, releasesToBeUpdated, releasesToBeDeleted, errs := r.diff(false, detailedExitCode, c, diffOpts)
@@ -1451,13 +1452,14 @@ Do you really want to apply?
 				subst.Releases = rs
 
 				syncOpts := &state.SyncOpts{
-					Set:         c.Set(),
-					SkipCleanup: c.RetainValuesFiles() || c.SkipCleanup(),
-					SkipCRDs:    c.SkipCRDs(),
-					Wait:        c.Wait(),
-					WaitForJobs: c.WaitForJobs(),
-					ReuseValues: c.ReuseValues(),
-					ResetValues: c.ResetValues(),
+					Set:          c.Set(),
+					SkipCleanup:  c.RetainValuesFiles() || c.SkipCleanup(),
+					SkipCRDs:     c.SkipCRDs(),
+					Wait:         c.Wait(),
+					WaitForJobs:  c.WaitForJobs(),
+					ReuseValues:  c.ReuseValues(),
+					ResetValues:  c.ResetValues(),
+					PostRenderer: c.PostRenderer(),
 				}
 				return subst.SyncReleases(&affectedReleases, helm, c.Values(), c.Concurrency(), syncOpts)
 			}))
@@ -1580,6 +1582,7 @@ func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) 
 			SkipDiffOnInstall: c.SkipDiffOnInstall(),
 			ReuseValues:       c.ReuseValues(),
 			ResetValues:       c.ResetValues(),
+			PostRenderer:      c.PostRenderer(),
 		}
 
 		filtered := &Run{
@@ -1839,12 +1842,13 @@ Do you really want to sync?
 				subst.Releases = rs
 
 				opts := &state.SyncOpts{
-					Set:         c.Set(),
-					SkipCRDs:    c.SkipCRDs(),
-					Wait:        c.Wait(),
-					WaitForJobs: c.WaitForJobs(),
-					ReuseValues: c.ReuseValues(),
-					ResetValues: c.ResetValues(),
+					Set:          c.Set(),
+					SkipCRDs:     c.SkipCRDs(),
+					Wait:         c.Wait(),
+					WaitForJobs:  c.WaitForJobs(),
+					ReuseValues:  c.ReuseValues(),
+					ResetValues:  c.ResetValues(),
+					PostRenderer: c.PostRenderer(),
 				}
 				return subst.SyncReleases(&affectedReleases, helm, c.Values(), c.Concurrency(), opts)
 			}))

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1881,6 +1881,7 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 			OutputDirTemplate: c.OutputDirTemplate(),
 			SkipCleanup:       c.SkipCleanup(),
 			SkipTests:         c.SkipTests(),
+			PostRenderer:      c.PostRenderer(),
 		}
 		return st.TemplateReleases(helm, c.OutputDir(), c.Values(), args, c.Concurrency(), c.Validate(), opts)
 	})

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2439,15 +2439,13 @@ func (helm *mockHelmExec) BuildDeps(name, chart string, flags ...string) error {
 
 func (helm *mockHelmExec) SetExtraArgs(args ...string) {
 }
+
 func (helm *mockHelmExec) SetHelmBinary(bin string) {
 }
+
 func (helm *mockHelmExec) SetEnableLiveOutput(enableLiveOutput bool) {
 }
-func (helm *mockHelmExec) SetPostRenderer(postRenderer string) {
-}
-func (helm *mockHelmExec) GetPostRenderer() string {
-	return ""
-}
+
 func (helm *mockHelmExec) AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string, passCredentials string, skipTLSVerify string) error {
 	helm.repos = append(helm.repos, mockRepo{Name: name})
 	return nil

--- a/pkg/app/mocks_test.go
+++ b/pkg/app/mocks_test.go
@@ -53,11 +53,6 @@ func (helm *noCallHelmExec) SetHelmBinary(bin string) {
 func (helm *noCallHelmExec) SetEnableLiveOutput(enableLiveOutput bool) {
 	helm.doPanic()
 }
-func (helm *noCallHelmExec) SetPostRenderer(postRenderer string) {
-}
-func (helm *noCallHelmExec) GetPostRenderer() string {
-	return ""
-}
 
 func (helm *noCallHelmExec) AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string, passCredentials string, skipTLSVerify string) error {
 	helm.doPanic()

--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -92,11 +92,6 @@ func (helm *Helm) SetHelmBinary(bin string) {
 }
 func (helm *Helm) SetEnableLiveOutput(enableLiveOutput bool) {
 }
-func (helm *Helm) SetPostRenderer(postRenderer string) {
-}
-func (helm *Helm) GetPostRenderer() string {
-	return ""
-}
 func (helm *Helm) AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string, passCredentials string, skipTLSVerify string) error {
 	helm.Repo = []string{name, repository, cafile, certfile, keyfile, username, password, managed, passCredentials, skipTLSVerify}
 	return nil

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -35,7 +35,6 @@ type execer struct {
 	logger               *zap.SugaredLogger
 	kubeContext          string
 	extra                []string
-	postRenderer         string
 	decryptedSecretMutex sync.Mutex
 	decryptedSecrets     map[string]*decryptedSecret
 	writeTempFile        func([]byte) (string, error)
@@ -134,14 +133,6 @@ func (helm *execer) SetHelmBinary(bin string) {
 
 func (helm *execer) SetEnableLiveOutput(enableLiveOutput bool) {
 	helm.enableLiveOutput = enableLiveOutput
-}
-
-func (helm *execer) SetPostRenderer(postRenderer string) {
-	helm.postRenderer = postRenderer
-}
-
-func (helm *execer) GetPostRenderer() string {
-	return helm.postRenderer
 }
 
 func (helm *execer) AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string, passCredentials string, skipTLSVerify string) error {

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -89,30 +89,6 @@ func Test_SetEnableLiveOutput(t *testing.T) {
 	}
 }
 
-func Test_SetPostRenderer(t *testing.T) {
-	helm := MockExecer(NewLogger(os.Stdout, "info"), "dev")
-	if helm.enableLiveOutput {
-		t.Error("helmexec.enableLiveOutput should not be enabled by default")
-	}
-	postRendererFoo := "/bin/rewrite-repo.sh"
-	helm.SetPostRenderer(postRendererFoo)
-	if helm.postRenderer != postRendererFoo {
-		t.Errorf("helmexec.SetPostRenderer() - actual = %s expect = %s", helm.postRenderer, postRendererFoo)
-	}
-}
-
-func Test_GetPostRenderer(t *testing.T) {
-	helm := MockExecer(NewLogger(os.Stdout, "info"), "dev")
-	if helm.enableLiveOutput {
-		t.Error("helmexec.enableLiveOutput should not be enabled by default")
-	}
-	postRendererFoo := "/bin/rewrite-repo.sh"
-	helm.SetPostRenderer(postRendererFoo)
-	if helm.GetPostRenderer() != postRendererFoo {
-		t.Errorf("helmexec.GetPostRenderer() - actual = %s expect = %s", helm.GetPostRenderer(), postRendererFoo)
-	}
-}
-
 func Test_AddRepo_Helm_3_3_2(t *testing.T) {
 	var buffer bytes.Buffer
 	logger := NewLogger(&buffer, "debug")

--- a/pkg/helmexec/helmexec.go
+++ b/pkg/helmexec/helmexec.go
@@ -14,8 +14,6 @@ type Interface interface {
 	SetExtraArgs(args ...string)
 	SetHelmBinary(bin string)
 	SetEnableLiveOutput(enableLiveOutput bool)
-	SetPostRenderer(postRenderer string)
-	GetPostRenderer() string
 
 	AddRepo(name, repository, cafile, certfile, keyfile, username, password string, managed string, passCredentials string, skipTLSVerify string) error
 	UpdateRepo() error

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -26,13 +26,13 @@ func (st *HelmState) appendHelmXFlags(flags []string, release *ReleaseSpec) []st
 }
 
 // append post-renderer flags to helm flags
-func (st *HelmState) appendPostRenderFlags(flags []string, release *ReleaseSpec, helm helmexec.Interface) []string {
+func (st *HelmState) appendPostRenderFlags(flags []string, release *ReleaseSpec, postRenderer string) []string {
 	switch {
-	// helm.GetPostRenderer() comes from cmd flag.
+	// postRenderer arg comes from cmd flag.
 	case release.PostRenderer != nil && *release.PostRenderer != "":
 		flags = append(flags, "--post-renderer", *release.PostRenderer)
-	case helm.GetPostRenderer() != "":
-		flags = append(flags, "--post-renderer", helm.GetPostRenderer())
+	case postRenderer != "":
+		flags = append(flags, "--post-renderer", postRenderer)
 	case st.HelmDefaults.PostRenderer != nil && *st.HelmDefaults.PostRenderer != "":
 		flags = append(flags, "--post-renderer", *st.HelmDefaults.PostRenderer)
 	}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2506,7 +2506,9 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 
 	flags = st.appendHelmXFlags(flags, release)
 
-	flags = st.appendPostRenderFlags(flags, release, opt.postRenderer)
+	if opt != nil {
+		flags = st.appendPostRenderFlags(flags, release, opt.postRenderer)
+	}
 
 	common, clean, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {
@@ -2524,7 +2526,9 @@ func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseS
 
 	flags = st.appendApiVersionsFlags(flags, release)
 
-	flags = st.appendPostRenderFlags(flags, release, opt.PostRenderer)
+	if opt != nil {
+		flags = st.appendPostRenderFlags(flags, release, opt.PostRenderer)
+	}
 
 	common, files, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {
@@ -2563,7 +2567,9 @@ func (st *HelmState) flagsForDiff(helm helmexec.Interface, release *ReleaseSpec,
 
 	flags = st.appendHelmXFlags(flags, release)
 
-	flags = st.appendPostRenderFlags(flags, release, opt.PostRenderer)
+	if opt != nil {
+		flags = st.appendPostRenderFlags(flags, release, opt.PostRenderer)
+	}
 
 	common, files, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -719,7 +719,7 @@ type SyncOpts struct {
 	WaitForJobs  bool
 	ReuseValues  bool
 	ResetValues  bool
-	postRenderer string
+	PostRenderer string
 }
 
 type SyncOpt interface{ Apply(*SyncOpts) }
@@ -2507,7 +2507,7 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 	flags = st.appendHelmXFlags(flags, release)
 
 	if opt != nil {
-		flags = st.appendPostRenderFlags(flags, release, opt.postRenderer)
+		flags = st.appendPostRenderFlags(flags, release, opt.PostRenderer)
 	}
 
 	common, clean, err := st.namespaceAndValuesFlags(helm, release, workerIndex)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2506,9 +2506,11 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 
 	flags = st.appendHelmXFlags(flags, release)
 
+	postRenderer := ""
 	if opt != nil {
-		flags = st.appendPostRenderFlags(flags, release, opt.PostRenderer)
+		postRenderer = opt.PostRenderer
 	}
+	flags = st.appendPostRenderFlags(flags, release, postRenderer)
 
 	common, clean, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {
@@ -2526,9 +2528,11 @@ func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseS
 
 	flags = st.appendApiVersionsFlags(flags, release)
 
+	postRenderer := ""
 	if opt != nil {
-		flags = st.appendPostRenderFlags(flags, release, opt.PostRenderer)
+		postRenderer = opt.PostRenderer
 	}
+	flags = st.appendPostRenderFlags(flags, release, postRenderer)
 
 	common, files, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {
@@ -2567,9 +2571,11 @@ func (st *HelmState) flagsForDiff(helm helmexec.Interface, release *ReleaseSpec,
 
 	flags = st.appendHelmXFlags(flags, release)
 
+	postRenderer := ""
 	if opt != nil {
-		flags = st.appendPostRenderFlags(flags, release, opt.PostRenderer)
+		postRenderer = opt.PostRenderer
 	}
+	flags = st.appendPostRenderFlags(flags, release, postRenderer)
 
 	common, files, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -598,7 +598,7 @@ func (st *HelmState) prepareSyncReleases(helm helmexec.Interface, additionalValu
 				// TODO We need a long-term fix for this :)
 				// See https://github.com/roboll/helmfile/issues/737
 				mut.Lock()
-				flags, files, flagsErr := st.flagsForUpgrade(helm, release, workerIndex)
+				flags, files, flagsErr := st.flagsForUpgrade(helm, release, workerIndex, opts)
 				mut.Unlock()
 				if flagsErr != nil {
 					results <- syncPrepareResult{errors: []*ReleaseError{newReleaseFailedError(release, flagsErr)}, files: files}
@@ -712,13 +712,14 @@ func (st *HelmState) DetectReleasesToBeDeleted(helm helmexec.Interface, releases
 }
 
 type SyncOpts struct {
-	Set         []string
-	SkipCleanup bool
-	SkipCRDs    bool
-	Wait        bool
-	WaitForJobs bool
-	ReuseValues bool
-	ResetValues bool
+	Set          []string
+	SkipCleanup  bool
+	SkipCRDs     bool
+	Wait         bool
+	WaitForJobs  bool
+	ReuseValues  bool
+	ResetValues  bool
+	postRenderer string
 }
 
 type SyncOpt interface{ Apply(*SyncOpts) }
@@ -1370,6 +1371,7 @@ type TemplateOpts struct {
 	OutputDirTemplate string
 	IncludeCRDs       bool
 	SkipTests         bool
+	PostRenderer      string
 }
 
 type TemplateOpt interface{ Apply(*TemplateOpts) }
@@ -1397,7 +1399,7 @@ func (st *HelmState) TemplateReleases(helm helmexec.Interface, outputDir string,
 
 		st.ApplyOverrides(release)
 
-		flags, files, err := st.flagsForTemplate(helm, release, 0)
+		flags, files, err := st.flagsForTemplate(helm, release, 0, opts)
 
 		if !opts.SkipCleanup {
 			defer st.removeFiles(files)
@@ -1787,7 +1789,7 @@ func (st *HelmState) prepareDiffReleases(helm helmexec.Interface, additionalValu
 				// TODO We need a long-term fix for this :)
 				// See https://github.com/roboll/helmfile/issues/737
 				mut.Lock()
-				flags, files, err := st.flagsForDiff(helm, release, disableValidation, workerIndex)
+				flags, files, err := st.flagsForDiff(helm, release, disableValidation, workerIndex, opt)
 				mut.Unlock()
 				if err != nil {
 					errs = append(errs, err)
@@ -1878,6 +1880,7 @@ type DiffOpts struct {
 	SkipDiffOnInstall bool
 	ReuseValues       bool
 	ResetValues       bool
+	PostRenderer      string
 }
 
 func (o *DiffOpts) Apply(opts *DiffOpts) {
@@ -2451,7 +2454,7 @@ func (st *HelmState) timeoutFlags(release *ReleaseSpec) []string {
 	return flags
 }
 
-func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSpec, workerIndex int) ([]string, []string, error) {
+func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSpec, workerIndex int, opt *SyncOpts) ([]string, []string, error) {
 	flags := st.chartVersionFlags(release)
 
 	if release.Verify != nil && *release.Verify || release.Verify == nil && st.HelmDefaults.Verify {
@@ -2503,7 +2506,7 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 
 	flags = st.appendHelmXFlags(flags, release)
 
-	flags = st.appendPostRenderFlags(flags, release, helm)
+	flags = st.appendPostRenderFlags(flags, release, opt.postRenderer)
 
 	common, clean, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {
@@ -2512,7 +2515,7 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 	return append(flags, common...), clean, nil
 }
 
-func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseSpec, workerIndex int) ([]string, []string, error) {
+func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseSpec, workerIndex int, opt *TemplateOpts) ([]string, []string, error) {
 	var flags []string
 
 	flags = st.chartVersionFlags(release)
@@ -2521,7 +2524,7 @@ func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseS
 
 	flags = st.appendApiVersionsFlags(flags, release)
 
-	flags = st.appendPostRenderFlags(flags, release, helm)
+	flags = st.appendPostRenderFlags(flags, release, opt.PostRenderer)
 
 	common, files, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {
@@ -2530,7 +2533,7 @@ func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseS
 	return append(flags, common...), files, nil
 }
 
-func (st *HelmState) flagsForDiff(helm helmexec.Interface, release *ReleaseSpec, disableValidation bool, workerIndex int) ([]string, []string, error) {
+func (st *HelmState) flagsForDiff(helm helmexec.Interface, release *ReleaseSpec, disableValidation bool, workerIndex int, opt *DiffOpts) ([]string, []string, error) {
 	flags := st.chartVersionFlags(release)
 
 	disableOpenAPIValidation := false
@@ -2560,7 +2563,7 @@ func (st *HelmState) flagsForDiff(helm helmexec.Interface, release *ReleaseSpec,
 
 	flags = st.appendHelmXFlags(flags, release)
 
-	flags = st.appendPostRenderFlags(flags, release, helm)
+	flags = st.appendPostRenderFlags(flags, release, opt.PostRenderer)
 
 	common, files, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -715,7 +715,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 				Version: tt.version,
 			}
 
-			args, _, err := state.flagsForUpgrade(helm, tt.release, 0)
+			args, _, err := state.flagsForUpgrade(helm, tt.release, 0, nil)
 			if err != nil && tt.wantErr == "" {
 				t.Errorf("unexpected error flagsForUpgrade: %v", err)
 			}
@@ -827,7 +827,7 @@ func TestHelmState_flagsForTemplate(t *testing.T) {
 				Version: tt.version,
 			}
 
-			args, _, err := state.flagsForTemplate(helm, tt.release, 0)
+			args, _, err := state.flagsForTemplate(helm, tt.release, 0, &TemplateOpts{})
 			if err != nil && tt.wantErr == "" {
 				t.Errorf("unexpected error flagsForUpgrade: %v", err)
 			}
@@ -1812,7 +1812,7 @@ func TestHelmState_DiffFlags(t *testing.T) {
 				RenderedValues: map[string]interface{}{},
 			}
 			for j := range tt.releases {
-				flags, _, errs := state.flagsForDiff(tt.helm, &tt.releases[j], false, 1)
+				flags, _, errs := state.flagsForDiff(tt.helm, &tt.releases[j], false, 1, nil)
 				if errs != nil {
 					t.Errorf("unexpected error: %v", errs)
 				}


### PR DESCRIPTION
clean: optimize postrenderer code


it makes more sense that move postrenderer to `diffopts` `syncopts` and `applyopsts`