### PR TITLE
Documentation updated about kubeVersion field

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -438,9 +438,9 @@ bases:
 apiVersions:
 - example/v1
 
-# DEPRECATED: This is available only on Helm 2, which has been EOL since 2020
-# Configure a Kubernetes version to  pass to 'helm template' via the --kube-version flag:
-# See https://github.com/roboll/helmfile/pull/2002 for more information.
+# Set the kubeVersion to render the chart with your desired Kubernetes version.
+# The flag --kube-version was deprecated in helm v3 but it was added again.
+# For further information https://github.com/helm/helm/issues/7326
 kubeVersion: v1.21
 ```
 


### PR DESCRIPTION
Resolves #722 

We have agreed to modify the doc since it looks a better solution than deprecate the kubeVersion field in the helmfile.yaml file.