### PR TITLE
Build correct arch for container image

### DIFF
--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.20-alpine as builder
 
 RUN apk add --no-cache make git
 WORKDIR /workspace/helmfile
@@ -7,11 +7,12 @@ COPY go.mod go.sum /workspace/helmfile/
 RUN go mod download
 
 COPY . /workspace/helmfile
-RUN make static-linux
+ARG TARGETARCH
+RUN make static-linux-${TARGETARCH}
 
 # -----------------------------------------------------------------------------
 
-FROM debian:stable-slim
+FROM --platform=$BUILDPLATFORM debian:stable-slim
 
 LABEL org.opencontainers.image.source https://github.com/helmfile/helmfile
 
@@ -94,6 +95,7 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.6.0 
 # Allow users other than root to use helm plugins located in root home
 RUN chmod 751 ${HOME}
 
-COPY --from=builder /workspace/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
+ARG TARGETARCH
+COPY --from=builder /workspace/helmfile/dist/helmfile_linux_${TARGETARCH} /usr/local/bin/helmfile
 
 CMD ["/usr/local/bin/helmfile"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.20-alpine as builder
 
 RUN apk add --no-cache make git
 WORKDIR /workspace/helmfile
@@ -7,11 +7,12 @@ COPY go.mod go.sum /workspace/helmfile/
 RUN go mod download
 
 COPY . /workspace/helmfile
-RUN make static-linux
+ARG TARGETARCH
+RUN make static-linux-${TARGETARCH}
 
 # -----------------------------------------------------------------------------
 
-FROM ubuntu:20.04
+FROM --platform=$BUILDPLATFORM ubuntu:20.04
 
 LABEL org.opencontainers.image.source https://github.com/helmfile/helmfile
 
@@ -94,6 +95,7 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.6.0 
 # Allow users other than root to use helm plugins located in root home
 RUN chmod 751 ${HOME}
 
-COPY --from=builder /workspace/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
+ARG TARGETARCH
+COPY --from=builder /workspace/helmfile/dist/helmfile_linux_${TARGETARCH} /usr/local/bin/helmfile
 
 CMD ["/usr/local/bin/helmfile"]

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,14 @@ static-linux:
 	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS=-mod=readonly go build -o "dist/helmfile_linux_amd64" -ldflags="$(GO_BUILD_VERSION_LDFLAGS)" ${TARGETS}
 .PHONY: static-linux
 
+static-linux-amd64:
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS=-mod=readonly go build -o "dist/helmfile_linux_amd64" -ldflags="$(GO_BUILD_VERSION_LDFLAGS)" ${TARGETS}
+.PHONY: static-linux-amd64
+
+static-linux-arm64:
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GOFLAGS=-mod=readonly go build -o "dist/helmfile_linux_arm64" -ldflags="$(GO_BUILD_VERSION_LDFLAGS)" ${TARGETS}
+.PHONY: static-linux-arm64
+
 install:
 	env CGO_ENABLED=0 go install -ldflags="$(GO_BUILD_VERSION_LDFLAGS)" ${TARGETS}
 .PHONY: install


### PR DESCRIPTION
Fixes #816 by building the correct helmfile binary for each arch.

Makes use of automatic platform ARGs that BuildKit has https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope