### PR TITLE
Fix depedency binaries for arm64 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ COPY go.mod go.sum /workspace/helmfile/
 RUN go mod download
 
 COPY . /workspace/helmfile
-ARG TARGETARCH
-RUN make static-linux-${TARGETARCH}
+ARG TARGETARCH TARGETOS
+RUN make static-${TARGETOS}-${TARGETARCH}
 
 # -----------------------------------------------------------------------------
 
@@ -17,6 +17,8 @@ FROM --platform=$BUILDPLATFORM alpine:3.16
 LABEL org.opencontainers.image.source https://github.com/helmfile/helmfile
 
 RUN apk add --no-cache ca-certificates git bash curl jq openssh-client gnupg
+
+ARG TARGETARCH TARGETOS TARGETPLATFORM
 
 # Set Helm home variables so that also non-root users can use plugins etc.
 ARG HOME="/helm"
@@ -30,15 +32,18 @@ ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
 ARG HELM_VERSION="v3.11.3"
 ENV HELM_VERSION="${HELM_VERSION}"
-ARG HELM_SHA256="ca2d5d40d4cdfb9a3a6205dd803b5bc8def00bd2f13e5526c127e9b667974a89"
 ARG HELM_LOCATION="https://get.helm.sh"
-ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
+ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
 RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
+    case ${TARGETPLATFORM} in \
+         "linux/amd64")  HELM_SHA256="ca2d5d40d4cdfb9a3a6205dd803b5bc8def00bd2f13e5526c127e9b667974a89"  ;; \
+         "linux/arm64")  HELM_SHA256="9f58e707dcbe9a3b7885c4e24ef57edfb9794490d72705b33a93fa1f3572cce4"  ;; \
+    esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \
-    tar xvf "${HELM_FILENAME}" -C /usr/local/bin --strip-components 1 linux-amd64/helm && \
+    tar xvf "${HELM_FILENAME}" -C /usr/local/bin --strip-components 1 ${TARGETOS}-${TARGETARCH}/helm && \
     rm "${HELM_FILENAME}" && \
     [ "$(helm version --template '{{.Version}}')" = "${HELM_VERSION}" ]
 
@@ -46,26 +51,32 @@ RUN set -x && \
 # for now but in a future version of alpine (in the testing version at the time of writing)
 # we should be able to install using apk add.
 ENV KUBECTL_VERSION="v1.25.2"
-ARG KUBECTL_SHA256="8639f2b9c33d38910d706171ce3d25be9b19fc139d0e3d4627f38ce84f9040eb"
 RUN set -x && \
-    curl --retry 5 --retry-connrefused -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    curl --retry 5 --retry-connrefused -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl" && \
+    case ${TARGETPLATFORM} in \
+         "linux/amd64")  KUBECTL_SHA256="8639f2b9c33d38910d706171ce3d25be9b19fc139d0e3d4627f38ce84f9040eb"  ;; \
+         "linux/arm64")  KUBECTL_SHA256="b26aa656194545699471278ad899a90b1ea9408d35f6c65e3a46831b9c063fd5"  ;; \
+    esac && \
     echo "${KUBECTL_SHA256}  kubectl" | sha256sum -c && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl && \
     [ "$(kubectl version -o json | jq -r '.clientVersion.gitVersion')" = "${KUBECTL_VERSION}" ]
 
 ENV KUSTOMIZE_VERSION="v4.5.7"
-ARG KUSTOMIZE_SHA256="701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9"
-ARG KUSTOMIZE_FILENAME="kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+ARG KUSTOMIZE_FILENAME="kustomize_${KUSTOMIZE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz"
 RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILENAME}" && \
+    case ${TARGETPLATFORM} in \
+         "linux/amd64")  KUSTOMIZE_SHA256="701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9"  ;; \
+         "linux/arm64")  KUSTOMIZE_SHA256="65665b39297cc73c13918f05bbe8450d17556f0acd16242a339271e14861df67"  ;; \
+    esac && \
     echo "${KUSTOMIZE_SHA256}  ${KUSTOMIZE_FILENAME}" | sha256sum -c && \
     tar xvf "${KUSTOMIZE_FILENAME}" -C /usr/local/bin && \
     rm "${KUSTOMIZE_FILENAME}" && \
     kustomize version --short | grep "kustomize/${KUSTOMIZE_VERSION}"
 
 ENV SOPS_VERSION="v3.7.3"
-ARG SOPS_FILENAME="sops-${SOPS_VERSION}.linux.amd64"
+ARG SOPS_FILENAME="sops-${SOPS_VERSION}.${TARGETOS}.${TARGETARCH}"
 RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/${SOPS_FILENAME}" && \
     chmod +x "${SOPS_FILENAME}" && \
@@ -73,7 +84,7 @@ RUN set -x && \
     sops --version | grep -E "^sops ${SOPS_VERSION#v}"
 
 ENV AGE_VERSION="v1.0.0"
-ARG AGE_FILENAME="age-${AGE_VERSION}-linux-amd64.tar.gz"
+ARG AGE_FILENAME="age-${AGE_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
 RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "https://github.com/FiloSottile/age/releases/download/${AGE_VERSION}/${AGE_FILENAME}" && \
     tar xvf "${AGE_FILENAME}" -C /usr/local/bin --strip-components 1 age/age age/age-keygen && \
@@ -90,7 +101,6 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.6.0 
 # Allow users other than root to use helm plugins located in root home
 RUN chmod 751 ${HOME}
 
-ARG TARGETARCH
-COPY --from=builder /workspace/helmfile/dist/helmfile_linux_${TARGETARCH} /usr/local/bin/helmfile
+COPY --from=builder /workspace/helmfile/dist/helmfile_${TARGETOS}_${TARGETARCH} /usr/local/bin/helmfile
 
 CMD ["/usr/local/bin/helmfile"]

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.20-alpine as builder
 
 RUN apk add --no-cache make git
 WORKDIR /workspace/helmfile
@@ -7,11 +7,12 @@ COPY go.mod go.sum /workspace/helmfile/
 RUN go mod download
 
 COPY . /workspace/helmfile
-RUN make static-linux
+ARG TARGETARCH
+RUN make static-linux-${TARGETARCH}
 
 # -----------------------------------------------------------------------------
 
-FROM debian:stable-slim
+FROM --platform=$BUILDPLATFORM debian:stable-slim
 
 LABEL org.opencontainers.image.source https://github.com/helmfile/helmfile
 
@@ -94,6 +95,7 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.6.0 
 # Allow users other than root to use helm plugins located in root home
 RUN chmod 751 ${HOME}
 
-COPY --from=builder /workspace/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
+ARG TARGETARCH
+COPY --from=builder /workspace/helmfile/dist/helmfile_linux_${TARGETARCH} /usr/local/bin/helmfile
 
 CMD ["/usr/local/bin/helmfile"]

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -7,8 +7,8 @@ COPY go.mod go.sum /workspace/helmfile/
 RUN go mod download
 
 COPY . /workspace/helmfile
-ARG TARGETARCH
-RUN make static-linux-${TARGETARCH}
+ARG TARGETARCH TARGETOS
+RUN make static-${TARGETOS}-${TARGETARCH}
 
 # -----------------------------------------------------------------------------
 
@@ -23,6 +23,8 @@ RUN apt update -qq && \
       git bash curl jq wget openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
+ARG TARGETARCH TARGETOS TARGETPLATFORM
+
 # Set Helm home variables so that also non-root users can use plugins etc.
 ARG HOME="/helm"
 ENV HOME="${HOME}"
@@ -35,15 +37,18 @@ ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
 ARG HELM_VERSION="v3.11.3"
 ENV HELM_VERSION="${HELM_VERSION}"
-ARG HELM_SHA256="ca2d5d40d4cdfb9a3a6205dd803b5bc8def00bd2f13e5526c127e9b667974a89"
 ARG HELM_LOCATION="https://get.helm.sh"
-ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
+ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
 RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
+    case ${TARGETPLATFORM} in \
+         "linux/amd64")  HELM_SHA256="ca2d5d40d4cdfb9a3a6205dd803b5bc8def00bd2f13e5526c127e9b667974a89"  ;; \
+         "linux/arm64")  HELM_SHA256="9f58e707dcbe9a3b7885c4e24ef57edfb9794490d72705b33a93fa1f3572cce4"  ;; \
+    esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \
-    tar xvf "${HELM_FILENAME}" -C /usr/local/bin --strip-components 1 linux-amd64/helm && \
+    tar xvf "${HELM_FILENAME}" -C /usr/local/bin --strip-components 1 ${TARGETOS}-${TARGETARCH}/helm && \
     rm "${HELM_FILENAME}" && \
     [ "$(helm version --template '{{.Version}}')" = "${HELM_VERSION}" ]
 
@@ -51,26 +56,32 @@ RUN set -x && \
 # for now but in a future version of alpine (in the testing version at the time of writing)
 # we should be able to install using apk add.
 ENV KUBECTL_VERSION="v1.25.2"
-ARG KUBECTL_SHA256="8639f2b9c33d38910d706171ce3d25be9b19fc139d0e3d4627f38ce84f9040eb"
 RUN set -x && \
-    curl --retry 5 --retry-connrefused -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    curl --retry 5 --retry-connrefused -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl" && \
+    case ${TARGETPLATFORM} in \
+         "linux/amd64")  KUBECTL_SHA256="8639f2b9c33d38910d706171ce3d25be9b19fc139d0e3d4627f38ce84f9040eb"  ;; \
+         "linux/arm64")  KUBECTL_SHA256="b26aa656194545699471278ad899a90b1ea9408d35f6c65e3a46831b9c063fd5"  ;; \
+    esac && \
     echo "${KUBECTL_SHA256}  kubectl" | sha256sum -c && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl && \
     [ "$(kubectl version -o json | jq -r '.clientVersion.gitVersion')" = "${KUBECTL_VERSION}" ]
 
 ENV KUSTOMIZE_VERSION="v4.5.7"
-ARG KUSTOMIZE_SHA256="701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9"
-ARG KUSTOMIZE_FILENAME="kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+ARG KUSTOMIZE_FILENAME="kustomize_${KUSTOMIZE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz"
 RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILENAME}" && \
+    case ${TARGETPLATFORM} in \
+         "linux/amd64")  KUSTOMIZE_SHA256="701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9"  ;; \
+         "linux/arm64")  KUSTOMIZE_SHA256="65665b39297cc73c13918f05bbe8450d17556f0acd16242a339271e14861df67"  ;; \
+    esac && \
     echo "${KUSTOMIZE_SHA256}  ${KUSTOMIZE_FILENAME}" | sha256sum -c && \
     tar xvf "${KUSTOMIZE_FILENAME}" -C /usr/local/bin && \
     rm "${KUSTOMIZE_FILENAME}" && \
     kustomize version --short | grep "kustomize/${KUSTOMIZE_VERSION}"
 
 ENV SOPS_VERSION="v3.7.3"
-ARG SOPS_FILENAME="sops-${SOPS_VERSION}.linux.amd64"
+ARG SOPS_FILENAME="sops-${SOPS_VERSION}.${TARGETOS}.${TARGETARCH}"
 RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/${SOPS_FILENAME}" && \
     chmod +x "${SOPS_FILENAME}" && \
@@ -78,7 +89,7 @@ RUN set -x && \
     sops --version | grep -E "^sops ${SOPS_VERSION#v}"
 
 ENV AGE_VERSION="v1.0.0"
-ARG AGE_FILENAME="age-${AGE_VERSION}-linux-amd64.tar.gz"
+ARG AGE_FILENAME="age-${AGE_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
 RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "https://github.com/FiloSottile/age/releases/download/${AGE_VERSION}/${AGE_FILENAME}" && \
     tar xvf "${AGE_FILENAME}" -C /usr/local/bin --strip-components 1 age/age age/age-keygen && \
@@ -95,7 +106,6 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.6.0 
 # Allow users other than root to use helm plugins located in root home
 RUN chmod 751 ${HOME}
 
-ARG TARGETARCH
-COPY --from=builder /workspace/helmfile/dist/helmfile_linux_${TARGETARCH} /usr/local/bin/helmfile
+COPY --from=builder /workspace/helmfile/dist/helmfile_${TARGETOS}_${TARGETARCH} /usr/local/bin/helmfile
 
 CMD ["/usr/local/bin/helmfile"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.20-alpine as builder
 
 RUN apk add --no-cache make git
 WORKDIR /workspace/helmfile
@@ -7,11 +7,12 @@ COPY go.mod go.sum /workspace/helmfile/
 RUN go mod download
 
 COPY . /workspace/helmfile
-RUN make static-linux
+ARG TARGETARCH
+RUN make static-linux-${TARGETARCH}
 
 # -----------------------------------------------------------------------------
 
-FROM ubuntu:20.04
+FROM --platform=$BUILDPLATFORM ubuntu:20.04
 
 LABEL org.opencontainers.image.source https://github.com/helmfile/helmfile
 
@@ -94,6 +95,7 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.6.0 
 # Allow users other than root to use helm plugins located in root home
 RUN chmod 751 ${HOME}
 
-COPY --from=builder /workspace/helmfile/dist/helmfile_linux_amd64 /usr/local/bin/helmfile
+ARG TARGETARCH
+COPY --from=builder /workspace/helmfile/dist/helmfile_linux_${TARGETARCH} /usr/local/bin/helmfile
 
 CMD ["/usr/local/bin/helmfile"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -7,8 +7,8 @@ COPY go.mod go.sum /workspace/helmfile/
 RUN go mod download
 
 COPY . /workspace/helmfile
-ARG TARGETARCH
-RUN make static-linux-${TARGETARCH}
+ARG TARGETARCH TARGETOS
+RUN make static-${TARGETOS}-${TARGETARCH}
 
 # -----------------------------------------------------------------------------
 
@@ -23,6 +23,8 @@ RUN apt update -qq && \
       git bash curl jq wget openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
+ARG TARGETARCH TARGETOS TARGETPLATFORM
+
 # Set Helm home variables so that also non-root users can use plugins etc.
 ARG HOME="/helm"
 ENV HOME="${HOME}"
@@ -35,15 +37,18 @@ ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
 ARG HELM_VERSION="v3.11.3"
 ENV HELM_VERSION="${HELM_VERSION}"
-ARG HELM_SHA256="ca2d5d40d4cdfb9a3a6205dd803b5bc8def00bd2f13e5526c127e9b667974a89"
 ARG HELM_LOCATION="https://get.helm.sh"
-ARG HELM_FILENAME="helm-${HELM_VERSION}-linux-amd64.tar.gz"
+ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
 RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
+    case ${TARGETPLATFORM} in \
+         "linux/amd64")  HELM_SHA256="ca2d5d40d4cdfb9a3a6205dd803b5bc8def00bd2f13e5526c127e9b667974a89"  ;; \
+         "linux/arm64")  HELM_SHA256="9f58e707dcbe9a3b7885c4e24ef57edfb9794490d72705b33a93fa1f3572cce4"  ;; \
+    esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \
-    tar xvf "${HELM_FILENAME}" -C /usr/local/bin --strip-components 1 linux-amd64/helm && \
+    tar xvf "${HELM_FILENAME}" -C /usr/local/bin --strip-components 1 ${TARGETOS}-${TARGETARCH}/helm && \
     rm "${HELM_FILENAME}" && \
     [ "$(helm version --template '{{.Version}}')" = "${HELM_VERSION}" ]
 
@@ -51,26 +56,32 @@ RUN set -x && \
 # for now but in a future version of alpine (in the testing version at the time of writing)
 # we should be able to install using apk add.
 ENV KUBECTL_VERSION="v1.25.2"
-ARG KUBECTL_SHA256="8639f2b9c33d38910d706171ce3d25be9b19fc139d0e3d4627f38ce84f9040eb"
 RUN set -x && \
-    curl --retry 5 --retry-connrefused -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    curl --retry 5 --retry-connrefused -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl" && \
+    case ${TARGETPLATFORM} in \
+         "linux/amd64")  KUBECTL_SHA256="8639f2b9c33d38910d706171ce3d25be9b19fc139d0e3d4627f38ce84f9040eb"  ;; \
+         "linux/arm64")  KUBECTL_SHA256="b26aa656194545699471278ad899a90b1ea9408d35f6c65e3a46831b9c063fd5"  ;; \
+    esac && \
     echo "${KUBECTL_SHA256}  kubectl" | sha256sum -c && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl && \
     [ "$(kubectl version -o json | jq -r '.clientVersion.gitVersion')" = "${KUBECTL_VERSION}" ]
 
 ENV KUSTOMIZE_VERSION="v4.5.7"
-ARG KUSTOMIZE_SHA256="701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9"
-ARG KUSTOMIZE_FILENAME="kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+ARG KUSTOMIZE_FILENAME="kustomize_${KUSTOMIZE_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz"
 RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/${KUSTOMIZE_FILENAME}" && \
+    case ${TARGETPLATFORM} in \
+         "linux/amd64")  KUSTOMIZE_SHA256="701e3c4bfa14e4c520d481fdf7131f902531bfc002cb5062dcf31263a09c70c9"  ;; \
+         "linux/arm64")  KUSTOMIZE_SHA256="65665b39297cc73c13918f05bbe8450d17556f0acd16242a339271e14861df67"  ;; \
+    esac && \
     echo "${KUSTOMIZE_SHA256}  ${KUSTOMIZE_FILENAME}" | sha256sum -c && \
     tar xvf "${KUSTOMIZE_FILENAME}" -C /usr/local/bin && \
     rm "${KUSTOMIZE_FILENAME}" && \
     kustomize version --short | grep "kustomize/${KUSTOMIZE_VERSION}"
 
 ENV SOPS_VERSION="v3.7.3"
-ARG SOPS_FILENAME="sops-${SOPS_VERSION}.linux.amd64"
+ARG SOPS_FILENAME="sops-${SOPS_VERSION}.${TARGETOS}.${TARGETARCH}"
 RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "https://github.com/mozilla/sops/releases/download/${SOPS_VERSION}/${SOPS_FILENAME}" && \
     chmod +x "${SOPS_FILENAME}" && \
@@ -78,7 +89,7 @@ RUN set -x && \
     sops --version | grep -E "^sops ${SOPS_VERSION#v}"
 
 ENV AGE_VERSION="v1.0.0"
-ARG AGE_FILENAME="age-${AGE_VERSION}-linux-amd64.tar.gz"
+ARG AGE_FILENAME="age-${AGE_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
 RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "https://github.com/FiloSottile/age/releases/download/${AGE_VERSION}/${AGE_FILENAME}" && \
     tar xvf "${AGE_FILENAME}" -C /usr/local/bin --strip-components 1 age/age age/age-keygen && \
@@ -95,7 +106,6 @@ RUN helm plugin install https://github.com/databus23/helm-diff --version v3.6.0 
 # Allow users other than root to use helm plugins located in root home
 RUN chmod 751 ${HOME}
 
-ARG TARGETARCH
-COPY --from=builder /workspace/helmfile/dist/helmfile_linux_${TARGETARCH} /usr/local/bin/helmfile
+COPY --from=builder /workspace/helmfile/dist/helmfile_${TARGETOS}_${TARGETARCH} /usr/local/bin/helmfile
 
 CMD ["/usr/local/bin/helmfile"]

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,14 @@ static-linux:
 	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS=-mod=readonly go build -o "dist/helmfile_linux_amd64" -ldflags="$(GO_BUILD_VERSION_LDFLAGS)" ${TARGETS}
 .PHONY: static-linux
 
+static-linux-amd64:
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS=-mod=readonly go build -o "dist/helmfile_linux_amd64" -ldflags="$(GO_BUILD_VERSION_LDFLAGS)" ${TARGETS}
+.PHONY: static-linux-amd64
+
+static-linux-arm64:
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GOFLAGS=-mod=readonly go build -o "dist/helmfile_linux_arm64" -ldflags="$(GO_BUILD_VERSION_LDFLAGS)" ${TARGETS}
+.PHONY: static-linux-arm64
+
 install:
 	env CGO_ENABLED=0 go install -ldflags="$(GO_BUILD_VERSION_LDFLAGS)" ${TARGETS}
 .PHONY: install


### PR DESCRIPTION
Actually fix #816 and followup on #817

I also abstracted out the TARGETOS (right now just linux) in case you ever want more target platforms.