### PR TITLE
Stop failing on single helmfile part missing specified env

### DIFF
--- a/pkg/app/testdata/app_list_test/fail_on_unknown_environment
+++ b/pkg/app/testdata/app_list_test/fail_on_unknown_environment
@@ -110,6 +110,7 @@ second-pass rendering result of "helmfile_1.yaml.part.0":
 47:   - test2
 48: 
 
+merged environment: &{staging  map[] map[]}
 changing working directory back to "/path/to"
 processing file "helmfile_2.yaml" in directory "/path/to/helmfile.d"
 changing working directory to "/path/to/helmfile.d"
@@ -168,6 +169,7 @@ second-pass rendering result of "helmfile_2.yaml.part.0":
 20:   version: 11.6.22
 21: 
 
+merged environment: &{staging  map[] map[]}
 changing working directory back to "/path/to"
 processing file "helmfile_3.yaml" in directory "/path/to/helmfile.d"
 changing working directory to "/path/to/helmfile.d"
@@ -194,4 +196,5 @@ second-pass rendering result of "helmfile_3.yaml.part.0":
  4:   namespace: kube-system
  5: 
 
+merged environment: &{staging  map[] map[]}
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_list_test/filters_releases_for_environment_used_in_multiple_files
+++ b/pkg/app/testdata/app_list_test/filters_releases_for_environment_used_in_multiple_files
@@ -196,4 +196,5 @@ second-pass rendering result of "helmfile_3.yaml.part.0":
  4:   namespace: kube-system
  5: 
 
+merged environment: &{shared  map[] map[]}
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_list_test/filters_releases_for_environment_used_in_one_file_only
+++ b/pkg/app/testdata/app_list_test/filters_releases_for_environment_used_in_one_file_only
@@ -110,6 +110,7 @@ second-pass rendering result of "helmfile_1.yaml.part.0":
 47:   - test2
 48: 
 
+merged environment: &{test  map[] map[]}
 changing working directory back to "/path/to"
 processing file "helmfile_2.yaml" in directory "/path/to/helmfile.d"
 changing working directory to "/path/to/helmfile.d"
@@ -195,4 +196,5 @@ second-pass rendering result of "helmfile_3.yaml.part.0":
  4:   namespace: kube-system
  5: 
 
+merged environment: &{test  map[] map[]}
 changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_list_test/list_releases_matching_selector_and_environment
+++ b/pkg/app/testdata/app_list_test/list_releases_matching_selector_and_environment
@@ -169,6 +169,7 @@ second-pass rendering result of "helmfile_2.yaml.part.0":
 20:   version: 11.6.22
 21: 
 
+merged environment: &{development  map[] map[]}
 changing working directory back to "/path/to"
 processing file "helmfile_3.yaml" in directory "/path/to/helmfile.d"
 changing working directory to "/path/to/helmfile.d"
@@ -195,4 +196,5 @@ second-pass rendering result of "helmfile_3.yaml.part.0":
  4:   namespace: kube-system
  5: 
 
+merged environment: &{development  map[] map[]}
 changing working directory back to "/path/to"

--- a/pkg/app/two_pass_renderer.go
+++ b/pkg/app/two_pass_renderer.go
@@ -53,7 +53,7 @@ func (r *desiredStateLoader) renderPrestate(firstPassEnv, overrode *environment.
 	c := r.underlying()
 	c.Strict = false
 	// create preliminary state, as we may have an environment. Tolerate errors.
-	prestate, err := c.ParseAndLoad([]byte(sanitized), baseDir, filename, r.env, false, firstPassEnv, overrode)
+	prestate, err := c.ParseAndLoad([]byte(sanitized), baseDir, filename, r.env, true, false, firstPassEnv, overrode)
 	if err != nil {
 		if _, ok := err.(*state.StateLoadError); ok {
 			r.logger.Debugf("could not deduce `environment:` block, configuring only .Environment.Name. error: %v", err)

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -20,7 +20,7 @@ func createFromYaml(content []byte, file string, env string, logger *zap.Sugared
 		fs:     filesystem.DefaultFileSystem(),
 		Strict: true,
 	}
-	return c.ParseAndLoad(content, filepath.Dir(file), file, env, true, nil, nil)
+	return c.ParseAndLoad(content, filepath.Dir(file), file, env, false, true, nil, nil)
 }
 
 func TestReadFromYaml(t *testing.T) {
@@ -54,9 +54,10 @@ func TestReadFromYaml_NonexistentEnv(t *testing.T) {
   chart: mychart
 `)
 	_, err := createFromYaml(yamlContent, yamlFile, "production", logger)
-	if err == nil {
-		t.Error("expected error")
-	}
+	// This does not produce an error because the environment existence check if done
+	// outside of the ParseAndLoad function since
+	// https://github.com/helmfile/helmfile/pull/885
+	require.NoError(t, err)
 }
 
 type stateTestEnv struct {
@@ -84,7 +85,7 @@ func (testEnv stateTestEnv) MustLoadStateWithEnableLiveOutput(t *testing.T, file
 
 	r := remote.NewRemote(logger, testFs.Cwd, testFs.ToFileSystem())
 	state, err := NewCreator(logger, testFs.ToFileSystem(), nil, nil, "", r, enableLiveOutput, "").
-		ParseAndLoad([]byte(yamlContent), filepath.Dir(file), file, envName, true, nil, nil)
+		ParseAndLoad([]byte(yamlContent), filepath.Dir(file), file, envName, true, true, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -154,7 +155,7 @@ releaseNamespace: mynamespace
 		Name: "production",
 	}
 	state, err := NewCreator(logger, testFs.ToFileSystem(), nil, nil, "", r, false, "").
-		ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", true, &env, nil)
+		ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", true, true, &env, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -241,7 +242,7 @@ overrideNamespace: myns
 
 	r := remote.NewRemote(logger, testFs.Cwd, testFs.ToFileSystem())
 	state, err := NewCreator(logger, testFs.ToFileSystem(), nil, nil, "", r, false, "").
-		ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", true, nil, nil)
+		ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", true, true, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -525,7 +526,7 @@ releaseContext:
 
 	r := remote.NewRemote(logger, testFs.Cwd, testFs.ToFileSystem())
 	state, err := NewCreator(logger, testFs.ToFileSystem(), nil, nil, "", r, false, "").
-		ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", true, nil, nil)
+		ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "production", true, true, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/testhelper/require_log.go
+++ b/pkg/testhelper/require_log.go
@@ -4,12 +4,23 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
 
 func RequireLog(t *testing.T, dir string, bs *bytes.Buffer) {
 	t.Helper()
+
+	// Get the caller pkg used for instruction on rerunning the specific test
+	pc, _, _, _ := runtime.Caller(1)
+	funcName := runtime.FuncForPC(pc).Name()
+	lastSlash := strings.LastIndexByte(funcName, '/')
+	if lastSlash < 0 {
+		lastSlash = 0
+	}
+	firstDot := strings.IndexByte(funcName[lastSlash:], '.') + lastSlash
+	callerPkg := funcName[:firstDot]
 
 	testNameComponents := strings.Split(t.Name(), "/")
 	testBaseName := strings.ToLower(
@@ -21,21 +32,37 @@ func RequireLog(t *testing.T, dir string, bs *bytes.Buffer) {
 	)
 	wantLogFileDir := filepath.Join("testdata", dir)
 	wantLogFile := filepath.Join(wantLogFileDir, testBaseName)
-	wantLogData, err := os.ReadFile(wantLogFile)
-	updateLogFile := err != nil
-	wantLog := string(wantLogData)
-	gotLog := bs.String()
-	if updateLogFile {
+
+	if os.Getenv("HELMFILE_UPDATE_SNAPSHOT") != "" {
 		if err := os.MkdirAll(wantLogFileDir, 0755); err != nil {
 			t.Fatalf("unable to create directory %q: %v", wantLogFileDir, err)
 		}
 		if err := os.WriteFile(wantLogFile, bs.Bytes(), 0644); err != nil {
 			t.Fatalf("unable to update lint log snapshot: %v", err)
 		}
+		return
 	}
+
+	wantLogData, err := os.ReadFile(wantLogFile)
+	if err != nil {
+		t.Fatalf(
+			"Snapshot file %q does not exist. Rerun this test with `HELMFILE_UPDATE_SNAPSHOT=1 go test -v -run %s %s` to create the snapshot",
+			wantLogFile,
+			t.Name(),
+			callerPkg,
+		)
+	}
+
+	wantLog := string(wantLogData)
+	gotLog := bs.String()
 
 	diff, exists := Diff(wantLog, gotLog, 3)
 	if exists {
-		t.Errorf("unexpected log:\nDIFF\n%s\nEOD\nPlease remove %s and rerun the test to recapture this test snapshot", diff, wantLogFile)
+		t.Errorf("unexpected %s: want (-), got (+): %s", testBaseName, diff)
+		t.Errorf(
+			"If you think this is due to the snapshot file being outdated, rerun this test with `HELMFILE_UPDATE_SNAPSHOT=1 go test -v -run %s %s` to update the snapshot",
+			t.Name(),
+			callerPkg,
+		)
 	}
 }


### PR DESCRIPTION
This fixes helmfile to not fail in cases like https://github.com/helmfile/helmfile/issues/807#issuecomment-1515287329.
I consider this a bug in our validation logic that it was too strict!

The first commit f9f4972a980f0820695833a48d9ede5c6a163900 is there for making it easy to update the test snapshots.

Ref https://github.com/helmfile/helmfile/issues/807