### PR TITLE
Feat: add --strip-args-values-on-exit-error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,6 +120,7 @@ func setGlobalOptionsForRootCmd(fs *pflag.FlagSet, globalOptions *config.GlobalO
 	fs.StringArrayVar(&globalOptions.StateValuesSet, "state-values-set", nil, "set state values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2). Used to override .Values within the helmfile template (not values template).")
 	fs.StringArrayVar(&globalOptions.StateValuesFile, "state-values-file", nil, "specify state values in a YAML file. Used to override .Values within the helmfile template (not values template).")
 	fs.BoolVar(&globalOptions.SkipDeps, "skip-deps", false, `skip running "helm repo update" and "helm dependency build"`)
+	fs.BoolVar(&globalOptions.StripArgsValuesOnExitError, "strip-args-values-on-exit-error", true, `Strip the potential secret values of the helm command args contained in a helmfile error message`)
 	fs.BoolVar(&globalOptions.DisableForceUpdate, "disable-force-update", false, `do not force helm repos to update when executing "helm repo add"`)
 	fs.BoolVarP(&globalOptions.Quiet, "quiet", "q", false, "Silence output. Equivalent to log-level warn")
 	fs.StringVar(&globalOptions.KubeContext, "kube-context", "", "Set kubectl context. Uses current context by default")

--- a/docs/index.md
+++ b/docs/index.md
@@ -210,7 +210,7 @@ helmDefaults:
   # propagate `--post-renderer` to helmv3 template and helm install
   postRenderer: "path/to/postRenderer"
   #	cascade `--cascade` to helmv3 delete, available values: background, foreground, or orphan, default: background
-  cascade: "background" 
+  cascade: "background"
   # insecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
   insecureSkipTLSVerify: false
 
@@ -312,7 +312,7 @@ releases:
     # propagate `--post-renderer` to helmv3 template and helm install
     postRenderer: "path/to/postRenderer"
     # cascade `--cascade` to helmv3 delete, available values: background, foreground, or orphan, default: background
-    cascade: "background" 
+    cascade: "background"
     # insecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
     insecureSkipTLSVerify: false
 
@@ -539,31 +539,32 @@ Available Commands:
   write-values Write values files for releases. Similar to `helmfile template`, write values files instead of manifests.
 
 Flags:
-      --allow-no-matching-release       Do not exit with an error code if the provided selector has no matching releases.
-  -c, --chart string                    Set chart. Uses the chart set in release by default, and is available in template as {{ .Chart }}
-      --color                           Output with color
-      --debug                           Enable verbose output for Helm and set log-level to debug, this disables --quiet/-q effect
-      --disable-force-update            do not force helm repos to update when executing "helm repo add"
-      --enable-live-output              Show live output from the Helm binary Stdout/Stderr into Helmfile own Stdout/Stderr.
-                                        It only applies for the Helm CLI commands, Stdout/Stderr for Hooks are still displayed only when it's execution finishes.
-  -e, --environment string              specify the environment name. Overrides "HELMFILE_ENVIRONMENT" OS environment variable when specified. defaults to "default"
-  -f, --file helmfile.yaml              load config from file or directory. defaults to "helmfile.yaml" or "helmfile.yaml.gotmpl" or "helmfile.d" (means "helmfile.d/*.yaml" or "helmfile.d/*.yaml.gotmpl") in this preference. Specify - to load the config from the standard input.
-  -b, --helm-binary string              Path to the helm binary (default "helm")
-  -h, --help                            help for helmfile
-  -i, --interactive                     Request confirmation before attempting to modify clusters
-      --kube-context string             Set kubectl context. Uses current context by default
-      --log-level string                Set log level, default info (default "info")
-  -n, --namespace string                Set namespace. Uses the namespace set in the context by default, and is available in templates as {{ .Namespace }}
-      --no-color                        Output without color
-  -q, --quiet                           Silence output. Equivalent to log-level warn
-  -l, --selector stringArray            Only run using the releases that match labels. Labels can take the form of foo=bar or foo!=bar.
-                                        A release must match all labels in a group in order to be used. Multiple groups can be specified at once.
-                                        "--selector tier=frontend,tier!=proxy --selector tier=backend" will match all frontend, non-proxy releases AND all backend releases.
-                                        The name of a release can be used as a label: "--selector name=myrelease"
-      --skip-deps                       skip running "helm repo update" and "helm dependency build"
-      --state-values-file stringArray   specify state values in a YAML file. Used to override .Values within the helmfile template (not values template).
-      --state-values-set stringArray    set state values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2). Used to override .Values within the helmfile template (not values template).
-  -v, --version                         version for helmfile
+      --allow-no-matching-release         Do not exit with an error code if the provided selector has no matching releases.
+  -c, --chart string                      Set chart. Uses the chart set in release by default, and is available in template as {{ .Chart }}
+      --color                             Output with color
+      --debug                             Enable verbose output for Helm and set log-level to debug, this disables --quiet/-q effect
+      --disable-force-update              do not force helm repos to update when executing "helm repo add"
+      --enable-live-output                Show live output from the Helm binary Stdout/Stderr into Helmfile own Stdout/Stderr.
+                                          It only applies for the Helm CLI commands, Stdout/Stderr for Hooks are still displayed only when it's execution finishes.
+  -e, --environment string                specify the environment name. Overrides "HELMFILE_ENVIRONMENT" OS environment variable when specified. defaults to "default"
+  -f, --file helmfile.yaml                load config from file or directory. defaults to "helmfile.yaml" or "helmfile.yaml.gotmpl" or "helmfile.d" (means "helmfile.d/*.yaml" or "helmfile.d/*.yaml.gotmpl") in this preference. Specify - to load the config from the standard input.
+  -b, --helm-binary string                Path to the helm binary (default "helm")
+  -h, --help                              help for helmfile
+  -i, --interactive                       Request confirmation before attempting to modify clusters
+      --kube-context string               Set kubectl context. Uses current context by default
+      --log-level string                  Set log level, default info (default "info")
+  -n, --namespace string                  Set namespace. Uses the namespace set in the context by default, and is available in templates as {{ .Namespace }}
+      --no-color                          Output without color
+  -q, --quiet                             Silence output. Equivalent to log-level warn
+  -l, --selector stringArray              Only run using the releases that match labels. Labels can take the form of foo=bar or foo!=bar.
+                                          A release must match all labels in a group in order to be used. Multiple groups can be specified at once.
+                                          "--selector tier=frontend,tier!=proxy --selector tier=backend" will match all frontend, non-proxy releases AND all backend releases.
+                                          The name of a release can be used as a label: "--selector name=myrelease"
+      --skip-deps                         skip running "helm repo update" and "helm dependency build"
+      --state-values-file stringArray     specify state values in a YAML file. Used to override .Values within the helmfile template (not values template).
+      --state-values-set stringArray      set state values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2). Used to override .Values within the helmfile template (not values template).
+      --strip-args-values-on-exit-error   On exit error, strip the values of the args
+  -v, --version                           version for helmfile
 
 Use "helmfile [command] --help" for more information about a command.
 ```

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -6,6 +6,7 @@ type ConfigProvider interface {
 	Args() string
 	HelmBinary() string
 	EnableLiveOutput() bool
+	StripArgsValuesOnExitError() bool
 	DisableForceUpdate() bool
 	SkipDeps() bool
 

--- a/pkg/config/global.go
+++ b/pkg/config/global.go
@@ -25,6 +25,8 @@ type GlobalOptions struct {
 	StateValuesFile []string
 	// SkipDeps is true if the running "helm repo update" and "helm dependency build" should be skipped
 	SkipDeps bool
+	// StripArgsValuesOnExitError is true if the ARGS output on exit error should be suppressed
+	StripArgsValuesOnExitError bool
 	// DisableForceUpdate is true if force updating repos is not desirable when executing "helm repo add"
 	DisableForceUpdate bool
 	// Quiet is true if the output should be quiet.
@@ -139,6 +141,11 @@ func (g *GlobalImpl) EnableLiveOutput() bool {
 // SkipDeps return if running "helm repo update" and "helm dependency build" should be skipped
 func (g *GlobalImpl) SkipDeps() bool {
 	return g.GlobalOptions.SkipDeps
+}
+
+// StripArgsValuesOnExitError return if the ARGS output on exit error should be suppressed
+func (g *GlobalImpl) StripArgsValuesOnExitError() bool {
+	return g.GlobalOptions.StripArgsValuesOnExitError
 }
 
 // DisableForceUpdate return when to disable forcing updates to repos upon adding

--- a/pkg/helmexec/exit_error.go
+++ b/pkg/helmexec/exit_error.go
@@ -5,13 +5,16 @@ import (
 	"strings"
 )
 
-func newExitError(path string, args []string, exitStatus int, err error, stderr, combined string) ExitError {
+func newExitError(path string, args []string, exitStatus int, err error, stderr, combined string, stripArgsValuesOnExitError bool) ExitError {
 	var out string
 
 	out += fmt.Sprintf("PATH:\n%s", Indent(path, "  "))
 
 	out += "\n\nARGS:"
 	for i, a := range args {
+		if i > 0 && strings.HasPrefix(args[i-1], "--set") && stripArgsValuesOnExitError {
+			a = "*** STRIP ***"
+		}
 		out += fmt.Sprintf("\n%s", Indent(fmt.Sprintf("%d: %s (%d bytes)", i, a, len(a)), "  "))
 	}
 

--- a/pkg/helmexec/exit_error_test.go
+++ b/pkg/helmexec/exit_error_test.go
@@ -1,0 +1,62 @@
+package helmexec
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewExitError(t *testing.T) {
+	for _, tt := range []struct {
+		name                       string
+		stripArgsValuesOnExitError bool
+		want                       string
+	}{
+		{
+			name:                       "newExitError with stripArgsValuesOnExitError false",
+			stripArgsValuesOnExitError: false,
+			want: `command "helm" exited with non-zero status:
+
+PATH:
+  helm
+
+ARGS:
+  0: --set (5 bytes)
+  1: a=b (3 bytes)
+  2: --set-string (12 bytes)
+  3: a=b (3 bytes)
+
+ERROR:
+  test
+
+EXIT STATUS
+  1`,
+		},
+		{
+			name:                       "newExitError with stripArgsValuesOnExitError true",
+			stripArgsValuesOnExitError: true,
+			want: `command "helm" exited with non-zero status:
+
+PATH:
+  helm
+
+ARGS:
+  0: --set (5 bytes)
+  1: *** STRIP *** (13 bytes)
+  2: --set-string (12 bytes)
+  3: *** STRIP *** (13 bytes)
+
+ERROR:
+  test
+
+EXIT STATUS
+  1`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			exitError := newExitError("helm", []string{"--set", "a=b", "--set-string", "a=b"}, 1, errors.New("test"), "", "", tt.stripArgsValuesOnExitError)
+			if want, have := tt.want, exitError.Error(); want != have {
+				t.Errorf("want %q, have %q", want, have)
+			}
+		})
+	}
+}

--- a/pkg/helmexec/runner_test.go
+++ b/pkg/helmexec/runner_test.go
@@ -74,7 +74,7 @@ Usage:  helm template [NAME] [CHART] [flags]
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := &bytes.Buffer{}
-			got, err := LiveOutput(context.Background(), tt.cmd, w)
+			got, err := LiveOutput(context.Background(), tt.cmd, false, w)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LiveOutput() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/tmpl/context_funcs.go
+++ b/pkg/tmpl/context_funcs.go
@@ -175,7 +175,7 @@ func (c *Context) EnvExec(envs map[string]interface{}, command string, args []in
 	g.Go(func() error {
 		// We use CombinedOutput to produce helpful error messages
 		// See https://github.com/roboll/helmfile/issues/1158
-		bs, err := helmexec.Output(context.Background(), cmd)
+		bs, err := helmexec.Output(context.Background(), cmd, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #886 

Add --strip-args-values-on-exit-error=true to the helmfile CLI would change the output on a error from:

```
PATH:
  /usr/local/bin/helm

ARGS:
  0: helm (4 bytes)
  1: upgrade (7 bytes)
  2: --install (9 bytes)
  3: value (5 bytes)
  4: /var/folders/cs/zz5gz_v567v7y00jpvc5v16h0000gn/T/helmfile1974210836/value/values/1.0.4/values (93 bytes)
  5: --version (9 bytes)
  6: 1.0.4 (5 bytes)
  7: --create-namespace (18 bytes)
  8: --set (5 bytes)
  9: a=v (3 bytes)
  10: --set (5 bytes)
  11: a=b (3 bytes)
  12: --reset-values (14 bytes)
  13: --history-max (13 bytes)
  14: 10 (2 bytes)

ERROR:
  exit status 1

EXIT STATUS
  1

```

to


```
PATH:
  /usr/local/bin/helm

ARGS:
  0: helm (4 bytes)
  1: upgrade (7 bytes)
  2: --install (9 bytes)
  3: value (5 bytes)
  4: /var/folders/cs/zz5gz_v567v7y00jpvc5v16h0000gn/T/helmfile3802986705/value/values/1.0.4/values (93 bytes)
  5: --version (9 bytes)
  6: 1.0.4 (5 bytes)
  7: --create-namespace (18 bytes)
  8: --set (5 bytes)
  9: *** STRIP *** (13 bytes)
  10: --set (5 bytes)
  11: *** STRIP *** (13 bytes)
  12: --reset-values (14 bytes)
  13: --history-max (13 bytes)
  14: 10 (2 bytes)

ERROR:
  exit status 1

EXIT STATUS
  1

```