### PR TITLE
Cancel rendering helmfile parts once the missing env is detected in the previous part

### DIFF
--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -265,5 +265,14 @@ func (ld *desiredStateLoader) load(env, overrodeEnv *environment.Environment, ba
 		}
 	}
 
+	// If environments are not defined in the helmfile at all although the env is specified,
+	// it's a missing env situation. Let's fail.
+	if len(finalState.Environments) == 0 && evaluateBases && env.Name != state.DefaultEnv {
+		return nil, &state.StateLoadError{
+			Msg:   fmt.Sprintf("failed to read %s", finalState.FilePath),
+			Cause: &state.UndefinedEnvError{Env: env.Name},
+		}
+	}
+
 	return finalState, nil
 }

--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -241,18 +241,27 @@ func (ld *desiredStateLoader) load(env, overrodeEnv *environment.Environment, ba
 		env = &finalState.Env
 
 		ld.logger.Debugf("merged environment: %v", env)
-	}
 
-	// We defer the missing env detection and failure until
-	// all the helmfile parts are loaded and merged.
-	// Otherwise, any single helmfile part missing the env would fail the whole helmfile run.
-	// That's problematic, because each helmfile part is supposed to be incomplete, and
-	// they become complete only after merging all the parts.
-	// See https://github.com/helmfile/helmfile/issues/807 for the rationale of this.
-	if _, ok := finalState.Environments[env.Name]; evaluateBases && env.Name != state.DefaultEnv && !ok {
-		return nil, &state.StateLoadError{
-			Msg:   fmt.Sprintf("failed to read %s", finalState.FilePath),
-			Cause: &state.UndefinedEnvError{Env: env.Name},
+		if len(finalState.Environments) == 0 {
+			continue
+		}
+
+		// At this point, we are sure that the env has been
+		// read from the vanilla or rendered YAML document.
+		// We can now check if the env is defined in it and fail accordingly.
+		// See https://github.com/helmfile/helmfile/issues/913
+
+		// We defer the missing env detection and failure until
+		// all the helmfile parts are loaded and merged.
+		// Otherwise, any single helmfile part missing the env would fail the whole helmfile run.
+		// That's problematic, because each helmfile part is supposed to be incomplete, and
+		// they become complete only after merging all the parts.
+		// See https://github.com/helmfile/helmfile/issues/807 for the rationale of this.
+		if _, ok := finalState.Environments[env.Name]; evaluateBases && env.Name != state.DefaultEnv && !ok {
+			return nil, &state.StateLoadError{
+				Msg:   fmt.Sprintf("failed to read %s", finalState.FilePath),
+				Cause: &state.UndefinedEnvError{Env: env.Name},
+			}
 		}
 	}
 

--- a/test/e2e/template/helmfile/testdata/snapshot/environment_missing_in_subhelmfile/config.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/environment_missing_in_subhelmfile/config.yaml
@@ -1,0 +1,5 @@
+chartifyTempDir: environment_missing_in_subhelmfile
+helmfileArgs:
+- --environment
+- test
+- template

--- a/test/e2e/template/helmfile/testdata/snapshot/environment_missing_in_subhelmfile/helmfiles/prod.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/environment_missing_in_subhelmfile/helmfiles/prod.yaml
@@ -1,0 +1,15 @@
+environments:
+  prod:
+    values:
+    - foo: prod
+
+---
+
+releases:
+- name: raw
+  chart: ../../../charts/raw-0.0.1
+  values:
+  - templates:
+    - |
+      subhelmfile: {{ .Values.foo }}
+      envName: {{ .Values.envName }}

--- a/test/e2e/template/helmfile/testdata/snapshot/environment_missing_in_subhelmfile/helmfiles/test.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/environment_missing_in_subhelmfile/helmfiles/test.yaml
@@ -1,0 +1,15 @@
+environments:
+  test:
+    values:
+    - foo: test
+
+---
+
+releases:
+- name: raw
+  chart: ../../../charts/raw-0.0.1
+  values:
+  - templates:
+    - |
+      subhelmfile: {{ .Values.foo }}
+      envName: {{ .Values.envName }}

--- a/test/e2e/template/helmfile/testdata/snapshot/environment_missing_in_subhelmfile/input.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/environment_missing_in_subhelmfile/input.yaml
@@ -1,0 +1,12 @@
+environments:
+  test:
+    values:
+    - test.yaml.gotmpl
+---
+helmfiles:
+- path: helmfiles/test.yaml
+  values:
+  - envName: {{ .Values.envName }}
+- path: helmfiles/prod.yaml
+  values:
+  - envName: {{ .Values.envName }}

--- a/test/e2e/template/helmfile/testdata/snapshot/environment_missing_in_subhelmfile/output.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/environment_missing_in_subhelmfile/output.yaml
@@ -1,0 +1,7 @@
+Building dependency release=raw, chart=../../../charts/raw-0.0.1
+Templating release=raw, chart=../../../charts/raw-0.0.1
+---
+# Source: raw/templates/resources.yaml
+subhelmfile: test
+envName: test
+

--- a/test/e2e/template/helmfile/testdata/snapshot/environment_missing_in_subhelmfile/test.yaml.gotmpl
+++ b/test/e2e/template/helmfile/testdata/snapshot/environment_missing_in_subhelmfile/test.yaml.gotmpl
@@ -1,0 +1,1 @@
+envName: {{ .Environment.Name }}


### PR DESCRIPTION
In #885, Helmfile v0.155.0, we made the missing env detection happen "after all the helmfile parts in a helmfile.yaml(.gotmpl) are rendered and merged".

That was indeed incorrect and resulted in any helmfile template part after the part that defines the `environments` part potentially failing.

This fixes that, by moving the env check a bit earlier than before. It now defers the env check until it sees one or more `environments` in the accumulated helmfile config.

Fixes #913