### PR TITLE
add bug to exempt labels on git stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,9 +4,10 @@ daysUntilStale: 14
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - in progress 
+  - in progress
   - pinned
   - security
+  - bug
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
- labels bug and wontfix don't go well together
- shutting down comments on bug issues is something intended?
- changing the stale label from wontfix to stale is less confusing. (wont)fix reminds of bugs. wontfix on e.g. questions and enhancements is kind of strange to me.
- plus... https://github.com/helmfile/helmfile/issues/893 (bug issue):
![image](https://github.com/helmfile/helmfile/assets/29926675/3cb6e91c-61b9-4c4e-af3e-8e8b76935a10)
🤣