### PR TITLE
Implement --diff-args

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -41,6 +41,7 @@ func NewApplyCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 	f.StringVar(&applyOptions.Output, "output", "", "output format for diff plugin")
 	f.BoolVar(&applyOptions.DetailedExitcode, "detailed-exitcode", false, "return a non-zero exit code 2 instead of 0 when there were changes detected AND the changes are synced successfully")
 	f.BoolVar(&applyOptions.StripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")
+	f.StringVar(&applyOptions.DiffArgs, "diff-args", "", `pass args to helm helm-diff`)
 	f.StringVar(&globalCfg.GlobalOptions.Args, "args", "", "pass args to helm exec")
 	if !runtime.V1Mode {
 		// TODO: Remove this function once Helmfile v0.x

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -31,6 +31,7 @@ func NewDiffCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 	}
 
 	f := cmd.Flags()
+	f.StringVar(&diffOptions.DiffArgs, "diff-args", "", `pass args to helm helm-diff`)
 	f.StringVar(&globalCfg.GlobalOptions.Args, "args", "", "pass args to helm diff")
 	f.StringArrayVar(&diffOptions.Set, "set", nil, "additional values to be merged into the helm command --set flag")
 	f.StringArrayVar(&diffOptions.Values, "values", nil, "additional value files to be merged into the helm command --values flag")

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2215,6 +2215,7 @@ type applyConfig struct {
 	stripTrailingCR        bool
 	interactive            bool
 	skipDiffOnInstall      bool
+	diffArgs               string
 	logger                 *zap.SugaredLogger
 	wait                   bool
 	waitForJobs            bool
@@ -2346,6 +2347,10 @@ func (a applyConfig) RetainValuesFiles() bool {
 
 func (a applyConfig) SkipDiffOnInstall() bool {
 	return a.skipDiffOnInstall
+}
+
+func (a applyConfig) DiffArgs() string {
+	return a.diffArgs
 }
 
 // helmfile-template-only flags

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -79,6 +79,8 @@ type ApplyConfigProvider interface {
 	SkipCleanup() bool
 	SkipDiffOnInstall() bool
 
+	DiffArgs() string
+
 	DAGConfig
 
 	concurrencyConfig
@@ -130,6 +132,7 @@ type DiffConfigProvider interface {
 	NoHooks() bool
 	SuppressDiff() bool
 	SkipDiffOnInstall() bool
+	DiffArgs() string
 
 	DAGConfig
 

--- a/pkg/app/diff_test.go
+++ b/pkg/app/diff_test.go
@@ -16,6 +16,7 @@ import (
 
 type diffConfig struct {
 	args                   string
+	diffArgs               string
 	values                 []string
 	retainValuesFiles      bool
 	set                    []string
@@ -45,6 +46,10 @@ type diffConfig struct {
 
 func (a diffConfig) Args() string {
 	return a.args
+}
+
+func (a diffConfig) DiffArgs() string {
+	return a.diffArgs
 }
 
 func (a diffConfig) Values() []string {

--- a/pkg/config/apply.go
+++ b/pkg/config/apply.go
@@ -34,6 +34,8 @@ type ApplyOptions struct {
 	IncludeTransitiveNeeds bool
 	// SkipDiffOnInstall is true if the diff should be skipped on install
 	SkipDiffOnInstall bool
+	// DiffArgs is the list of arguments to pass to the helm-diff.
+	DiffArgs string
 	// IncludeTests is true if the tests should be included
 	IncludeTests bool
 	// Suppress is true if the output should be suppressed
@@ -153,6 +155,11 @@ func (a *ApplyImpl) SkipCleanup() bool {
 // SkipDiffOnInstall returns the skip diff on install.
 func (a *ApplyImpl) SkipDiffOnInstall() bool {
 	return a.ApplyOptions.SkipDiffOnInstall
+}
+
+// DiffArgs is the list of arguments to pass to helm-diff.
+func (a *ApplyImpl) DiffArgs() string {
+	return a.ApplyOptions.DiffArgs
 }
 
 // SkipNeeds returns the skip needs.

--- a/pkg/config/diff.go
+++ b/pkg/config/diff.go
@@ -42,6 +42,8 @@ type DiffOptions struct {
 	ResetValues bool
 	// Propagate '--post-renderer' to helmv3 template and helm install
 	PostRenderer string
+	// DiffArgs is the list of arguments to pass to helm-diff.
+	DiffArgs string
 }
 
 // NewDiffOptions creates a new Apply
@@ -145,6 +147,11 @@ func (t *DiffImpl) SkipCRDs() bool {
 // SkipDiffOnInstall returns the skip diff on install
 func (t *DiffImpl) SkipDiffOnInstall() bool {
 	return t.DiffOptions.SkipDiffOnInstall
+}
+
+// DiffArgs returns the list of arguments to pass to helm-diff.
+func (t *DiffImpl) DiffArgs() string {
+	return t.DiffOptions.DiffArgs
 }
 
 // Suppress returns the suppress

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1910,6 +1910,7 @@ type DiffOpts struct {
 	Set               []string
 	SkipCleanup       bool
 	SkipDiffOnInstall bool
+	DiffArgs          string
 	ReuseValues       bool
 	ResetValues       bool
 	PostRenderer      string


### PR DESCRIPTION
`--diff-args` is useful to disable the validation only on helm diff. Additionally command like `--suppress ServiceMonitor` are only supported by helm diff, but not on helm ls. `--diff-args` make even sense on `helmfile diff`

Use cases:

If we want to install new CRDs and CR on that cluster on a helm chart which already present, the helm diff command files. since the new API object is present.

I'm aware that validation: false resolves the problem, however this would also skip the validation for the helm upgrade command. But I'm looking for a way to skip the validation ONLY for helm-diff.

--args is not helmful here, this command like helm ls are also affected and they fail then.