### PR TITLE
run deps without chart preparation

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -120,19 +120,7 @@ func (a *App) Init(c InitConfigProvider) error {
 
 func (a *App) Deps(c DepsConfigProvider) error {
 	return a.ForEachState(func(run *Run) (_ bool, errs []error) {
-		prepErr := run.withPreparedCharts("deps", state.ChartPrepareOptions{
-			SkipRepos:   c.SkipRepos(),
-			SkipDeps:    true,
-			SkipResolve: true,
-			Concurrency: c.Concurrency(),
-		}, func() {
-			errs = run.Deps(c)
-		})
-
-		if prepErr != nil {
-			errs = append(errs, prepErr)
-		}
-
+		errs = run.Deps(c)
 		return
 	}, c.IncludeTransitiveNeeds(), SetFilter(true))
 }

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -104,6 +104,12 @@ func (r *Run) withPreparedCharts(helmfileCommand string, opts state.ChartPrepare
 }
 
 func (r *Run) Deps(c DepsConfigProvider) []error {
+	if !c.SkipRepos() {
+		if err := r.ctx.SyncReposOnce(r.state, r.helm); err != nil {
+			return []error{err}
+		}
+	}
+
 	r.helm.SetExtraArgs(GetArgs(c.Args(), r.state)...)
 
 	return r.state.UpdateDeps(r.helm, c.IncludeTransitiveNeeds())

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -90,6 +90,7 @@ ${kubectl} create namespace ${test_ns} || fail "Could not create namespace ${tes
 . ${dir}/test-cases/chart-needs.sh
 . ${dir}/test-cases/postrender.sh
 . ${dir}/test-cases/chartify.sh
+. ${dir}/test-cases/deps-mr-1011.sh
 
 # ALL DONE -----------------------------------------------------------------------------------------------------------
 

--- a/test/integration/test-cases/deps-mr-1011.sh
+++ b/test/integration/test-cases/deps-mr-1011.sh
@@ -1,0 +1,9 @@
+deps_mr_1011_input_dir="${cases_dir}/deps-mr-1011/input"
+
+config_file="helmfile.yaml"
+
+test_start "helmfile deps nonreg for #1011"
+
+${helmfile} -f ${deps_mr_1011_input_dir}/${config_file} deps || fail "\"helmfile deps\" shouldn't fail"
+
+test_pass "helmfile deps nonreg for #1011"

--- a/test/integration/test-cases/deps-mr-1011/input/helmfile.yaml
+++ b/test/integration/test-cases/deps-mr-1011/input/helmfile.yaml
@@ -1,0 +1,13 @@
+repositories:
+  - name: rook-release
+    url: https://charts.rook.io/release
+  - name: incubator
+    url: https://charts.helm.sh/incubator
+
+releases:
+  - name: rook-ceph
+    chart: rook-release/rook-ceph
+    version: 1.12.x
+    dependencies:
+      - chart: incubator/raw
+        version: x


### PR DESCRIPTION
Hello!

with the following helmfile:
```yaml
releases:
  - chart: rook-release/rook-ceph
    name: rook-ceph
    namespace: rook-ceph
    values: ...
```
running `helmfile deps`  is OK, but with `dependencies` :
```yaml
releases:
  - chart: rook-release/rook-ceph
    name: rook-ceph
    namespace: rook-ceph
    dependencies:
      - chart: jouve/extra
        version: x
    values: ...
```
 `helmfile deps`  fails with the following error:
```
Updating dependency /tmp/chartify3667831028/rook-ceph/rook-ceph/rook-ceph
in ./helmfile.yaml: command "/usr/sbin/helm" exited with non-zero status:

PATH:
  /usr/sbin/helm

ARGS:
  0: helm (4 bytes)
  1: dependency (10 bytes)
  2: update (6 bytes)
  3: /tmp/chartify3667831028/rook-ceph/rook-ceph/rook-ceph (53 bytes)

ERROR:
  exit status 1

EXIT STATUS
  1

STDERR:
  Error: directory /tmp/chartify3667831028/rook-ceph/rook-ceph/library not found

COMBINED OUTPUT:
  Error: directory /tmp/chartify3667831028/rook-ceph/rook-ceph/library not found
```

`helmfile deps` runs on the local prepared chart (because of `dependencies`), so with a "local chart" logic that runs `helm dep up`  inside the local chart and this fails because the generated Chart.yaml contains a "file://" dependency ([from original Chart.yaml](https://github.com/rook/rook/blob/master/deploy/charts/rook-ceph/Chart.yaml#L12)) to ../library which does not exists after the charts is packaged as `library/` is vendored in the .tgz `charts/`  folder 

In this PR, I suggest to run deps outside of withPreparedChart, so the dependency is resolved against the ".tgz" chart instead of a local chart, so similar to the case without `dependencies`  that works.

Bonus: it's a bit faster since it not rendering the values anymore