### PR TITLE
Add diffArgs to helmDefaults

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -180,6 +180,8 @@ helmDefaults:
   # additional and global args passed to helm (default "")
   args:
     - "--set k=v"
+  diffArgs:
+    - "--suppress-secrets"
   # verify the chart before upgrading (only works with packaged charts not directories) (default false)
   verify: true
   keyring: path/to/keyring.gpg

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1320,7 +1320,7 @@ func (a *App) apply(r *Run, c ApplyConfigProvider) (bool, bool, []error) {
 	st := r.state
 	helm := r.helm
 
-	helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, false)...)
+	helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, nil)...)
 
 	selectedReleases, selectedAndNeededReleases, err := a.getSelectedReleases(r, c.IncludeTransitiveNeeds())
 	if err != nil {
@@ -1371,7 +1371,8 @@ func (a *App) apply(r *Run, c ApplyConfigProvider) (bool, bool, []error) {
 
 	// join --args and --diff-args together to one string.
 	args := strings.Join([]string{c.Args(), c.DiffArgs()}, " ")
-	helm.SetExtraArgs(argparser.GetArgs(args, r.state, true)...)
+	argsOpts := &argparser.GetArgsOptions{WithDiffArgs: true}
+	helm.SetExtraArgs(argparser.GetArgs(args, r.state, argsOpts)...)
 
 	infoMsg, releasesToBeUpdated, releasesToBeDeleted, errs := r.diff(false, detailedExitCode, c, diffOpts)
 	if len(errs) > 0 {
@@ -1567,7 +1568,7 @@ Do you really want to delete?
 `, strings.Join(names, "\n"))
 	interactive := c.Interactive()
 	if !interactive || interactive && r.askForConfirmation(msg) {
-		r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, false)...)
+		r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, nil)...)
 
 		if len(releasesToDelete) > 0 {
 			_, deletionErrs := withDAG(st, helm, a.Logger, state.PlanOptions{SelectedReleases: toDelete, Reverse: true, SkipNeeds: true}, a.WrapWithoutSelector(func(subst *state.HelmState, helm helmexec.Interface) []error {
@@ -1593,7 +1594,8 @@ func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) 
 		helm := r.helm
 
 		args := strings.Join([]string{c.Args(), c.DiffArgs()}, " ")
-		helm.SetExtraArgs(argparser.GetArgs(args, r.state, true)...)
+		argsOpts := &argparser.GetArgsOptions{WithDiffArgs: true}
+		helm.SetExtraArgs(argparser.GetArgs(args, r.state, argsOpts)...)
 
 		var errs []error
 
@@ -1617,7 +1619,7 @@ func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) 
 		}
 		infoMsg, updated, deleted, errs = filtered.diff(true, c.DetailedExitcode(), c, opts)
 
-		helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, true)...)
+		helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, argsOpts)...)
 		return errs
 	})
 
@@ -1630,7 +1632,7 @@ func (a *App) lint(r *Run, c LintConfigProvider) (bool, []error, []error) {
 	ok, errs := a.withNeeds(r, c, false, func(st *state.HelmState) []error {
 		helm := r.helm
 
-		args := argparser.GetArgs(c.Args(), st, false)
+		args := argparser.GetArgs(c.Args(), st, nil)
 
 		// Reset the extra args if already set, not to break `helm fetch` by adding the args intended for `lint`
 		helm.SetExtraArgs()
@@ -1691,7 +1693,7 @@ func (a *App) status(r *Run, c StatusesConfigProvider) (bool, []error) {
 	// Traverse DAG of all the releases so that we don't suffer from false-positive missing dependencies
 	st.Releases = allReleases
 
-	args := argparser.GetArgs(c.Args(), st, false)
+	args := argparser.GetArgs(c.Args(), st, nil)
 
 	// Reset the extra args if already set, not to break `helm fetch` by adding the args intended for `lint`
 	helm.SetExtraArgs()
@@ -1824,7 +1826,7 @@ Do you really want to sync?
 
 	var errs []error
 
-	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, false)...)
+	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, nil)...)
 
 	// Traverse DAG of all the releases so that we don't suffer from false-positive missing dependencies
 	st.Releases = selectedAndNeededReleases
@@ -1891,7 +1893,7 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 	return a.withNeeds(r, c, false, func(st *state.HelmState) []error {
 		helm := r.helm
 
-		args := argparser.GetArgs(c.Args(), st, false)
+		args := argparser.GetArgs(c.Args(), st, nil)
 
 		// Reset the extra args if already set, not to break `helm fetch` by adding the args intended for `lint`
 		helm.SetExtraArgs()
@@ -2014,7 +2016,7 @@ func (a *App) test(r *Run, c TestConfigProvider) []error {
 	// with conditions and selectors
 	st.Releases = toTest
 
-	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, false)...)
+	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, nil)...)
 
 	return st.TestReleases(r.helm, cleanup, timeout, concurrency, state.Logs(c.Logs()))
 }

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1320,7 +1320,7 @@ func (a *App) apply(r *Run, c ApplyConfigProvider) (bool, bool, []error) {
 	st := r.state
 	helm := r.helm
 
-	helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
+	helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, false)...)
 
 	selectedReleases, selectedAndNeededReleases, err := a.getSelectedReleases(r, c.IncludeTransitiveNeeds())
 	if err != nil {
@@ -1371,7 +1371,7 @@ func (a *App) apply(r *Run, c ApplyConfigProvider) (bool, bool, []error) {
 
 	// join --args and --diff-args together to one string.
 	args := strings.Join([]string{c.Args(), c.DiffArgs()}, " ")
-	helm.SetExtraArgs(argparser.GetArgs(args, r.state)...)
+	helm.SetExtraArgs(argparser.GetArgs(args, r.state, true)...)
 
 	infoMsg, releasesToBeUpdated, releasesToBeDeleted, errs := r.diff(false, detailedExitCode, c, diffOpts)
 	if len(errs) > 0 {
@@ -1567,7 +1567,7 @@ Do you really want to delete?
 `, strings.Join(names, "\n"))
 	interactive := c.Interactive()
 	if !interactive || interactive && r.askForConfirmation(msg) {
-		r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
+		r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, false)...)
 
 		if len(releasesToDelete) > 0 {
 			_, deletionErrs := withDAG(st, helm, a.Logger, state.PlanOptions{SelectedReleases: toDelete, Reverse: true, SkipNeeds: true}, a.WrapWithoutSelector(func(subst *state.HelmState, helm helmexec.Interface) []error {
@@ -1593,7 +1593,7 @@ func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) 
 		helm := r.helm
 
 		args := strings.Join([]string{c.Args(), c.DiffArgs()}, " ")
-		helm.SetExtraArgs(argparser.GetArgs(args, r.state)...)
+		helm.SetExtraArgs(argparser.GetArgs(args, r.state, true)...)
 
 		var errs []error
 
@@ -1617,7 +1617,7 @@ func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) 
 		}
 		infoMsg, updated, deleted, errs = filtered.diff(true, c.DetailedExitcode(), c, opts)
 
-		helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
+		helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, true)...)
 		return errs
 	})
 
@@ -1630,7 +1630,7 @@ func (a *App) lint(r *Run, c LintConfigProvider) (bool, []error, []error) {
 	ok, errs := a.withNeeds(r, c, false, func(st *state.HelmState) []error {
 		helm := r.helm
 
-		args := argparser.GetArgs(c.Args(), st)
+		args := argparser.GetArgs(c.Args(), st, false)
 
 		// Reset the extra args if already set, not to break `helm fetch` by adding the args intended for `lint`
 		helm.SetExtraArgs()
@@ -1691,7 +1691,7 @@ func (a *App) status(r *Run, c StatusesConfigProvider) (bool, []error) {
 	// Traverse DAG of all the releases so that we don't suffer from false-positive missing dependencies
 	st.Releases = allReleases
 
-	args := argparser.GetArgs(c.Args(), st)
+	args := argparser.GetArgs(c.Args(), st, false)
 
 	// Reset the extra args if already set, not to break `helm fetch` by adding the args intended for `lint`
 	helm.SetExtraArgs()
@@ -1824,7 +1824,7 @@ Do you really want to sync?
 
 	var errs []error
 
-	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
+	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, false)...)
 
 	// Traverse DAG of all the releases so that we don't suffer from false-positive missing dependencies
 	st.Releases = selectedAndNeededReleases
@@ -1891,7 +1891,7 @@ func (a *App) template(r *Run, c TemplateConfigProvider) (bool, []error) {
 	return a.withNeeds(r, c, false, func(st *state.HelmState) []error {
 		helm := r.helm
 
-		args := argparser.GetArgs(c.Args(), st)
+		args := argparser.GetArgs(c.Args(), st, false)
 
 		// Reset the extra args if already set, not to break `helm fetch` by adding the args intended for `lint`
 		helm.SetExtraArgs()
@@ -2014,7 +2014,7 @@ func (a *App) test(r *Run, c TestConfigProvider) []error {
 	// with conditions and selectors
 	st.Releases = toTest
 
-	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
+	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, false)...)
 
 	return st.TestReleases(r.helm, cleanup, timeout, concurrency, state.Logs(c.Logs()))
 }

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -105,13 +105,13 @@ func (r *Run) withPreparedCharts(helmfileCommand string, opts state.ChartPrepare
 }
 
 func (r *Run) Deps(c DepsConfigProvider) []error {
-	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, false)...)
+	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, nil)...)
 
 	return r.state.UpdateDeps(r.helm, c.IncludeTransitiveNeeds())
 }
 
 func (r *Run) Repos(c ReposConfigProvider) error {
-	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, false)...)
+	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, nil)...)
 
 	return r.ctx.SyncReposOnce(r.state, r.helm)
 }

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -105,13 +105,13 @@ func (r *Run) withPreparedCharts(helmfileCommand string, opts state.ChartPrepare
 }
 
 func (r *Run) Deps(c DepsConfigProvider) []error {
-	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
+	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, false)...)
 
 	return r.state.UpdateDeps(r.helm, c.IncludeTransitiveNeeds())
 }
 
 func (r *Run) Repos(c ReposConfigProvider) error {
-	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state)...)
+	r.helm.SetExtraArgs(argparser.GetArgs(c.Args(), r.state, false)...)
 
 	return r.ctx.SyncReposOnce(r.state, r.helm)
 }

--- a/pkg/argparser/args.go
+++ b/pkg/argparser/args.go
@@ -83,7 +83,7 @@ func analyzeArgs(am *argMap, args string) {
 	}
 }
 
-func GetArgs(args string, state *state.HelmState) []string {
+func GetArgs(args string, state *state.HelmState, withDiffArgs bool) []string {
 	argsMap := newArgMap()
 
 	if len(args) > 0 {
@@ -92,6 +92,10 @@ func GetArgs(args string, state *state.HelmState) []string {
 
 	if len(state.HelmDefaults.Args) > 0 {
 		analyzeArgs(argsMap, strings.Join(state.HelmDefaults.Args, " "))
+	}
+
+	if len(state.HelmDefaults.DiffArgs) > 0 && withDiffArgs {
+		analyzeArgs(argsMap, strings.Join(state.HelmDefaults.DiffArgs, " "))
 	}
 
 	var argArr []string

--- a/pkg/argparser/args.go
+++ b/pkg/argparser/args.go
@@ -16,6 +16,9 @@ type argMap struct {
 	m     map[string][]*keyVal
 	flags []string
 }
+type GetArgsOptions struct {
+	WithDiffArgs bool
+}
 
 // isNewFlag checks if the given arg is a new flag
 func isNewFlag(flag string) bool {
@@ -83,7 +86,7 @@ func analyzeArgs(am *argMap, args string) {
 	}
 }
 
-func GetArgs(args string, state *state.HelmState, withDiffArgs bool) []string {
+func GetArgs(args string, state *state.HelmState, opts *GetArgsOptions) []string {
 	argsMap := newArgMap()
 
 	if len(args) > 0 {
@@ -94,7 +97,7 @@ func GetArgs(args string, state *state.HelmState, withDiffArgs bool) []string {
 		analyzeArgs(argsMap, strings.Join(state.HelmDefaults.Args, " "))
 	}
 
-	if len(state.HelmDefaults.DiffArgs) > 0 && withDiffArgs {
+	if len(state.HelmDefaults.DiffArgs) > 0 && opts != nil && opts.WithDiffArgs {
 		analyzeArgs(argsMap, strings.Join(state.HelmDefaults.DiffArgs, " "))
 	}
 

--- a/pkg/argparser/args_test.go
+++ b/pkg/argparser/args_test.go
@@ -16,13 +16,13 @@ func TestGetArgs(t *testing.T) {
 		expected        string
 		defaultArgs     []string
 		defaultDiffArgs []string
-		withDiffArgs    bool
+		opts            *GetArgsOptions
 	}{
 		{
 			args:            "-f a.yaml -f b.yaml -i --set app1.bootstrap=true --set app2.bootstrap=false",
 			defaultArgs:     []string{"--recreate-pods", "--force"},
 			defaultDiffArgs: []string{"--suppress", "Deployment"},
-			withDiffArgs:    true,
+			opts:            &GetArgsOptions{WithDiffArgs: true},
 			expected:        "-f a.yaml -f b.yaml -i --set app1.bootstrap=true --set app2.bootstrap=false --recreate-pods --force --suppress Deployment",
 		},
 		{
@@ -39,6 +39,7 @@ func TestGetArgs(t *testing.T) {
 			args:            "--timeout=3600 --set app1.bootstrap=true --set app2.bootstrap=false,app3.bootstrap=true",
 			defaultArgs:     []string{"--recreate-pods", "--force"},
 			defaultDiffArgs: []string{"--suppress", "Deployment"},
+			opts:            &GetArgsOptions{},
 			expected:        "--timeout=3600 --set app1.bootstrap=true --set app2.bootstrap=false,app3.bootstrap=true --recreate-pods --force",
 		},
 	}
@@ -49,7 +50,7 @@ func TestGetArgs(t *testing.T) {
 				HelmDefaults: Helmdefaults,
 			},
 		}
-		receivedArgs := GetArgs(test.args, testState, test.withDiffArgs)
+		receivedArgs := GetArgs(test.args, testState, test.opts)
 
 		require.Equalf(t, test.expected, strings.Join(receivedArgs, " "), "expected args %s, received args %s", test.expected, strings.Join(receivedArgs, " "))
 	}

--- a/pkg/argparser/args_test.go
+++ b/pkg/argparser/args_test.go
@@ -12,38 +12,44 @@ import (
 // TestGetArgs tests the GetArgs function
 func TestGetArgs(t *testing.T) {
 	tests := []struct {
-		args        string
-		expected    string
-		defaultArgs []string
+		args            string
+		expected        string
+		defaultArgs     []string
+		defaultDiffArgs []string
+		withDiffArgs    bool
 	}{
 		{
-			args:        "-f a.yaml -f b.yaml -i --set app1.bootstrap=true --set app2.bootstrap=false",
-			defaultArgs: []string{"--recreate-pods", "--force"},
-			expected:    "-f a.yaml -f b.yaml -i --set app1.bootstrap=true --set app2.bootstrap=false --recreate-pods --force",
+			args:            "-f a.yaml -f b.yaml -i --set app1.bootstrap=true --set app2.bootstrap=false",
+			defaultArgs:     []string{"--recreate-pods", "--force"},
+			defaultDiffArgs: []string{"--suppress", "Deployment"},
+			withDiffArgs:    true,
+			expected:        "-f a.yaml -f b.yaml -i --set app1.bootstrap=true --set app2.bootstrap=false --recreate-pods --force --suppress Deployment",
 		},
 		{
-			args:        "-e  a.yaml   -d b.yaml   -i --set app1.bootstrap=true --set app2.bootstrap=false",
-			defaultArgs: []string{"-q www", "-w"},
-			expected:    "-e a.yaml -d b.yaml -i --set app1.bootstrap=true --set app2.bootstrap=false -q www -w",
+			args:            "-e  a.yaml   -d b.yaml   -i --set app1.bootstrap=true --set app2.bootstrap=false",
+			defaultArgs:     []string{"-q www", "-w"},
+			defaultDiffArgs: []string{},
+			expected:        "-e a.yaml -d b.yaml -i --set app1.bootstrap=true --set app2.bootstrap=false -q www -w",
 		},
 		{
 			args:     "--timeout=3600 --set app1.bootstrap=true --set app2.bootstrap=false",
 			expected: "--timeout=3600 --set app1.bootstrap=true --set app2.bootstrap=false",
 		},
 		{
-			args:        "--timeout=3600 --set app1.bootstrap=true --set app2.bootstrap=false,app3.bootstrap=true",
-			defaultArgs: []string{"--recreate-pods", "--force"},
-			expected:    "--timeout=3600 --set app1.bootstrap=true --set app2.bootstrap=false,app3.bootstrap=true --recreate-pods --force",
+			args:            "--timeout=3600 --set app1.bootstrap=true --set app2.bootstrap=false,app3.bootstrap=true",
+			defaultArgs:     []string{"--recreate-pods", "--force"},
+			defaultDiffArgs: []string{"--suppress", "Deployment"},
+			expected:        "--timeout=3600 --set app1.bootstrap=true --set app2.bootstrap=false,app3.bootstrap=true --recreate-pods --force",
 		},
 	}
 	for _, test := range tests {
-		Helmdefaults := state.HelmSpec{KubeContext: "test", Args: test.defaultArgs}
+		Helmdefaults := state.HelmSpec{KubeContext: "test", Args: test.defaultArgs, DiffArgs: test.defaultDiffArgs}
 		testState := &state.HelmState{
 			ReleaseSetSpec: state.ReleaseSetSpec{
 				HelmDefaults: Helmdefaults,
 			},
 		}
-		receivedArgs := GetArgs(test.args, testState)
+		receivedArgs := GetArgs(test.args, testState, test.withDiffArgs)
 
 		require.Equalf(t, test.expected, strings.Join(receivedArgs, " "), "expected args %s, received args %s", test.expected, strings.Join(receivedArgs, " "))
 	}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -148,6 +148,7 @@ type SubhelmfileEnvironmentSpec struct {
 type HelmSpec struct {
 	KubeContext string   `yaml:"kubeContext,omitempty"`
 	Args        []string `yaml:"args,omitempty"`
+	DiffArgs    []string `yaml:"diffArgs,omitempty"`
 	Verify      bool     `yaml:"verify"`
 	Keyring     string   `yaml:"keyring,omitempty"`
 	// EnableDNS, when set to true, enable DNS lookups when rendering templates


### PR DESCRIPTION
This OSS always helps me. Thank you to all the maintainers.

In my use case, I want to keep `diffArgs` in `helmfile.yaml`. (Added in #959)
I think this is useful if you want to specify additional arguments to `helm-diff` only when using a specific `helmfile.yaml`.
(It is now possible to version control argument specifications for specific charts)

Please let me know if there is anything else I need to do to fix it.

---

For example,

```
$ ls -l helmfile.yaml 
-rw-r--r-- 1 tkhs tkhs 1567 Sep 13 00:03 helmfile.yaml

$ /home/runner/work/helmfile/helmfile/helmfile diff
Adding repo eks https://aws.github.io/eks-charts
"eks" has been added to your repositories

Comparing release=aws-load-balancer-controller, chart=eks/aws-load-balancer-controller
kube-system, aws-load-balancer-tls, Secret (v1) has changed:
  # Source: aws-load-balancer-controller/templates/webhook.yaml
  apiVersion: v1
  kind: Secret
  metadata:
    labels:
      app.kubernetes.io/instance: aws-load-balancer-controller
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: aws-load-balancer-controller
      app.kubernetes.io/version: v2.4.5
      helm.sh/chart: aws-load-balancer-controller-1.4.6
    name: aws-load-balancer-tls
    namespace: kube-system
  data:
-   ca.crt: '-------- # (1188 bytes)'
-   tls.crt: '-------- # (1428 bytes)'
-   tls.key: '-------- # (1679 bytes)'
+   ca.crt: '++++++++ # (1188 bytes)'
+   tls.crt: '++++++++ # (1428 bytes)'
+   tls.key: '++++++++ # (1675 bytes)'
  type: kubernetes.io/tls
...

kube-system, aws-load-balancer-webhook, MutatingWebhookConfiguration (admissionregistration.k8s.io) has changed:
  # Source: aws-load-balancer-controller/templates/webhook.yaml
  apiVersion: admissionregistration.k8s.io/v1
  kind: MutatingWebhookConfiguration
  metadata:
    name: aws-load-balancer-webhook
    labels:
      helm.sh/chart: aws-load-balancer-controller-1.4.6
      app.kubernetes.io/name: aws-load-balancer-controller
      app.kubernetes.io/instance: aws-load-balancer-controller
      app.kubernetes.io/version: "v2.4.5"
      app.kubernetes.io/managed-by: Helm
  webhooks:
  - clientConfig:
-     caBundle: LS0tLxxxxx
+     caBundle: LS0tLyyyyy
```

Add `helmDefaults.diffArgs` to `helmfile.yaml`

```yaml
helmDefaults:
  diffArgs:
    - --suppress-secrets
    - --suppress
    - MutatingWebhookConfiguration
    - --suppress
    - ValidatingWebhookConfiguration
```

Options are set for `helm-diff` only `helmfile diff` and `helmfile apply` .

```
$ /home/runner/work/helmfile/helmfile/helmfile diff
Adding repo eks https://aws.github.io/eks-charts
"eks" has been added to your repositories

Comparing release=aws-load-balancer-controller, chart=eks/aws-load-balancer-controller
kube-system, aws-load-balancer-tls, Secret (v1) has changed:
+ Changes suppressed on sensitive content of type Secret
kube-system, aws-load-balancer-webhook, MutatingWebhookConfiguration (admissionregistration.k8s.io) has changed:
+ Changes suppressed on sensitive content of type MutatingWebhookConfiguration
kube-system, aws-load-balancer-webhook, ValidatingWebhookConfiguration (admissionregistration.k8s.io) has changed:
+ Changes suppressed on sensitive content of type ValidatingWebhookConfiguration
```

Other subcommands, such as `helmfile template`, are not affected.

```
$ /home/runner/work/helmfile/helmfile/helmfile template | head
Adding repo eks https://aws.github.io/eks-charts
"eks" has been added to your repositories

Templating release=aws-load-balancer-controller, chart=eks/aws-load-balancer-controller
---
# Source: aws-load-balancer-controller/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: aws-load-balancer-controller
  namespace: kube-system
  labels:
    helm.sh/chart: aws-load-balancer-controller-1.4.6
    app.kubernetes.io/name: aws-load-balancer-controller
```