### PR TITLE
feat: support most remote urls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/a8m/envsubst v1.3.0 // indirect
-	github.com/aws/aws-sdk-go v1.44.122 // indirect
+	github.com/aws/aws-sdk-go v1.44.251
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/dimchansky/utfbom v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,9 @@ github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a h1:pv34s756C4pEXnjg
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
-github.com/aws/aws-sdk-go v1.44.122 h1:p6mw01WBaNpbdP2xrisz5tIkcNwzj/HysobNoaAHjgo=
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.44.251 h1:unCIT7a/BkYvJ/43D0Ts/0aRbWDMQM0SUzBtdsKPwCg=
+github.com/aws/aws-sdk-go v1.44.251/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.21.0 h1:gMT0IW+03wtYJhRqTVYn0wLzwdnK9sRMcxmtfGzRdJc=
 github.com/aws/aws-sdk-go-v2 v1.21.0/go.mod h1:/RfNgGmRxI+iFOB1OeJUyxiU+9s88k3pfHvDagGEp0M=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.13 h1:OPLEkmhXf6xFPiz0bLeDArZIDx1NNS4oJyG4nv3Gct0=

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -244,8 +244,8 @@ func (r *Remote) Fetch(path string, cacheDirOpt ...string) (string, error) {
 
 		if u.Getter == "normal" {
 			cachedFilePath := filepath.Join(cacheDirPath, file)
-			_, err := os.Stat(cachedFilePath)
-			if err == nil {
+			ok, err := r.fs.FileExists(cachedFilePath)
+			if err == nil && ok {
 				cached = true
 			}
 		} else if r.fs.DirectoryExistsAt(cacheDirPath) {
@@ -512,6 +512,10 @@ func (g *S3Getter) S3FileExists(path string) (string, error) {
 
 func HttpFileExists(path string) error {
 	head, err := http.Head(path)
+	statusOK := head.StatusCode >= 200 && head.StatusCode < 300
+	if !statusOK {
+		return fmt.Errorf("%s is not exists: head request get http code %d", path, head.StatusCode)
+	}
 	defer func() {
 		_ = head.Body.Close()
 	}()

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -151,6 +151,9 @@ func ParseNormal(path string) (*Source, error) {
 	}
 
 	u, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
 	dir := filepath.Dir(u.Path)
 	if len(dir) > 0 {
 		dir = dir[1:]
@@ -164,7 +167,7 @@ func ParseNormal(path string) (*Source, error) {
 		Dir:      dir,
 		File:     filepath.Base(u.Path),
 		RawQuery: u.RawQuery,
-	}, err
+	}, nil
 }
 
 func ParseNormalProtocol(path string) (string, error) {
@@ -363,9 +366,6 @@ func (g *S3Getter) Get(wd, src, dst string) error {
 			Region: aws.String(region),
 		},
 	}))
-	if err != nil {
-		return err
-	}
 
 	// Create an S3 client using the session
 	s3Client := s3.New(sess)
@@ -462,9 +462,6 @@ func (g *S3Getter) S3FileExists(path string) (string, error) {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
-	if err != nil {
-		return "", fmt.Errorf("failed to authentication with aws %w", err)
-	}
 
 	g.Logger.Debugf("Getting bucket %s location %s", bucket, path)
 	s3Client := s3.New(sess)

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -1,540 +1,559 @@
 package remote
 
 import (
-  "context"
-  "fmt"
-  "github.com/aws/aws-sdk-go/aws"
-  "io"
-  "path"
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"io"
+	"path"
 
-  "net/http"
-  neturl "net/url"
-  "os"
-  "path/filepath"
-  "strconv"
-  "strings"
+	"net/http"
+	neturl "net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 
-  "github.com/aws/aws-sdk-go/aws/session"
-  "github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
 
-  "github.com/hashicorp/go-getter"
-  "github.com/hashicorp/go-getter/helper/url"
-  "go.uber.org/multierr"
-  "go.uber.org/zap"
+	"github.com/hashicorp/go-getter"
+	"github.com/hashicorp/go-getter/helper/url"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
 
-  "github.com/helmfile/helmfile/pkg/envvar"
-  "github.com/helmfile/helmfile/pkg/filesystem"
+	"github.com/helmfile/helmfile/pkg/envvar"
+	"github.com/helmfile/helmfile/pkg/filesystem"
 )
 
 var disableInsecureFeatures bool
 
 func init() {
-  disableInsecureFeatures, _ = strconv.ParseBool(os.Getenv(envvar.DisableInsecureFeatures))
+	disableInsecureFeatures, _ = strconv.ParseBool(os.Getenv(envvar.DisableInsecureFeatures))
 }
 
 func CacheDir() string {
-  if h := os.Getenv(envvar.CacheHome); h != "" {
-    return h
-  }
+	if h := os.Getenv(envvar.CacheHome); h != "" {
+		return h
+	}
 
-  dir, err := os.UserCacheDir()
-  if err != nil {
-    // fall back to relative path with hidden directory
-    return ".helmfile"
-  }
-  return filepath.Join(dir, "helmfile")
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		// fall back to relative path with hidden directory
+		return ".helmfile"
+	}
+	return filepath.Join(dir, "helmfile")
 }
 
 type Remote struct {
-  Logger *zap.SugaredLogger
+	Logger *zap.SugaredLogger
 
-  // Home is the directory in which remote downloads files. If empty, user cache directory is used
-  Home string
+	// Home is the directory in which remote downloads files. If empty, user cache directory is used
+	Home string
 
-  // Getter is the underlying implementation of getter used for fetching remote files
-  Getter Getter
+	// Getter is the underlying implementation of getter used for fetching remote files
+	Getter Getter
 
-  S3Getter Getter
+	S3Getter Getter
 
-  HttpGetter Getter
+	HttpGetter Getter
 
-  // Filesystem abstraction
-  // Inject any implementation of your choice, like an im-memory impl for testing, os.ReadFile for the real-world use.
-  fs *filesystem.FileSystem
+	// Filesystem abstraction
+	// Inject any implementation of your choice, like an im-memory impl for testing, os.ReadFile for the real-world use.
+	fs *filesystem.FileSystem
 }
 
 // Locate takes an URL to a remote file or a path to a local file.
 // If the argument was an URL, it fetches the remote directory contained within the URL,
 // and returns the path to the file in the fetched directory
 func (r *Remote) Locate(urlOrPath string, cacheDirOpt ...string) (string, error) {
-  if r.fs.FileExistsAt(urlOrPath) || r.fs.DirectoryExistsAt(urlOrPath) {
-    return urlOrPath, nil
-  }
-  fetched, err := r.Fetch(urlOrPath, cacheDirOpt...)
-  if err != nil {
-    if _, ok := err.(InvalidURLError); ok {
-      return urlOrPath, nil
-    }
-    return "", err
-  }
-  return fetched, nil
+	if r.fs.FileExistsAt(urlOrPath) || r.fs.DirectoryExistsAt(urlOrPath) {
+		return urlOrPath, nil
+	}
+	fetched, err := r.Fetch(urlOrPath, cacheDirOpt...)
+	if err != nil {
+		if _, ok := err.(InvalidURLError); ok {
+			return urlOrPath, nil
+		}
+		return "", err
+	}
+	return fetched, nil
 }
 
 type InvalidURLError struct {
-  err string
+	err string
 }
 
 func (e InvalidURLError) Error() string {
-  return e.err
+	return e.err
 }
 
 type Source struct {
-  Getter, Scheme, User, Host, Dir, File, RawQuery string
+	Getter, Scheme, User, Host, Dir, File, RawQuery string
 }
 
 func IsRemote(goGetterSrc string) bool {
-  if _, err := Parse(goGetterSrc); err != nil {
-    return false
-  }
-  return true
+	if _, err := Parse(goGetterSrc); err != nil {
+		return false
+	}
+	return true
 }
 
 func Parse(goGetterSrc string) (*Source, error) {
-  items := strings.Split(goGetterSrc, "::")
-  var getter string
-  if len(items) == 2 {
-    getter = items[0]
-    goGetterSrc = items[1]
-  } else {
-    items = strings.Split(goGetterSrc, "://")
+	items := strings.Split(goGetterSrc, "::")
+	var getter string
+	if len(items) == 2 {
+		getter = items[0]
+		goGetterSrc = items[1]
+	} else {
+		items = strings.Split(goGetterSrc, "://")
 
-    if len(items) == 2 {
-      return ParseNormal(goGetterSrc)
-    }
-  }
+		if len(items) == 2 {
+			return ParseNormal(goGetterSrc)
+		}
+	}
 
-  u, err := url.Parse(goGetterSrc)
-  if err != nil {
-    return nil, InvalidURLError{err: fmt.Sprintf("parse url: %v", err)}
-  }
+	u, err := url.Parse(goGetterSrc)
+	if err != nil {
+		return nil, InvalidURLError{err: fmt.Sprintf("parse url: %v", err)}
+	}
 
-  if u.Scheme == "" {
-    return nil, InvalidURLError{err: fmt.Sprintf("parse url: missing scheme - probably this is a local file path? %s", goGetterSrc)}
-  }
+	if u.Scheme == "" {
+		return nil, InvalidURLError{err: fmt.Sprintf("parse url: missing scheme - probably this is a local file path? %s", goGetterSrc)}
+	}
 
-  pathComponents := strings.Split(u.Path, "@")
-  if len(pathComponents) != 2 {
-    dir := filepath.Dir(u.Path)
-    if len(dir) > 0 {
-      dir = dir[1:]
-    }
-    pathComponents = []string{dir, filepath.Base(u.Path)}
-  }
+	pathComponents := strings.Split(u.Path, "@")
+	if len(pathComponents) != 2 {
+		dir := filepath.Dir(u.Path)
+		if len(dir) > 0 {
+			dir = dir[1:]
+		}
+		pathComponents = []string{dir, filepath.Base(u.Path)}
+	}
 
-  return &Source{
-    Getter:   getter,
-    User:     u.User.String(),
-    Scheme:   u.Scheme,
-    Host:     u.Host,
-    Dir:      pathComponents[0],
-    File:     pathComponents[1],
-    RawQuery: u.RawQuery,
-  }, nil
+	return &Source{
+		Getter:   getter,
+		User:     u.User.String(),
+		Scheme:   u.Scheme,
+		Host:     u.Host,
+		Dir:      pathComponents[0],
+		File:     pathComponents[1],
+		RawQuery: u.RawQuery,
+	}, nil
 }
 
 func ParseNormal(path string) (*Source, error) {
-  _, err := ParseNormalProtocol(path)
-  if err != nil {
-    return nil, err
-  }
+	_, err := ParseNormalProtocol(path)
+	if err != nil {
+		return nil, err
+	}
 
-  u, err := url.Parse(path)
-  dir := filepath.Dir(u.Path)
-  if len(dir) > 0 {
-    dir = dir[1:]
-  }
+	u, err := url.Parse(path)
+	dir := filepath.Dir(u.Path)
+	if len(dir) > 0 {
+		dir = dir[1:]
+	}
 
-  return &Source{
-    Getter:   "normal",
-    User:     u.User.String(),
-    Scheme:   u.Scheme,
-    Host:     u.Host,
-    Dir:      dir,
-    File:     filepath.Base(u.Path),
-    RawQuery: u.RawQuery,
-  }, err
+	return &Source{
+		Getter:   "normal",
+		User:     u.User.String(),
+		Scheme:   u.Scheme,
+		Host:     u.Host,
+		Dir:      dir,
+		File:     filepath.Base(u.Path),
+		RawQuery: u.RawQuery,
+	}, err
 }
 
 func ParseNormalProtocol(path string) (string, error) {
-  parts := strings.Split(path, "://")
+	parts := strings.Split(path, "://")
 
-  if len(parts) == 0 {
-    return "", fmt.Errorf("failed to parse URL %s", path)
-  }
-  protocol := strings.ToLower(parts[0])
+	if len(parts) == 0 {
+		return "", fmt.Errorf("failed to parse URL %s", path)
+	}
+	protocol := strings.ToLower(parts[0])
 
-  protocols := []string{"s3", "http", "https"}
-  for _, option := range protocols {
-    if option == protocol {
-      return protocol, nil
-    }
-  }
-  return "", fmt.Errorf("failed to parse URL %s", path)
+	protocols := []string{"s3", "http", "https"}
+	for _, option := range protocols {
+		if option == protocol {
+			return protocol, nil
+		}
+	}
+	return "", fmt.Errorf("failed to parse URL %s", path)
 }
 
 func (r *Remote) Fetch(path string, cacheDirOpt ...string) (string, error) {
-  u, err := Parse(path)
-  if err != nil {
-    return "", err
-  }
+	u, err := Parse(path)
+	if err != nil {
+		return "", err
+	}
 
-  srcDir := fmt.Sprintf("%s://%s/%s", u.Scheme, u.Host, u.Dir)
-  file := u.File
+	srcDir := fmt.Sprintf("%s://%s/%s", u.Scheme, u.Host, u.Dir)
+	file := u.File
 
-  r.Logger.Debugf("remote> getter: %s", u.Getter)
-  r.Logger.Debugf("remote> scheme: %s", u.Scheme)
-  r.Logger.Debugf("remote> user: %s", u.User)
-  r.Logger.Debugf("remote> host: %s", u.Host)
-  r.Logger.Debugf("remote> dir: %s", u.Dir)
-  r.Logger.Debugf("remote> file: %s", u.File)
+	r.Logger.Debugf("remote> getter: %s", u.Getter)
+	r.Logger.Debugf("remote> scheme: %s", u.Scheme)
+	r.Logger.Debugf("remote> user: %s", u.User)
+	r.Logger.Debugf("remote> host: %s", u.Host)
+	r.Logger.Debugf("remote> dir: %s", u.Dir)
+	r.Logger.Debugf("remote> file: %s", u.File)
 
-  // This should be shared across variant commands, so that they can share cache for the shared imports
-  cacheBaseDir := ""
-  if len(cacheDirOpt) == 1 {
-    cacheBaseDir = cacheDirOpt[0]
-  } else if len(cacheDirOpt) > 0 {
-    return "", fmt.Errorf("[bug] cacheDirOpt's length: want 0 or 1, got %d", len(cacheDirOpt))
-  }
+	// This should be shared across variant commands, so that they can share cache for the shared imports
+	cacheBaseDir := ""
+	if len(cacheDirOpt) == 1 {
+		cacheBaseDir = cacheDirOpt[0]
+	} else if len(cacheDirOpt) > 0 {
+		return "", fmt.Errorf("[bug] cacheDirOpt's length: want 0 or 1, got %d", len(cacheDirOpt))
+	}
 
-  query := u.RawQuery
+	query := u.RawQuery
 
-  var cacheKey string
-  replacer := strings.NewReplacer(":", "", "//", "_", "/", "_", ".", "_")
-  dirKey := replacer.Replace(srcDir)
-  if len(query) > 0 {
-    q, _ := neturl.ParseQuery(query)
-    if q.Has("sshkey") {
-      q.Set("sshkey", "redacted")
-    }
-    paramsKey := strings.ReplaceAll(q.Encode(), "&", "_")
-    cacheKey = fmt.Sprintf("%s.%s", dirKey, paramsKey)
-  } else {
-    cacheKey = dirKey
-  }
+	var cacheKey string
+	replacer := strings.NewReplacer(":", "", "//", "_", "/", "_", ".", "_")
+	dirKey := replacer.Replace(srcDir)
+	if len(query) > 0 {
+		q, _ := neturl.ParseQuery(query)
+		if q.Has("sshkey") {
+			q.Set("sshkey", "redacted")
+		}
+		paramsKey := strings.ReplaceAll(q.Encode(), "&", "_")
+		cacheKey = fmt.Sprintf("%s.%s", dirKey, paramsKey)
+	} else {
+		cacheKey = dirKey
+	}
 
-  cached := false
+	cached := false
 
-  // e.g. https_github_com_cloudposse_helmfiles_git.ref=0.xx.0
-  getterDst := filepath.Join(cacheBaseDir, cacheKey)
+	// e.g. https_github_com_cloudposse_helmfiles_git.ref=0.xx.0
+	getterDst := filepath.Join(cacheBaseDir, cacheKey)
 
-  // e.g. os.CacheDir()/helmfile/https_github_com_cloudposse_helmfiles_git.ref=0.xx.0
-  cacheDirPath := filepath.Join(r.Home, getterDst)
-  if u.Getter == "normal" {
-    srcDir = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
-    cacheKey = replacer.Replace(srcDir)
-    cacheDirPath = filepath.Join(r.Home, cacheKey, u.Dir)
-  }
+	// e.g. os.CacheDir()/helmfile/https_github_com_cloudposse_helmfiles_git.ref=0.xx.0
+	cacheDirPath := filepath.Join(r.Home, getterDst)
+	if u.Getter == "normal" {
+		srcDir = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+		cacheKey = replacer.Replace(srcDir)
+		cacheDirPath = filepath.Join(r.Home, cacheKey, u.Dir)
+	}
 
-  r.Logger.Debugf("remote> home: %s", r.Home)
-  r.Logger.Debugf("remote> getter dest: %s", getterDst)
-  r.Logger.Debugf("remote> cached dir: %s", cacheDirPath)
+	r.Logger.Debugf("remote> home: %s", r.Home)
+	r.Logger.Debugf("remote> getter dest: %s", getterDst)
+	r.Logger.Debugf("remote> cached dir: %s", cacheDirPath)
 
-  {
-    if r.fs.FileExistsAt(cacheDirPath) {
-      return "", fmt.Errorf("%s is not directory. please remove it so that variant could use it for dependency caching", getterDst)
-    }
+	{
+		if r.fs.FileExistsAt(cacheDirPath) {
+			return "", fmt.Errorf("%s is not directory. please remove it so that variant could use it for dependency caching", getterDst)
+		}
 
-    if u.Getter == "normal" {
-      cachedFilePath := filepath.Join(cacheDirPath, file)
-      _, err := os.Stat(cachedFilePath)
-      if err == nil {
-        cached = true
-      }
-    } else if r.fs.DirectoryExistsAt(cacheDirPath) {
-      cached = true
-    }
-  }
+		if u.Getter == "normal" {
+			cachedFilePath := filepath.Join(cacheDirPath, file)
+			_, err := os.Stat(cachedFilePath)
+			if err == nil {
+				cached = true
+			}
+		} else if r.fs.DirectoryExistsAt(cacheDirPath) {
+			cached = true
+		}
+	}
 
-  if !cached {
-    var getterSrc string
-    if u.User != "" {
-      getterSrc = fmt.Sprintf("%s://%s@%s%s", u.Scheme, u.User, u.Host, u.Dir)
-    } else {
-      getterSrc = fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, u.Dir)
-    }
+	if !cached {
+		var getterSrc string
+		if u.User != "" {
+			getterSrc = fmt.Sprintf("%s://%s@%s%s", u.Scheme, u.User, u.Host, u.Dir)
+		} else {
+			getterSrc = fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, u.Dir)
+		}
 
-    if len(query) > 0 {
-      getterSrc = strings.Join([]string{getterSrc, query}, "?")
-    }
+		if len(query) > 0 {
+			getterSrc = strings.Join([]string{getterSrc, query}, "?")
+		}
 
-    r.Logger.Debugf("remote> downloading %s to %s", getterSrc, getterDst)
+		r.Logger.Debugf("remote> downloading %s to %s", getterSrc, getterDst)
 
-    if u.Getter == "normal" && u.Scheme == "s3" {
+		if u.Getter == "normal" && u.Scheme == "s3" {
 
-      err := r.S3Getter.Get(r.Home, path, cacheDirPath)
-      if err != nil {
-        return "", multierr.Append(err, err)
-      }
+			err := r.S3Getter.Get(r.Home, path, cacheDirPath)
+			if err != nil {
+				return "", multierr.Append(err, err)
+			}
 
-    } else if u.Getter == "normal" && (u.Scheme == "https" || u.Scheme == "http") {
-      err := r.HttpGetter.Get(r.Home, path, cacheDirPath)
-      if err != nil {
-        return "", multierr.Append(err, err)
-      }
-    } else {
-      if u.Getter != "" {
-        getterSrc = u.Getter + "::" + getterSrc
-      }
+		} else if u.Getter == "normal" && (u.Scheme == "https" || u.Scheme == "http") {
+			err := r.HttpGetter.Get(r.Home, path, cacheDirPath)
+			if err != nil {
+				return "", multierr.Append(err, err)
+			}
+		} else {
+			if u.Getter != "" {
+				getterSrc = u.Getter + "::" + getterSrc
+			}
 
-      if err := r.Getter.Get(r.Home, getterSrc, cacheDirPath); err != nil {
-        rmerr := os.RemoveAll(cacheDirPath)
-        if rmerr != nil {
-          return "", multierr.Append(err, rmerr)
-        }
-        return "", err
-      }
-    }
+			if err := r.Getter.Get(r.Home, getterSrc, cacheDirPath); err != nil {
+				rmerr := os.RemoveAll(cacheDirPath)
+				if rmerr != nil {
+					return "", multierr.Append(err, rmerr)
+				}
+				return "", err
+			}
+		}
 
-  }
+	}
 
-  return filepath.Join(cacheDirPath, file), nil
+	return filepath.Join(cacheDirPath, file), nil
 }
 
 type Getter interface {
-  Get(wd, src, dst string) error
+	Get(wd, src, dst string) error
 }
 
 type GoGetter struct {
-  Logger *zap.SugaredLogger
+	Logger *zap.SugaredLogger
 }
 
 type S3Getter struct {
-  Logger *zap.SugaredLogger
+	Logger *zap.SugaredLogger
 }
 
 type HttpGetter struct {
-  Logger *zap.SugaredLogger
+	Logger *zap.SugaredLogger
 }
 
 func (g *GoGetter) Get(wd, src, dst string) error {
-  ctx := context.Background()
+	ctx := context.Background()
 
-  get := &getter.Client{
-    Ctx:     ctx,
-    Src:     src,
-    Dst:     dst,
-    Pwd:     wd,
-    Mode:    getter.ClientModeDir,
-    Options: []getter.ClientOption{},
-  }
+	get := &getter.Client{
+		Ctx:     ctx,
+		Src:     src,
+		Dst:     dst,
+		Pwd:     wd,
+		Mode:    getter.ClientModeDir,
+		Options: []getter.ClientOption{},
+	}
 
-  g.Logger.Debugf("client: %+v", *get)
+	g.Logger.Debugf("client: %+v", *get)
 
-  if err := get.Get(); err != nil {
-    return fmt.Errorf("get: %v", err)
-  }
+	if err := get.Get(); err != nil {
+		return fmt.Errorf("get: %v", err)
+	}
 
-  return nil
+	return nil
 }
 
 func (g *S3Getter) Get(wd, src, dst string) error {
 
-  u, err := url.Parse(src)
-  if err != nil {
-    return err
-  }
-  file := path.Base(u.Path)
-  targetFilePath := filepath.Join(dst, file)
+	u, err := url.Parse(src)
+	if err != nil {
+		return err
+	}
+	file := path.Base(u.Path)
+	targetFilePath := filepath.Join(dst, file)
 
-  region, err := S3FileExists(src)
-  if err != nil {
-    return err
-  }
+	region, err := g.S3FileExists(src)
+	if err != nil {
+		return err
+	}
 
-  bucket, key, err := ParseS3Url(src)
-  if err != nil {
-    return err
-  }
+	bucket, key, err := ParseS3Url(src)
+	if err != nil {
+		return err
+	}
 
-  err = os.MkdirAll(dst, os.FileMode(0700))
-  if err != nil {
-    return err
-  }
+	err = os.MkdirAll(dst, os.FileMode(0700))
+	if err != nil {
+		return err
+	}
 
-  // Create a new AWS session using the default AWS configuration
-  sess := session.Must(session.NewSessionWithOptions(session.Options{
-    SharedConfigState: session.SharedConfigEnable,
-    Config: aws.Config{
-      Region: aws.String(region),
-    },
-  }))
-  if err != nil {
-    return err
-  }
+	// Create a new AWS session using the default AWS configuration
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+		Config: aws.Config{
+			Region: aws.String(region),
+		},
+	}))
+	if err != nil {
+		return err
+	}
 
-  // Create an S3 client using the session
-  s3Client := s3.New(sess)
+	// Create an S3 client using the session
+	s3Client := s3.New(sess)
 
-  getObjectInput := &s3.GetObjectInput{
-    Bucket: &bucket,
-    Key:    &key,
-  }
-  resp, err := s3Client.GetObject(getObjectInput)
-  defer func(Body io.ReadCloser) {
-    err := Body.Close()
-    if err != nil {
-      g.Logger.Errorf("Error closing connection to remote data source \n%v", err)
-    }
-  }(resp.Body)
+	getObjectInput := &s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	}
+	resp, err := s3Client.GetObject(getObjectInput)
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			g.Logger.Errorf("Error closing connection to remote data source \n%v", err)
+		}
+	}(resp.Body)
 
-  if err != nil {
-    return err
-  }
+	if err != nil {
+		return err
+	}
 
-  localFile, err := os.Create(targetFilePath)
-  if err != nil {
-    return err
-  }
-  defer func(localFile *os.File) {
-    err := localFile.Close()
-    if err != nil {
-      g.Logger.Errorf("Error writing file \n%v", err)
-    }
-  }(localFile)
+	localFile, err := os.Create(targetFilePath)
+	if err != nil {
+		return err
+	}
+	defer func(localFile *os.File) {
+		err := localFile.Close()
+		if err != nil {
+			g.Logger.Errorf("Error writing file \n%v", err)
+		}
+	}(localFile)
 
-  _, err = localFile.ReadFrom(resp.Body)
-  if err != nil {
-    return err
-  }
+	_, err = localFile.ReadFrom(resp.Body)
+	if err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 }
 
 func (g *HttpGetter) Get(wd, src, dst string) error {
 
-  u, err := url.Parse(src)
-  if err != nil {
-    return err
-  }
-  file := path.Base(u.Path)
-  targetFilePath := filepath.Join(dst, file)
+	u, err := url.Parse(src)
+	if err != nil {
+		return err
+	}
+	file := path.Base(u.Path)
+	targetFilePath := filepath.Join(dst, file)
 
-  err = HttpFileExists(src)
-  if err != nil {
-    return err
-  }
+	err = HttpFileExists(src)
+	if err != nil {
+		return err
+	}
 
-  err = os.MkdirAll(dst, os.FileMode(0700))
-  if err != nil {
-    return err
-  }
+	err = os.MkdirAll(dst, os.FileMode(0700))
+	if err != nil {
+		return err
+	}
 
-  resp, err := http.Get(src)
-  defer func(Body io.ReadCloser) {
-    err := Body.Close()
-    if err != nil {
-      fmt.Printf("Error %v", err)
-      g.Logger.Errorf("Error closing connection to remote data source\n%v", err)
-    }
-  }(resp.Body)
+	resp, err := http.Get(src)
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			fmt.Printf("Error %v", err)
+			g.Logger.Errorf("Error closing connection to remote data source\n%v", err)
+		}
+	}(resp.Body)
 
-  if err != nil {
-    fmt.Printf("Error %v", err)
-    return err
-  }
+	if err != nil {
+		fmt.Printf("Error %v", err)
+		return err
+	}
 
-  localFile, err := os.Create(targetFilePath)
-  if err != nil {
-    return err
-  }
-  defer func(localFile *os.File) {
-    err := localFile.Close()
-    if err != nil {
-      g.Logger.Errorf("Error writing file \n%v", err)
-    }
-  }(localFile)
+	localFile, err := os.Create(targetFilePath)
+	if err != nil {
+		return err
+	}
+	defer func(localFile *os.File) {
+		err := localFile.Close()
+		if err != nil {
+			g.Logger.Errorf("Error writing file \n%v", err)
+		}
+	}(localFile)
 
-  _, err = localFile.ReadFrom(resp.Body)
-  if err != nil {
-    return err
-  }
+	_, err = localFile.ReadFrom(resp.Body)
+	if err != nil {
+		return err
+	}
 
-  return nil
+	return nil
 }
 
-func S3FileExists(path string) (string, error) {
+func (g *S3Getter) S3FileExists(path string) (string, error) {
 
-  bucket, key, err := ParseS3Url(path)
-  if err != nil {
-    return "", err
-  }
+	g.Logger.Debugf("Parsing S3 URL %s", path)
+	bucket, key, err := ParseS3Url(path)
+	if err != nil {
+		return "", err
+	}
 
-  // Region
-  sess := session.Must(session.NewSessionWithOptions(session.Options{
-    SharedConfigState: session.SharedConfigEnable,
-  }))
-  if err != nil {
-    return "", fmt.Errorf("failed to authentication with aws %w", err)
-  }
+	// Region
+	g.Logger.Debugf("Creating session for determining S3 region %s", path)
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+	if err != nil {
+		return "", fmt.Errorf("failed to authentication with aws %w", err)
+	}
 
-  s3Client := s3.New(sess)
-  getBucketLocationInput := &s3.GetBucketLocationInput{
-    Bucket: aws.String(bucket),
-  }
-  resp, err := s3Client.GetBucketLocation(getBucketLocationInput)
-  if err != nil {
-    return "", fmt.Errorf("Error: Failed to retrieve bucket location: %v\n", err)
-  }
+	g.Logger.Debugf("Getting bucket %s location %s", bucket, path)
+	s3Client := s3.New(sess)
+	bucketRegion := "us-east-1"
+	getBucketLocationInput := &s3.GetBucketLocationInput{
+		Bucket: aws.String(bucket),
+	}
+	resp, err := s3Client.GetBucketLocation(getBucketLocationInput)
+	if err != nil {
+		return "", fmt.Errorf("Error: Failed to retrieve bucket location: %v\n", err)
+	}
+	if resp == nil || resp.LocationConstraint == nil {
+		g.Logger.Debugf("Bucket has no location Assuming us-east-1")
+	} else {
+		bucketRegion = *resp.LocationConstraint
+	}
+	g.Logger.Debugf("Got bucket location %s", bucketRegion)
 
-  // File existence
-  s3Client = s3.New(sess)
-  headObjectInput := &s3.HeadObjectInput{
-    Bucket: &bucket,
-    Key:    &key,
-  }
+	// File existence
+	g.Logger.Debugf("Creating new session with region to see if file exists")
+	regionSession, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+		Config: aws.Config{
+			Region: aws.String(bucketRegion),
+		},
+	})
+	g.Logger.Debugf("Creating new s3 client to check if object exists")
+	s3Client = s3.New(regionSession)
+	headObjectInput := &s3.HeadObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	}
 
-  _, err = s3Client.HeadObject(headObjectInput)
-  return *resp.LocationConstraint, err
+	g.Logger.Debugf("Fethcing head %s", path)
+	_, err = s3Client.HeadObject(headObjectInput)
+	return bucketRegion, err
 }
 
 func HttpFileExists(path string) error {
-  _, err := http.Head(path)
-  return err
+	_, err := http.Head(path)
+	return err
 }
 
 func ParseS3Url(s3URL string) (string, string, error) {
-  parsedURL, err := url.Parse(s3URL)
-  if err != nil {
-    return "", "", fmt.Errorf("failed to parse S3 URL: %w", err)
-  }
+	parsedURL, err := url.Parse(s3URL)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse S3 URL: %w", err)
+	}
 
-  if parsedURL.Scheme != "s3" {
-    return "", "", fmt.Errorf("invalid URL scheme (expected 's3')")
-  }
+	if parsedURL.Scheme != "s3" {
+		return "", "", fmt.Errorf("invalid URL scheme (expected 's3')")
+	}
 
-  bucket := parsedURL.Host
-  key := strings.TrimPrefix(parsedURL.Path, "/")
+	bucket := parsedURL.Host
+	key := strings.TrimPrefix(parsedURL.Path, "/")
 
-  return bucket, key, nil
+	return bucket, key, nil
 }
 
 func NewRemote(logger *zap.SugaredLogger, homeDir string, fs *filesystem.FileSystem) *Remote {
-  if disableInsecureFeatures {
-    panic("Remote sources are disabled due to 'DISABLE_INSECURE_FEATURES'")
-  }
-  remote := &Remote{
-    Logger:     logger,
-    Home:       homeDir,
-    Getter:     &GoGetter{Logger: logger},
-    S3Getter:   &S3Getter{Logger: logger},
-    HttpGetter: &HttpGetter{Logger: logger},
-    fs:         fs,
-  }
+	if disableInsecureFeatures {
+		panic("Remote sources are disabled due to 'DISABLE_INSECURE_FEATURES'")
+	}
+	remote := &Remote{
+		Logger:     logger,
+		Home:       homeDir,
+		Getter:     &GoGetter{Logger: logger},
+		S3Getter:   &S3Getter{Logger: logger},
+		HttpGetter: &HttpGetter{Logger: logger},
+		fs:         fs,
+	}
 
-  if remote.Home == "" {
-    // Use for remote charts
-    remote.Home = CacheDir()
-  }
+	if remote.Home == "" {
+		// Use for remote charts
+		remote.Home = CacheDir()
+	}
 
-  return remote
+	return remote
 }

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -1,261 +1,540 @@
 package remote
 
 import (
-	"context"
-	"fmt"
-	neturl "net/url"
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
+  "context"
+  "fmt"
+  "github.com/aws/aws-sdk-go/aws"
+  "io"
+  "path"
 
-	"github.com/hashicorp/go-getter"
-	"github.com/hashicorp/go-getter/helper/url"
-	"go.uber.org/multierr"
-	"go.uber.org/zap"
+  "net/http"
+  neturl "net/url"
+  "os"
+  "path/filepath"
+  "strconv"
+  "strings"
 
-	"github.com/helmfile/helmfile/pkg/envvar"
-	"github.com/helmfile/helmfile/pkg/filesystem"
+  "github.com/aws/aws-sdk-go/aws/session"
+  "github.com/aws/aws-sdk-go/service/s3"
+
+  "github.com/hashicorp/go-getter"
+  "github.com/hashicorp/go-getter/helper/url"
+  "go.uber.org/multierr"
+  "go.uber.org/zap"
+
+  "github.com/helmfile/helmfile/pkg/envvar"
+  "github.com/helmfile/helmfile/pkg/filesystem"
 )
 
 var disableInsecureFeatures bool
 
 func init() {
-	disableInsecureFeatures, _ = strconv.ParseBool(os.Getenv(envvar.DisableInsecureFeatures))
+  disableInsecureFeatures, _ = strconv.ParseBool(os.Getenv(envvar.DisableInsecureFeatures))
 }
 
 func CacheDir() string {
-	if h := os.Getenv(envvar.CacheHome); h != "" {
-		return h
-	}
+  if h := os.Getenv(envvar.CacheHome); h != "" {
+    return h
+  }
 
-	dir, err := os.UserCacheDir()
-	if err != nil {
-		// fall back to relative path with hidden directory
-		return ".helmfile"
-	}
-	return filepath.Join(dir, "helmfile")
+  dir, err := os.UserCacheDir()
+  if err != nil {
+    // fall back to relative path with hidden directory
+    return ".helmfile"
+  }
+  return filepath.Join(dir, "helmfile")
 }
 
 type Remote struct {
-	Logger *zap.SugaredLogger
+  Logger *zap.SugaredLogger
 
-	// Home is the directory in which remote downloads files. If empty, user cache directory is used
-	Home string
+  // Home is the directory in which remote downloads files. If empty, user cache directory is used
+  Home string
 
-	// Getter is the underlying implementation of getter used for fetching remote files
-	Getter Getter
+  // Getter is the underlying implementation of getter used for fetching remote files
+  Getter Getter
 
-	// Filesystem abstraction
-	// Inject any implementation of your choice, like an im-memory impl for testing, os.ReadFile for the real-world use.
-	fs *filesystem.FileSystem
+  S3Getter Getter
+
+  HttpGetter Getter
+
+  // Filesystem abstraction
+  // Inject any implementation of your choice, like an im-memory impl for testing, os.ReadFile for the real-world use.
+  fs *filesystem.FileSystem
 }
 
 // Locate takes an URL to a remote file or a path to a local file.
 // If the argument was an URL, it fetches the remote directory contained within the URL,
 // and returns the path to the file in the fetched directory
 func (r *Remote) Locate(urlOrPath string, cacheDirOpt ...string) (string, error) {
-	if r.fs.FileExistsAt(urlOrPath) || r.fs.DirectoryExistsAt(urlOrPath) {
-		return urlOrPath, nil
-	}
-	fetched, err := r.Fetch(urlOrPath, cacheDirOpt...)
-	if err != nil {
-		if _, ok := err.(InvalidURLError); ok {
-			return urlOrPath, nil
-		}
-		return "", err
-	}
-	return fetched, nil
+  if r.fs.FileExistsAt(urlOrPath) || r.fs.DirectoryExistsAt(urlOrPath) {
+    return urlOrPath, nil
+  }
+  fetched, err := r.Fetch(urlOrPath, cacheDirOpt...)
+  if err != nil {
+    if _, ok := err.(InvalidURLError); ok {
+      return urlOrPath, nil
+    }
+    return "", err
+  }
+  return fetched, nil
 }
 
 type InvalidURLError struct {
-	err string
+  err string
 }
 
 func (e InvalidURLError) Error() string {
-	return e.err
+  return e.err
 }
 
 type Source struct {
-	Getter, Scheme, User, Host, Dir, File, RawQuery string
+  Getter, Scheme, User, Host, Dir, File, RawQuery string
 }
 
 func IsRemote(goGetterSrc string) bool {
-	if _, err := Parse(goGetterSrc); err != nil {
-		return false
-	}
-	return true
+  if _, err := Parse(goGetterSrc); err != nil {
+    return false
+  }
+  return true
 }
 
 func Parse(goGetterSrc string) (*Source, error) {
-	items := strings.Split(goGetterSrc, "::")
-	var getter string
-	if len(items) == 2 {
-		getter = items[0]
-		goGetterSrc = items[1]
-	}
+  items := strings.Split(goGetterSrc, "::")
+  var getter string
+  if len(items) == 2 {
+    getter = items[0]
+    goGetterSrc = items[1]
+  } else {
+    items = strings.Split(goGetterSrc, "://")
 
-	u, err := url.Parse(goGetterSrc)
-	if err != nil {
-		return nil, InvalidURLError{err: fmt.Sprintf("parse url: %v", err)}
-	}
+    if len(items) == 2 {
+      return ParseNormal(goGetterSrc)
+    }
+  }
 
-	if u.Scheme == "" {
-		return nil, InvalidURLError{err: fmt.Sprintf("parse url: missing scheme - probably this is a local file path? %s", goGetterSrc)}
-	}
+  u, err := url.Parse(goGetterSrc)
+  if err != nil {
+    return nil, InvalidURLError{err: fmt.Sprintf("parse url: %v", err)}
+  }
 
-	pathComponents := strings.Split(u.Path, "@")
-	if len(pathComponents) != 2 {
-		return nil, fmt.Errorf("invalid src format: it must be `[<getter>::]<scheme>://<host>/<path/to/dir>@<path/to/file>?key1=val1&key2=val2: got %s", goGetterSrc)
-	}
+  if u.Scheme == "" {
+    return nil, InvalidURLError{err: fmt.Sprintf("parse url: missing scheme - probably this is a local file path? %s", goGetterSrc)}
+  }
 
-	return &Source{
-		Getter:   getter,
-		User:     u.User.String(),
-		Scheme:   u.Scheme,
-		Host:     u.Host,
-		Dir:      pathComponents[0],
-		File:     pathComponents[1],
-		RawQuery: u.RawQuery,
-	}, nil
+  pathComponents := strings.Split(u.Path, "@")
+  if len(pathComponents) != 2 {
+    dir := filepath.Dir(u.Path)
+    if len(dir) > 0 {
+      dir = dir[1:]
+    }
+    pathComponents = []string{dir, filepath.Base(u.Path)}
+  }
+
+  return &Source{
+    Getter:   getter,
+    User:     u.User.String(),
+    Scheme:   u.Scheme,
+    Host:     u.Host,
+    Dir:      pathComponents[0],
+    File:     pathComponents[1],
+    RawQuery: u.RawQuery,
+  }, nil
 }
 
-func (r *Remote) Fetch(goGetterSrc string, cacheDirOpt ...string) (string, error) {
-	u, err := Parse(goGetterSrc)
-	if err != nil {
-		return "", err
-	}
+func ParseNormal(path string) (*Source, error) {
+  _, err := ParseNormalProtocol(path)
+  if err != nil {
+    return nil, err
+  }
 
-	srcDir := fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, u.Dir)
-	file := u.File
+  u, err := url.Parse(path)
+  dir := filepath.Dir(u.Path)
+  if len(dir) > 0 {
+    dir = dir[1:]
+  }
 
-	r.Logger.Debugf("remote> getter: %s", u.Getter)
-	r.Logger.Debugf("remote> scheme: %s", u.Scheme)
-	r.Logger.Debugf("remote> user: %s", u.User)
-	r.Logger.Debugf("remote> host: %s", u.Host)
-	r.Logger.Debugf("remote> dir: %s", u.Dir)
-	r.Logger.Debugf("remote> file: %s", u.File)
+  return &Source{
+    Getter:   "normal",
+    User:     u.User.String(),
+    Scheme:   u.Scheme,
+    Host:     u.Host,
+    Dir:      dir,
+    File:     filepath.Base(u.Path),
+    RawQuery: u.RawQuery,
+  }, err
+}
 
-	// This should be shared across variant commands, so that they can share cache for the shared imports
-	cacheBaseDir := ""
-	if len(cacheDirOpt) == 1 {
-		cacheBaseDir = cacheDirOpt[0]
-	} else if len(cacheDirOpt) > 0 {
-		return "", fmt.Errorf("[bug] cacheDirOpt's length: want 0 or 1, got %d", len(cacheDirOpt))
-	}
+func ParseNormalProtocol(path string) (string, error) {
+  parts := strings.Split(path, "://")
 
-	query := u.RawQuery
+  if len(parts) == 0 {
+    return "", fmt.Errorf("failed to parse URL %s", path)
+  }
+  protocol := strings.ToLower(parts[0])
 
-	var cacheKey string
-	replacer := strings.NewReplacer(":", "", "//", "_", "/", "_", ".", "_")
-	dirKey := replacer.Replace(srcDir)
-	if len(query) > 0 {
-		q, _ := neturl.ParseQuery(query)
-		if q.Has("sshkey") {
-			q.Set("sshkey", "redacted")
-		}
-		paramsKey := strings.ReplaceAll(q.Encode(), "&", "_")
-		cacheKey = fmt.Sprintf("%s.%s", dirKey, paramsKey)
-	} else {
-		cacheKey = dirKey
-	}
+  protocols := []string{"s3", "http", "https"}
+  for _, option := range protocols {
+    if option == protocol {
+      return protocol, nil
+    }
+  }
+  return "", fmt.Errorf("failed to parse URL %s", path)
+}
 
-	cached := false
+func (r *Remote) Fetch(path string, cacheDirOpt ...string) (string, error) {
+  u, err := Parse(path)
+  if err != nil {
+    return "", err
+  }
 
-	// e.g. https_github_com_cloudposse_helmfiles_git.ref=0.xx.0
-	getterDst := filepath.Join(cacheBaseDir, cacheKey)
+  srcDir := fmt.Sprintf("%s://%s/%s", u.Scheme, u.Host, u.Dir)
+  file := u.File
 
-	// e.g. os.CacheDir()/helmfile/https_github_com_cloudposse_helmfiles_git.ref=0.xx.0
-	cacheDirPath := filepath.Join(r.Home, getterDst)
+  r.Logger.Debugf("remote> getter: %s", u.Getter)
+  r.Logger.Debugf("remote> scheme: %s", u.Scheme)
+  r.Logger.Debugf("remote> user: %s", u.User)
+  r.Logger.Debugf("remote> host: %s", u.Host)
+  r.Logger.Debugf("remote> dir: %s", u.Dir)
+  r.Logger.Debugf("remote> file: %s", u.File)
 
-	r.Logger.Debugf("remote> home: %s", r.Home)
-	r.Logger.Debugf("remote> getter dest: %s", getterDst)
-	r.Logger.Debugf("remote> cached dir: %s", cacheDirPath)
+  // This should be shared across variant commands, so that they can share cache for the shared imports
+  cacheBaseDir := ""
+  if len(cacheDirOpt) == 1 {
+    cacheBaseDir = cacheDirOpt[0]
+  } else if len(cacheDirOpt) > 0 {
+    return "", fmt.Errorf("[bug] cacheDirOpt's length: want 0 or 1, got %d", len(cacheDirOpt))
+  }
 
-	{
-		if r.fs.FileExistsAt(cacheDirPath) {
-			return "", fmt.Errorf("%s is not directory. please remove it so that variant could use it for dependency caching", getterDst)
-		}
+  query := u.RawQuery
 
-		if r.fs.DirectoryExistsAt(cacheDirPath) {
-			cached = true
-		}
-	}
+  var cacheKey string
+  replacer := strings.NewReplacer(":", "", "//", "_", "/", "_", ".", "_")
+  dirKey := replacer.Replace(srcDir)
+  if len(query) > 0 {
+    q, _ := neturl.ParseQuery(query)
+    if q.Has("sshkey") {
+      q.Set("sshkey", "redacted")
+    }
+    paramsKey := strings.ReplaceAll(q.Encode(), "&", "_")
+    cacheKey = fmt.Sprintf("%s.%s", dirKey, paramsKey)
+  } else {
+    cacheKey = dirKey
+  }
 
-	if !cached {
-		var getterSrc string
-		if u.User != "" {
-			getterSrc = fmt.Sprintf("%s://%s@%s%s", u.Scheme, u.User, u.Host, u.Dir)
-		} else {
-			getterSrc = fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, u.Dir)
-		}
+  cached := false
 
-		if len(query) > 0 {
-			getterSrc = strings.Join([]string{getterSrc, query}, "?")
-		}
+  // e.g. https_github_com_cloudposse_helmfiles_git.ref=0.xx.0
+  getterDst := filepath.Join(cacheBaseDir, cacheKey)
 
-		if u.Getter != "" {
-			getterSrc = u.Getter + "::" + getterSrc
-		}
+  // e.g. os.CacheDir()/helmfile/https_github_com_cloudposse_helmfiles_git.ref=0.xx.0
+  cacheDirPath := filepath.Join(r.Home, getterDst)
+  if u.Getter == "normal" {
+    srcDir = fmt.Sprintf("%s://%s", u.Scheme, u.Host)
+    cacheKey = replacer.Replace(srcDir)
+    cacheDirPath = filepath.Join(r.Home, cacheKey, u.Dir)
+  }
 
-		r.Logger.Debugf("remote> downloading %s to %s", getterSrc, getterDst)
+  r.Logger.Debugf("remote> home: %s", r.Home)
+  r.Logger.Debugf("remote> getter dest: %s", getterDst)
+  r.Logger.Debugf("remote> cached dir: %s", cacheDirPath)
 
-		if err := r.Getter.Get(r.Home, getterSrc, cacheDirPath); err != nil {
-			rmerr := os.RemoveAll(cacheDirPath)
-			if rmerr != nil {
-				return "", multierr.Append(err, rmerr)
-			}
-			return "", err
-		}
-	}
+  {
+    if r.fs.FileExistsAt(cacheDirPath) {
+      return "", fmt.Errorf("%s is not directory. please remove it so that variant could use it for dependency caching", getterDst)
+    }
 
-	return filepath.Join(cacheDirPath, file), nil
+    if u.Getter == "normal" {
+      cachedFilePath := filepath.Join(cacheDirPath, file)
+      _, err := os.Stat(cachedFilePath)
+      if err == nil {
+        cached = true
+      }
+    } else if r.fs.DirectoryExistsAt(cacheDirPath) {
+      cached = true
+    }
+  }
+
+  if !cached {
+    var getterSrc string
+    if u.User != "" {
+      getterSrc = fmt.Sprintf("%s://%s@%s%s", u.Scheme, u.User, u.Host, u.Dir)
+    } else {
+      getterSrc = fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, u.Dir)
+    }
+
+    if len(query) > 0 {
+      getterSrc = strings.Join([]string{getterSrc, query}, "?")
+    }
+
+    r.Logger.Debugf("remote> downloading %s to %s", getterSrc, getterDst)
+
+    if u.Getter == "normal" && u.Scheme == "s3" {
+
+      err := r.S3Getter.Get(r.Home, path, cacheDirPath)
+      if err != nil {
+        return "", multierr.Append(err, err)
+      }
+
+    } else if u.Getter == "normal" && (u.Scheme == "https" || u.Scheme == "http") {
+      err := r.HttpGetter.Get(r.Home, path, cacheDirPath)
+      if err != nil {
+        return "", multierr.Append(err, err)
+      }
+    } else {
+      if u.Getter != "" {
+        getterSrc = u.Getter + "::" + getterSrc
+      }
+
+      if err := r.Getter.Get(r.Home, getterSrc, cacheDirPath); err != nil {
+        rmerr := os.RemoveAll(cacheDirPath)
+        if rmerr != nil {
+          return "", multierr.Append(err, rmerr)
+        }
+        return "", err
+      }
+    }
+
+  }
+
+  return filepath.Join(cacheDirPath, file), nil
 }
 
 type Getter interface {
-	Get(wd, src, dst string) error
+  Get(wd, src, dst string) error
 }
 
 type GoGetter struct {
-	Logger *zap.SugaredLogger
+  Logger *zap.SugaredLogger
+}
+
+type S3Getter struct {
+  Logger *zap.SugaredLogger
+}
+
+type HttpGetter struct {
+  Logger *zap.SugaredLogger
 }
 
 func (g *GoGetter) Get(wd, src, dst string) error {
-	ctx := context.Background()
+  ctx := context.Background()
 
-	get := &getter.Client{
-		Ctx:     ctx,
-		Src:     src,
-		Dst:     dst,
-		Pwd:     wd,
-		Mode:    getter.ClientModeDir,
-		Options: []getter.ClientOption{},
-	}
+  get := &getter.Client{
+    Ctx:     ctx,
+    Src:     src,
+    Dst:     dst,
+    Pwd:     wd,
+    Mode:    getter.ClientModeDir,
+    Options: []getter.ClientOption{},
+  }
 
-	g.Logger.Debugf("client: %+v", *get)
+  g.Logger.Debugf("client: %+v", *get)
 
-	if err := get.Get(); err != nil {
-		return fmt.Errorf("get: %v", err)
-	}
+  if err := get.Get(); err != nil {
+    return fmt.Errorf("get: %v", err)
+  }
 
-	return nil
+  return nil
+}
+
+func (g *S3Getter) Get(wd, src, dst string) error {
+
+  u, err := url.Parse(src)
+  if err != nil {
+    return err
+  }
+  file := path.Base(u.Path)
+  targetFilePath := filepath.Join(dst, file)
+
+  region, err := S3FileExists(src)
+  if err != nil {
+    return err
+  }
+
+  bucket, key, err := ParseS3Url(src)
+  if err != nil {
+    return err
+  }
+
+  err = os.MkdirAll(dst, os.FileMode(0700))
+  if err != nil {
+    return err
+  }
+
+  // Create a new AWS session using the default AWS configuration
+  sess := session.Must(session.NewSessionWithOptions(session.Options{
+    SharedConfigState: session.SharedConfigEnable,
+    Config: aws.Config{
+      Region: aws.String(region),
+    },
+  }))
+  if err != nil {
+    return err
+  }
+
+  // Create an S3 client using the session
+  s3Client := s3.New(sess)
+
+  getObjectInput := &s3.GetObjectInput{
+    Bucket: &bucket,
+    Key:    &key,
+  }
+  resp, err := s3Client.GetObject(getObjectInput)
+  defer func(Body io.ReadCloser) {
+    err := Body.Close()
+    if err != nil {
+      g.Logger.Errorf("Error closing connection to remote data source \n%v", err)
+    }
+  }(resp.Body)
+
+  if err != nil {
+    return err
+  }
+
+  localFile, err := os.Create(targetFilePath)
+  if err != nil {
+    return err
+  }
+  defer func(localFile *os.File) {
+    err := localFile.Close()
+    if err != nil {
+      g.Logger.Errorf("Error writing file \n%v", err)
+    }
+  }(localFile)
+
+  _, err = localFile.ReadFrom(resp.Body)
+  if err != nil {
+    return err
+  }
+
+  return nil
+}
+
+func (g *HttpGetter) Get(wd, src, dst string) error {
+
+  u, err := url.Parse(src)
+  if err != nil {
+    return err
+  }
+  file := path.Base(u.Path)
+  targetFilePath := filepath.Join(dst, file)
+
+  err = HttpFileExists(src)
+  if err != nil {
+    return err
+  }
+
+  err = os.MkdirAll(dst, os.FileMode(0700))
+  if err != nil {
+    return err
+  }
+
+  resp, err := http.Get(src)
+  defer func(Body io.ReadCloser) {
+    err := Body.Close()
+    if err != nil {
+      fmt.Printf("Error %v", err)
+      g.Logger.Errorf("Error closing connection to remote data source\n%v", err)
+    }
+  }(resp.Body)
+
+  if err != nil {
+    fmt.Printf("Error %v", err)
+    return err
+  }
+
+  localFile, err := os.Create(targetFilePath)
+  if err != nil {
+    return err
+  }
+  defer func(localFile *os.File) {
+    err := localFile.Close()
+    if err != nil {
+      g.Logger.Errorf("Error writing file \n%v", err)
+    }
+  }(localFile)
+
+  _, err = localFile.ReadFrom(resp.Body)
+  if err != nil {
+    return err
+  }
+
+  return nil
+}
+
+func S3FileExists(path string) (string, error) {
+
+  bucket, key, err := ParseS3Url(path)
+  if err != nil {
+    return "", err
+  }
+
+  // Region
+  sess := session.Must(session.NewSessionWithOptions(session.Options{
+    SharedConfigState: session.SharedConfigEnable,
+  }))
+  if err != nil {
+    return "", fmt.Errorf("failed to authentication with aws %w", err)
+  }
+
+  s3Client := s3.New(sess)
+  getBucketLocationInput := &s3.GetBucketLocationInput{
+    Bucket: aws.String(bucket),
+  }
+  resp, err := s3Client.GetBucketLocation(getBucketLocationInput)
+  if err != nil {
+    return "", fmt.Errorf("Error: Failed to retrieve bucket location: %v\n", err)
+  }
+
+  // File existence
+  s3Client = s3.New(sess)
+  headObjectInput := &s3.HeadObjectInput{
+    Bucket: &bucket,
+    Key:    &key,
+  }
+
+  _, err = s3Client.HeadObject(headObjectInput)
+  return *resp.LocationConstraint, err
+}
+
+func HttpFileExists(path string) error {
+  _, err := http.Head(path)
+  return err
+}
+
+func ParseS3Url(s3URL string) (string, string, error) {
+  parsedURL, err := url.Parse(s3URL)
+  if err != nil {
+    return "", "", fmt.Errorf("failed to parse S3 URL: %w", err)
+  }
+
+  if parsedURL.Scheme != "s3" {
+    return "", "", fmt.Errorf("invalid URL scheme (expected 's3')")
+  }
+
+  bucket := parsedURL.Host
+  key := strings.TrimPrefix(parsedURL.Path, "/")
+
+  return bucket, key, nil
 }
 
 func NewRemote(logger *zap.SugaredLogger, homeDir string, fs *filesystem.FileSystem) *Remote {
-	if disableInsecureFeatures {
-		panic("Remote sources are disabled due to 'DISABLE_INSECURE_FEATURES'")
-	}
-	remote := &Remote{
-		Logger: logger,
-		Home:   homeDir,
-		Getter: &GoGetter{Logger: logger},
-		fs:     fs,
-	}
+  if disableInsecureFeatures {
+    panic("Remote sources are disabled due to 'DISABLE_INSECURE_FEATURES'")
+  }
+  remote := &Remote{
+    Logger:     logger,
+    Home:       homeDir,
+    Getter:     &GoGetter{Logger: logger},
+    S3Getter:   &S3Getter{Logger: logger},
+    HttpGetter: &HttpGetter{Logger: logger},
+    fs:         fs,
+  }
 
-	if remote.Home == "" {
-		// Use for remote charts
-		remote.Home = CacheDir()
-	}
+  if remote.Home == "" {
+    // Use for remote charts
+    remote.Home = CacheDir()
+  }
 
-	return remote
+  return remote
 }

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -20,21 +20,18 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 		filepath.Join(CacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
 	}
 
-	type testcase struct {
+	testcases := []struct {
+		name           string
 		files          map[string]string
 		expectCacheHit bool
+	}{
+		{name: "not expectCacheHit", files: cleanfs, expectCacheHit: false},
+		{name: "expectCacheHit", files: cachefs, expectCacheHit: true},
 	}
 
-	testcases := []testcase{
-		{files: cleanfs, expectCacheHit: false},
-		{files: cachefs, expectCacheHit: true},
-	}
-
-	for i := range testcases {
-		testcase := testcases[i]
-
-		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			testfs := testhelper.NewTestFs(testcase.files)
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			testfs := testhelper.NewTestFs(tt.files)
 
 			hit := true
 
@@ -78,10 +75,10 @@ func TestRemote_HttpsGitHub(t *testing.T) {
 				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
 			}
 
-			if testcase.expectCacheHit && !hit {
+			if tt.expectCacheHit && !hit {
 				t.Errorf("unexpected result: unexpected cache miss")
 			}
-			if !testcase.expectCacheHit && hit {
+			if !tt.expectCacheHit && hit {
 				t.Errorf("unexpected result: unexpected cache hit")
 			}
 		})
@@ -93,24 +90,21 @@ func TestRemote_SShGitHub(t *testing.T) {
 		CacheDir(): "",
 	}
 	cachefs := map[string]string{
-		filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
+		filepath.Join(CacheDir(), "ssh_github_com_helmfile_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
 	}
 
-	type testcase struct {
+	testcases := []struct {
+		name           string
 		files          map[string]string
 		expectCacheHit bool
+	}{
+		{name: "not expectCacheHit", files: cleanfs, expectCacheHit: false},
+		{name: "expectCacheHit", files: cachefs, expectCacheHit: true},
 	}
 
-	testcases := []testcase{
-		{files: cleanfs, expectCacheHit: false},
-		{files: cachefs, expectCacheHit: true},
-	}
-
-	for i := range testcases {
-		testcase := testcases[i]
-
-		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			testfs := testhelper.NewTestFs(testcase.files)
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			testfs := testhelper.NewTestFs(tt.files)
 
 			hit := true
 
@@ -118,7 +112,7 @@ func TestRemote_SShGitHub(t *testing.T) {
 				if wd != CacheDir() {
 					return fmt.Errorf("unexpected wd: %s", wd)
 				}
-				if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0" {
+				if src != "git::ssh://git@github.com/helmfile/helmfiles.git?ref=0.40.0" {
 					return fmt.Errorf("unexpected src: %s", src)
 				}
 
@@ -137,21 +131,21 @@ func TestRemote_SShGitHub(t *testing.T) {
 				fs:     testfs.ToFileSystem(),
 			}
 
-			url := "git::ssh://git@github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0"
+			url := "git::ssh://git@github.com/helmfile/helmfiles.git@releases/kiam.yaml?ref=0.40.0"
 			file, err := remote.Locate(url)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			expectedFile := filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
+			expectedFile := filepath.Join(CacheDir(), "ssh_github_com_helmfile_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
 			if file != expectedFile {
 				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
 			}
 
-			if testcase.expectCacheHit && !hit {
+			if tt.expectCacheHit && !hit {
 				t.Errorf("unexpected result: unexpected cache miss")
 			}
-			if !testcase.expectCacheHit && hit {
+			if !tt.expectCacheHit && hit {
 				t.Errorf("unexpected result: unexpected cache hit")
 			}
 		})
@@ -163,24 +157,21 @@ func TestRemote_SShGitHub_WithSshKey(t *testing.T) {
 		CacheDir(): "",
 	}
 	cachefs := map[string]string{
-		filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0_sshkey=redacted/releases/kiam.yaml"): "foo: bar",
+		filepath.Join(CacheDir(), "ssh_github_com_helmfile_helmfiles_git.ref=0.40.0_sshkey=redacted/releases/kiam.yaml"): "foo: bar",
 	}
 
-	type testcase struct {
+	testcases := []struct {
+		name           string
 		files          map[string]string
 		expectCacheHit bool
+	}{
+		{name: "not expectCacheHit", files: cleanfs, expectCacheHit: false},
+		{name: "expectCacheHit", files: cachefs, expectCacheHit: true},
 	}
 
-	testcases := []testcase{
-		{files: cleanfs, expectCacheHit: false},
-		{files: cachefs, expectCacheHit: true},
-	}
-
-	for i := range testcases {
-		testcase := testcases[i]
-
-		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			testfs := testhelper.NewTestFs(testcase.files)
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			testfs := testhelper.NewTestFs(tt.files)
 
 			hit := true
 
@@ -188,7 +179,7 @@ func TestRemote_SShGitHub_WithSshKey(t *testing.T) {
 				if wd != CacheDir() {
 					return fmt.Errorf("unexpected wd: %s", wd)
 				}
-				if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0&sshkey=ZWNkc2Etc2hhMi1uaXN0cDI1NiBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEF5TlRZQUFBQUlibWx6ZEhBeU5UWUFBQUJCQkJTU3dOY2xoVzQ2Vm9VR3dMQ3JscVRHYUdOVWdRVUVEUEptc1ZzdUViL2RBNUcrQk9YMWxGaUVMYU9HQ2F6bS9KQkR2V3Y2Y0ZDQUtVRjVocVJOUjdJPSA=" {
+				if src != "git::ssh://git@github.com/helmfile/helmfiles.git?ref=0.40.0&sshkey=ZWNkc2Etc2hhMi1uaXN0cDI1NiBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEF5TlRZQUFBQUlibWx6ZEhBeU5UWUFBQUJCQkJTU3dOY2xoVzQ2Vm9VR3dMQ3JscVRHYUdOVWdRVUVEUEptc1ZzdUViL2RBNUcrQk9YMWxGaUVMYU9HQ2F6bS9KQkR2V3Y2Y0ZDQUtVRjVocVJOUjdJPSA=" {
 					return fmt.Errorf("unexpected src: %s", src)
 				}
 
@@ -207,21 +198,21 @@ func TestRemote_SShGitHub_WithSshKey(t *testing.T) {
 				fs:     testfs.ToFileSystem(),
 			}
 
-			url := "git::ssh://git@github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0&sshkey=ZWNkc2Etc2hhMi1uaXN0cDI1NiBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEF5TlRZQUFBQUlibWx6ZEhBeU5UWUFBQUJCQkJTU3dOY2xoVzQ2Vm9VR3dMQ3JscVRHYUdOVWdRVUVEUEptc1ZzdUViL2RBNUcrQk9YMWxGaUVMYU9HQ2F6bS9KQkR2V3Y2Y0ZDQUtVRjVocVJOUjdJPSA="
+			url := "git::ssh://git@github.com/helmfile/helmfiles.git@releases/kiam.yaml?ref=0.40.0&sshkey=ZWNkc2Etc2hhMi1uaXN0cDI1NiBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEF5TlRZQUFBQUlibWx6ZEhBeU5UWUFBQUJCQkJTU3dOY2xoVzQ2Vm9VR3dMQ3JscVRHYUdOVWdRVUVEUEptc1ZzdUViL2RBNUcrQk9YMWxGaUVMYU9HQ2F6bS9KQkR2V3Y2Y0ZDQUtVRjVocVJOUjdJPSA="
 			file, err := remote.Locate(url)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			expectedFile := filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0_sshkey=redacted/releases/kiam.yaml")
+			expectedFile := filepath.Join(CacheDir(), "ssh_github_com_helmfile_helmfiles_git.ref=0.40.0_sshkey=redacted/releases/kiam.yaml")
 			if file != expectedFile {
 				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
 			}
 
-			if testcase.expectCacheHit && !hit {
+			if tt.expectCacheHit && !hit {
 				t.Errorf("unexpected result: unexpected cache miss")
 			}
-			if !testcase.expectCacheHit && hit {
+			if !tt.expectCacheHit && hit {
 				t.Errorf("unexpected result: unexpected cache hit")
 			}
 		})
@@ -236,21 +227,18 @@ func TestRemote_S3(t *testing.T) {
 		filepath.Join(CacheDir(), "s3_helm-s3-values-example/subdir/values.yaml"): "foo: bar",
 	}
 
-	type testcase struct {
+	testcases := []struct {
+		name           string
 		files          map[string]string
 		expectCacheHit bool
+	}{
+		{name: "not expectCacheHit", files: cleanfs, expectCacheHit: false},
+		{name: "expectCacheHit", files: cachefs, expectCacheHit: true},
 	}
 
-	testcases := []testcase{
-		{files: cleanfs, expectCacheHit: false},
-		{files: cachefs, expectCacheHit: true},
-	}
-
-	for i := range testcases {
-		testcase := testcases[i]
-
-		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			testfs := testhelper.NewTestFs(testcase.files)
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			testfs := testhelper.NewTestFs(tt.files)
 
 			hit := true
 
@@ -290,10 +278,10 @@ func TestRemote_S3(t *testing.T) {
 				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
 			}
 
-			if testcase.expectCacheHit && !hit {
+			if tt.expectCacheHit && !hit {
 				t.Errorf("unexpected result: unexpected cache miss")
 			}
-			if !testcase.expectCacheHit && hit {
+			if !tt.expectCacheHit && hit {
 				t.Errorf("unexpected result: unexpected cache hit")
 			}
 		})
@@ -301,18 +289,23 @@ func TestRemote_S3(t *testing.T) {
 }
 
 func TestParse(t *testing.T) {
-	type testcase struct {
-		input                            string
-		getter, scheme, dir, file, query string
-		err                              string
-	}
-
-	testcases := []testcase{
+	testcases := []struct {
+		name   string
+		input  string
+		getter string
+		scheme string
+		dir    string
+		file   string
+		query  string
+		err    string
+	}{
 		{
+			name:  "miss scheme",
 			input: "raw/incubator",
 			err:   "parse url: missing scheme - probably this is a local file path? raw/incubator",
 		},
 		{
+			name:   "git scheme",
 			input:  "git::https://github.com/stakater/Forecastle.git@deployments/kubernetes/chart/forecastle?ref=v1.0.54",
 			getter: "git",
 			scheme: "https",
@@ -321,6 +314,7 @@ func TestParse(t *testing.T) {
 			query:  "ref=v1.0.54",
 		},
 		{
+			name:   "s3 scheme",
 			input:  "s3://helm-s3-values-example/values.yaml",
 			getter: "normal",
 			scheme: "s3",
@@ -329,6 +323,7 @@ func TestParse(t *testing.T) {
 			query:  "",
 		},
 		{
+			name:   "s3 scheme with subdir",
 			input:  "s3://helm-s3-values-example/subdir/values.yaml",
 			getter: "normal",
 			scheme: "s3",
@@ -337,6 +332,7 @@ func TestParse(t *testing.T) {
 			query:  "",
 		},
 		{
+			name:   "http scheme",
 			input:  "http::http://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
 			getter: "http",
 			scheme: "http",
@@ -345,6 +341,7 @@ func TestParse(t *testing.T) {
 			query:  "",
 		},
 		{
+			name:   "http scheme with subdir",
 			input:  "http::http://helm-s3-values-example.s3.us-east-2.amazonaws.com/subdir/values.yaml",
 			getter: "http",
 			scheme: "http",
@@ -353,6 +350,7 @@ func TestParse(t *testing.T) {
 			query:  "",
 		},
 		{
+			name:   "https scheme",
 			input:  "http::https://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
 			getter: "http",
 			scheme: "https",
@@ -361,6 +359,7 @@ func TestParse(t *testing.T) {
 			query:  "",
 		},
 		{
+			name:   "http scheme normal",
 			input:  "http://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
 			getter: "normal",
 			scheme: "http",
@@ -369,6 +368,7 @@ func TestParse(t *testing.T) {
 			query:  "",
 		},
 		{
+			name:   "https scheme normal",
 			input:  "https://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
 			getter: "normal",
 			scheme: "https",
@@ -378,18 +378,16 @@ func TestParse(t *testing.T) {
 		},
 	}
 
-	for i := range testcases {
-		tc := testcases[i]
-
-		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			src, err := Parse(tc.input)
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			src, err := Parse(tt.input)
 
 			var errMsg string
 			if err != nil {
 				errMsg = err.Error()
 			}
 
-			if diff := cmp.Diff(tc.err, errMsg); diff != "" {
+			if diff := cmp.Diff(tt.err, errMsg); diff != "" {
 				t.Fatalf("Unexpected error:\n%s", diff)
 			}
 
@@ -402,23 +400,23 @@ func TestParse(t *testing.T) {
 				query = src.RawQuery
 			}
 
-			if diff := cmp.Diff(tc.getter, getter); diff != "" {
+			if diff := cmp.Diff(tt.getter, getter); diff != "" {
 				t.Fatalf("Unexpected getter:\n%s", diff)
 			}
 
-			if diff := cmp.Diff(tc.scheme, scheme); diff != "" {
+			if diff := cmp.Diff(tt.scheme, scheme); diff != "" {
 				t.Fatalf("Unexpected scheme:\n%s", diff)
 			}
 
-			if diff := cmp.Diff(tc.file, file); diff != "" {
+			if diff := cmp.Diff(tt.file, file); diff != "" {
 				t.Fatalf("Unexpected file:\n%s", diff)
 			}
 
-			if diff := cmp.Diff(tc.dir, dir); diff != "" {
+			if diff := cmp.Diff(tt.dir, dir); diff != "" {
 				t.Fatalf("Unexpected dir:\n%s", diff)
 			}
 
-			if diff := cmp.Diff(tc.query, query); diff != "" {
+			if diff := cmp.Diff(tt.query, query); diff != "" {
 				t.Fatalf("Unexpected query:\n%s", diff)
 			}
 		})
@@ -441,24 +439,21 @@ func TestRemote_Fetch(t *testing.T) {
 		filepath.Join(CacheDir(), "https_github_com_helmfile_helmfile_git.ref=v0.151.0/README.md"): "foo: bar",
 	}
 
-	type testcase struct {
+	testcases := []struct {
+		name           string
 		files          map[string]string
 		expectCacheHit bool
 		cacheDirOpt    string
+	}{
+		{name: "not expectCacheHit", files: cleanfs, expectCacheHit: false, cacheDirOpt: ""},
+		{name: "expectCacheHit", files: cachefs, expectCacheHit: true, cacheDirOpt: ""},
+		{name: "not expectCacheHit with states", files: cleanfs, expectCacheHit: false, cacheDirOpt: "states"},
+		{name: "expectCacheHit with states", files: cachefs, expectCacheHit: true, cacheDirOpt: "states"},
 	}
 
-	testcases := []testcase{
-		{files: cleanfs, expectCacheHit: false, cacheDirOpt: ""},
-		{files: cachefs, expectCacheHit: true, cacheDirOpt: ""},
-		{files: cleanfs, expectCacheHit: false, cacheDirOpt: "states"},
-		{files: cachefs, expectCacheHit: true, cacheDirOpt: "states"},
-	}
-
-	for i := range testcases {
-		testcase := testcases[i]
-
-		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			testfs := testhelper.NewTestFs(testcase.files)
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			testfs := testhelper.NewTestFs(tt.files)
 
 			hit := true
 
@@ -496,10 +491,10 @@ func TestRemote_Fetch(t *testing.T) {
 				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
 			}
 
-			if testcase.expectCacheHit && !hit {
+			if tt.expectCacheHit && !hit {
 				t.Errorf("unexpected result: unexpected cache miss")
 			}
-			if !testcase.expectCacheHit && hit {
+			if !tt.expectCacheHit && hit {
 				t.Errorf("unexpected result: unexpected cache hit")
 			}
 		})

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -1,379 +1,507 @@
 package remote
 
 import (
-	"fmt"
-	"io"
-	"path/filepath"
-	"testing"
+  "fmt"
+  "io"
+  "path/filepath"
+  "testing"
 
-	"github.com/google/go-cmp/cmp"
+  "github.com/google/go-cmp/cmp"
 
-	"github.com/helmfile/helmfile/pkg/helmexec"
-	"github.com/helmfile/helmfile/pkg/testhelper"
+  "github.com/helmfile/helmfile/pkg/helmexec"
+  "github.com/helmfile/helmfile/pkg/testhelper"
 )
 
 func TestRemote_HttpsGitHub(t *testing.T) {
-	cleanfs := map[string]string{
-		CacheDir(): "",
-	}
-	cachefs := map[string]string{
-		filepath.Join(CacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
-	}
+  cleanfs := map[string]string{
+    CacheDir(): "",
+  }
+  cachefs := map[string]string{
+    filepath.Join(CacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
+  }
 
-	type testcase struct {
-		files          map[string]string
-		expectCacheHit bool
-	}
+  type testcase struct {
+    files          map[string]string
+    expectCacheHit bool
+  }
 
-	testcases := []testcase{
-		{files: cleanfs, expectCacheHit: false},
-		{files: cachefs, expectCacheHit: true},
-	}
+  testcases := []testcase{
+    {files: cleanfs, expectCacheHit: false},
+    {files: cachefs, expectCacheHit: true},
+  }
 
-	for i := range testcases {
-		testcase := testcases[i]
+  for i := range testcases {
+    testcase := testcases[i]
 
-		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			testfs := testhelper.NewTestFs(testcase.files)
+    t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+      testfs := testhelper.NewTestFs(testcase.files)
 
-			hit := true
+      hit := true
 
-			get := func(wd, src, dst string) error {
-				if wd != CacheDir() {
-					return fmt.Errorf("unexpected wd: %s", wd)
-				}
-				if src != "git::https://github.com/cloudposse/helmfiles.git?ref=0.40.0" {
-					return fmt.Errorf("unexpected src: %s", src)
-				}
+      get := func(wd, src, dst string) error {
+        if wd != CacheDir() {
+          return fmt.Errorf("unexpected wd: %s", wd)
+        }
+        if src != "git::https://github.com/cloudposse/helmfiles.git?ref=0.40.0" {
+          return fmt.Errorf("unexpected src: %s", src)
+        }
 
-				hit = false
+        hit = false
 
-				return nil
-			}
+        return nil
+      }
 
-			getter := &testGetter{
-				get: get,
-			}
-			remote := &Remote{
-				Logger: helmexec.NewLogger(io.Discard, "debug"),
-				Home:   CacheDir(),
-				Getter: getter,
-				fs:     testfs.ToFileSystem(),
-			}
+      getter := &testGetter{
+        get: get,
+      }
+      remote := &Remote{
+        Logger: helmexec.NewLogger(io.Discard, "debug"),
+        Home:   CacheDir(),
+        Getter: getter,
+        fs:     testfs.ToFileSystem(),
+      }
 
-			// FYI, go-getter in the `dir` mode accepts URL like the below. So helmfile expects URLs similar to it:
-			//   go-getter -mode dir git::https://github.com/cloudposse/helmfiles.git?ref=0.40.0 gettertest1/b
+      // FYI, go-getter in the `dir` mode accepts URL like the below. So helmfile expects URLs similar to it:
+      //   go-getter -mode dir git::https://github.com/cloudposse/helmfiles.git?ref=0.40.0 gettertest1/b
 
-			// We use `@` to separate dir and the file path. This is a good idea borrowed from helm-git:
-			//   https://github.com/aslafy-z/helm-git
+      // We use `@` to separate dir and the file path. This is a good idea borrowed from helm-git:
+      //   https://github.com/aslafy-z/helm-git
 
-			url := "git::https://github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0"
-			file, err := remote.Locate(url)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+      url := "git::https://github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0"
+      file, err := remote.Locate(url)
+      if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+      }
 
-			expectedFile := filepath.Join(CacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
-			if file != expectedFile {
-				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
-			}
+      expectedFile := filepath.Join(CacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
+      if file != expectedFile {
+        t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
+      }
 
-			if testcase.expectCacheHit && !hit {
-				t.Errorf("unexpected result: unexpected cache miss")
-			}
-			if !testcase.expectCacheHit && hit {
-				t.Errorf("unexpected result: unexpected cache hit")
-			}
-		})
-	}
+      if testcase.expectCacheHit && !hit {
+        t.Errorf("unexpected result: unexpected cache miss")
+      }
+      if !testcase.expectCacheHit && hit {
+        t.Errorf("unexpected result: unexpected cache hit")
+      }
+    })
+  }
 }
 
 func TestRemote_SShGitHub(t *testing.T) {
-	cleanfs := map[string]string{
-		CacheDir(): "",
-	}
-	cachefs := map[string]string{
-		filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
-	}
+  cleanfs := map[string]string{
+    CacheDir(): "",
+  }
+  cachefs := map[string]string{
+    filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
+  }
 
-	type testcase struct {
-		files          map[string]string
-		expectCacheHit bool
-	}
+  type testcase struct {
+    files          map[string]string
+    expectCacheHit bool
+  }
 
-	testcases := []testcase{
-		{files: cleanfs, expectCacheHit: false},
-		{files: cachefs, expectCacheHit: true},
-	}
+  testcases := []testcase{
+    {files: cleanfs, expectCacheHit: false},
+    {files: cachefs, expectCacheHit: true},
+  }
 
-	for i := range testcases {
-		testcase := testcases[i]
+  for i := range testcases {
+    testcase := testcases[i]
 
-		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			testfs := testhelper.NewTestFs(testcase.files)
+    t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+      testfs := testhelper.NewTestFs(testcase.files)
 
-			hit := true
+      hit := true
 
-			get := func(wd, src, dst string) error {
-				if wd != CacheDir() {
-					return fmt.Errorf("unexpected wd: %s", wd)
-				}
-				if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0" {
-					return fmt.Errorf("unexpected src: %s", src)
-				}
+      get := func(wd, src, dst string) error {
+        if wd != CacheDir() {
+          return fmt.Errorf("unexpected wd: %s", wd)
+        }
+        if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0" {
+          return fmt.Errorf("unexpected src: %s", src)
+        }
 
-				hit = false
+        hit = false
 
-				return nil
-			}
+        return nil
+      }
 
-			getter := &testGetter{
-				get: get,
-			}
-			remote := &Remote{
-				Logger: helmexec.NewLogger(io.Discard, "debug"),
-				Home:   CacheDir(),
-				Getter: getter,
-				fs:     testfs.ToFileSystem(),
-			}
+      getter := &testGetter{
+        get: get,
+      }
+      remote := &Remote{
+        Logger: helmexec.NewLogger(io.Discard, "debug"),
+        Home:   CacheDir(),
+        Getter: getter,
+        fs:     testfs.ToFileSystem(),
+      }
 
-			url := "git::ssh://git@github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0"
-			file, err := remote.Locate(url)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+      url := "git::ssh://git@github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0"
+      file, err := remote.Locate(url)
+      if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+      }
 
-			expectedFile := filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
-			if file != expectedFile {
-				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
-			}
+      expectedFile := filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
+      if file != expectedFile {
+        t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
+      }
 
-			if testcase.expectCacheHit && !hit {
-				t.Errorf("unexpected result: unexpected cache miss")
-			}
-			if !testcase.expectCacheHit && hit {
-				t.Errorf("unexpected result: unexpected cache hit")
-			}
-		})
-	}
+      if testcase.expectCacheHit && !hit {
+        t.Errorf("unexpected result: unexpected cache miss")
+      }
+      if !testcase.expectCacheHit && hit {
+        t.Errorf("unexpected result: unexpected cache hit")
+      }
+    })
+  }
 }
 
 func TestRemote_SShGitHub_WithSshKey(t *testing.T) {
-	cleanfs := map[string]string{
-		CacheDir(): "",
-	}
-	cachefs := map[string]string{
-		filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0_sshkey=redacted/releases/kiam.yaml"): "foo: bar",
-	}
+  cleanfs := map[string]string{
+    CacheDir(): "",
+  }
+  cachefs := map[string]string{
+    filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0_sshkey=redacted/releases/kiam.yaml"): "foo: bar",
+  }
 
-	type testcase struct {
-		files          map[string]string
-		expectCacheHit bool
-	}
+  type testcase struct {
+    files          map[string]string
+    expectCacheHit bool
+  }
 
-	testcases := []testcase{
-		{files: cleanfs, expectCacheHit: false},
-		{files: cachefs, expectCacheHit: true},
-	}
+  testcases := []testcase{
+    {files: cleanfs, expectCacheHit: false},
+    {files: cachefs, expectCacheHit: true},
+  }
 
-	for i := range testcases {
-		testcase := testcases[i]
+  for i := range testcases {
+    testcase := testcases[i]
 
-		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			testfs := testhelper.NewTestFs(testcase.files)
+    t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+      testfs := testhelper.NewTestFs(testcase.files)
 
-			hit := true
+      hit := true
 
-			get := func(wd, src, dst string) error {
-				if wd != CacheDir() {
-					return fmt.Errorf("unexpected wd: %s", wd)
-				}
-				if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0&sshkey=ZWNkc2Etc2hhMi1uaXN0cDI1NiBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEF5TlRZQUFBQUlibWx6ZEhBeU5UWUFBQUJCQkJTU3dOY2xoVzQ2Vm9VR3dMQ3JscVRHYUdOVWdRVUVEUEptc1ZzdUViL2RBNUcrQk9YMWxGaUVMYU9HQ2F6bS9KQkR2V3Y2Y0ZDQUtVRjVocVJOUjdJPSA=" {
-					return fmt.Errorf("unexpected src: %s", src)
-				}
+      get := func(wd, src, dst string) error {
+        if wd != CacheDir() {
+          return fmt.Errorf("unexpected wd: %s", wd)
+        }
+        if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0&sshkey=ZWNkc2Etc2hhMi1uaXN0cDI1NiBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEF5TlRZQUFBQUlibWx6ZEhBeU5UWUFBQUJCQkJTU3dOY2xoVzQ2Vm9VR3dMQ3JscVRHYUdOVWdRVUVEUEptc1ZzdUViL2RBNUcrQk9YMWxGaUVMYU9HQ2F6bS9KQkR2V3Y2Y0ZDQUtVRjVocVJOUjdJPSA=" {
+          return fmt.Errorf("unexpected src: %s", src)
+        }
 
-				hit = false
+        hit = false
 
-				return nil
-			}
+        return nil
+      }
 
-			getter := &testGetter{
-				get: get,
-			}
-			remote := &Remote{
-				Logger: helmexec.NewLogger(io.Discard, "debug"),
-				Home:   CacheDir(),
-				Getter: getter,
-				fs:     testfs.ToFileSystem(),
-			}
+      getter := &testGetter{
+        get: get,
+      }
+      remote := &Remote{
+        Logger: helmexec.NewLogger(io.Discard, "debug"),
+        Home:   CacheDir(),
+        Getter: getter,
+        fs:     testfs.ToFileSystem(),
+      }
 
-			url := "git::ssh://git@github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0&sshkey=ZWNkc2Etc2hhMi1uaXN0cDI1NiBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEF5TlRZQUFBQUlibWx6ZEhBeU5UWUFBQUJCQkJTU3dOY2xoVzQ2Vm9VR3dMQ3JscVRHYUdOVWdRVUVEUEptc1ZzdUViL2RBNUcrQk9YMWxGaUVMYU9HQ2F6bS9KQkR2V3Y2Y0ZDQUtVRjVocVJOUjdJPSA="
-			file, err := remote.Locate(url)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+      url := "git::ssh://git@github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0&sshkey=ZWNkc2Etc2hhMi1uaXN0cDI1NiBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEF5TlRZQUFBQUlibWx6ZEhBeU5UWUFBQUJCQkJTU3dOY2xoVzQ2Vm9VR3dMQ3JscVRHYUdOVWdRVUVEUEptc1ZzdUViL2RBNUcrQk9YMWxGaUVMYU9HQ2F6bS9KQkR2V3Y2Y0ZDQUtVRjVocVJOUjdJPSA="
+      file, err := remote.Locate(url)
+      if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+      }
 
-			expectedFile := filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0_sshkey=redacted/releases/kiam.yaml")
-			if file != expectedFile {
-				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
-			}
+      expectedFile := filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0_sshkey=redacted/releases/kiam.yaml")
+      if file != expectedFile {
+        t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
+      }
 
-			if testcase.expectCacheHit && !hit {
-				t.Errorf("unexpected result: unexpected cache miss")
-			}
-			if !testcase.expectCacheHit && hit {
-				t.Errorf("unexpected result: unexpected cache hit")
-			}
-		})
-	}
+      if testcase.expectCacheHit && !hit {
+        t.Errorf("unexpected result: unexpected cache miss")
+      }
+      if !testcase.expectCacheHit && hit {
+        t.Errorf("unexpected result: unexpected cache hit")
+      }
+    })
+  }
+}
+
+func TestRemote_S3(t *testing.T) {
+  cleanfs := map[string]string{
+    CacheDir(): "",
+  }
+  cachefs := map[string]string{
+    filepath.Join(CacheDir(), "s3_helm-s3-values-example/subdir/values.yaml"): "foo: bar",
+  }
+
+  type testcase struct {
+    files          map[string]string
+    expectCacheHit bool
+  }
+
+  testcases := []testcase{
+    {files: cleanfs, expectCacheHit: false},
+    {files: cachefs, expectCacheHit: true},
+  }
+
+  for i := range testcases {
+    testcase := testcases[i]
+
+    t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+      testfs := testhelper.NewTestFs(testcase.files)
+
+      hit := true
+
+      get := func(wd, src, dst string) error {
+        if wd != CacheDir() {
+          return fmt.Errorf("unexpected wd: %s", wd)
+        }
+        if src != "s3://helm-s3-values-example/subdir/values.yaml" {
+          return fmt.Errorf("unexpected src: %s", src)
+        }
+
+        hit = false
+
+        return nil
+      }
+
+      getter := &testGetter{
+        get: get,
+      }
+      remote := &Remote{
+        Logger:     helmexec.NewLogger(io.Discard, "debug"),
+        Home:       CacheDir(),
+        Getter:     getter,
+        S3Getter:   getter,
+        HttpGetter: getter,
+        fs:         testfs.ToFileSystem(),
+      }
+
+      url := "s3://helm-s3-values-example/subdir/values.yaml"
+      file, err := remote.Locate(url)
+      if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+      }
+
+      expectedFile := filepath.Join(CacheDir(), "s3_helm-s3-values-example/subdir/values.yaml")
+      if file != expectedFile {
+        t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
+      }
+
+      if testcase.expectCacheHit && !hit {
+        t.Errorf("unexpected result: unexpected cache miss")
+      }
+      if !testcase.expectCacheHit && hit {
+        t.Errorf("unexpected result: unexpected cache hit")
+      }
+    })
+  }
 }
 
 func TestParse(t *testing.T) {
-	type testcase struct {
-		input                            string
-		getter, scheme, dir, file, query string
-		err                              string
-	}
+  type testcase struct {
+    input                            string
+    getter, scheme, dir, file, query string
+    err                              string
+  }
 
-	testcases := []testcase{
-		{
-			input: "raw/incubator",
-			err:   "parse url: missing scheme - probably this is a local file path? raw/incubator",
-		},
-		{
-			input:  "git::https://github.com/stakater/Forecastle.git@deployments/kubernetes/chart/forecastle?ref=v1.0.54",
-			getter: "git",
-			scheme: "https",
-			dir:    "/stakater/Forecastle.git",
-			file:   "deployments/kubernetes/chart/forecastle",
-			query:  "ref=v1.0.54",
-		},
-	}
+  testcases := []testcase{
+    {
+      input: "raw/incubator",
+      err:   "parse url: missing scheme - probably this is a local file path? raw/incubator",
+    },
+    {
+      input:  "git::https://github.com/stakater/Forecastle.git@deployments/kubernetes/chart/forecastle?ref=v1.0.54",
+      getter: "git",
+      scheme: "https",
+      dir:    "/stakater/Forecastle.git",
+      file:   "deployments/kubernetes/chart/forecastle",
+      query:  "ref=v1.0.54",
+    },
+    {
+      input:  "s3://helm-s3-values-example/values.yaml",
+      getter: "normal",
+      scheme: "s3",
+      dir:    "",
+      file:   "values.yaml",
+      query:  "",
+    },
+    {
+      input:  "s3://helm-s3-values-example/subdir/values.yaml",
+      getter: "normal",
+      scheme: "s3",
+      dir:    "subdir",
+      file:   "values.yaml",
+      query:  "",
+    },
+    {
+      input:  "http::http://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
+      getter: "http",
+      scheme: "http",
+      dir:    "",
+      file:   "values.yaml",
+      query:  "",
+    },
+    {
+      input:  "http::http://helm-s3-values-example.s3.us-east-2.amazonaws.com/subdir/values.yaml",
+      getter: "http",
+      scheme: "http",
+      dir:    "subdir",
+      file:   "values.yaml",
+      query:  "",
+    },
+    {
+      input:  "http::https://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
+      getter: "http",
+      scheme: "https",
+      dir:    "",
+      file:   "values.yaml",
+      query:  "",
+    },
+    {
+      input:  "http://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
+      getter: "normal",
+      scheme: "http",
+      dir:    "",
+      file:   "values.yaml",
+      query:  "",
+    },
+    {
+      input:  "https://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
+      getter: "normal",
+      scheme: "https",
+      dir:    "",
+      file:   "values.yaml",
+      query:  "",
+    },
+  }
 
-	for i := range testcases {
-		tc := testcases[i]
+  for i := range testcases {
+    tc := testcases[i]
 
-		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			src, err := Parse(tc.input)
+    t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+      src, err := Parse(tc.input)
 
-			var errMsg string
-			if err != nil {
-				errMsg = err.Error()
-			}
+      var errMsg string
+      if err != nil {
+        errMsg = err.Error()
+      }
 
-			if diff := cmp.Diff(tc.err, errMsg); diff != "" {
-				t.Fatalf("Unexpected error:\n%s", diff)
-			}
+      if diff := cmp.Diff(tc.err, errMsg); diff != "" {
+        t.Fatalf("Unexpected error:\n%s", diff)
+      }
 
-			var getter, scheme, dir, file, query string
-			if src != nil {
-				getter = src.Getter
-				scheme = src.Scheme
-				dir = src.Dir
-				file = src.File
-				query = src.RawQuery
-			}
+      var getter, scheme, dir, file, query string
+      if src != nil {
+        getter = src.Getter
+        scheme = src.Scheme
+        dir = src.Dir
+        file = src.File
+        query = src.RawQuery
+      }
 
-			if diff := cmp.Diff(tc.getter, getter); diff != "" {
-				t.Fatalf("Unexpected getter:\n%s", diff)
-			}
+      if diff := cmp.Diff(tc.getter, getter); diff != "" {
+        t.Fatalf("Unexpected getter:\n%s", diff)
+      }
 
-			if diff := cmp.Diff(tc.scheme, scheme); diff != "" {
-				t.Fatalf("Unexpected scheme:\n%s", diff)
-			}
+      if diff := cmp.Diff(tc.scheme, scheme); diff != "" {
+        t.Fatalf("Unexpected scheme:\n%s", diff)
+      }
 
-			if diff := cmp.Diff(tc.file, file); diff != "" {
-				t.Fatalf("Unexpected file:\n%s", diff)
-			}
+      if diff := cmp.Diff(tc.file, file); diff != "" {
+        t.Fatalf("Unexpected file:\n%s", diff)
+      }
 
-			if diff := cmp.Diff(tc.dir, dir); diff != "" {
-				t.Fatalf("Unexpected dir:\n%s", diff)
-			}
+      if diff := cmp.Diff(tc.dir, dir); diff != "" {
+        t.Fatalf("Unexpected dir:\n%s", diff)
+      }
 
-			if diff := cmp.Diff(tc.query, query); diff != "" {
-				t.Fatalf("Unexpected query:\n%s", diff)
-			}
-		})
-	}
+      if diff := cmp.Diff(tc.query, query); diff != "" {
+        t.Fatalf("Unexpected query:\n%s", diff)
+      }
+    })
+  }
 }
 
 type testGetter struct {
-	get func(wd, src, dst string) error
+  get func(wd, src, dst string) error
 }
 
 func (t *testGetter) Get(wd, src, dst string) error {
-	return t.get(wd, src, dst)
+  return t.get(wd, src, dst)
 }
 
 func TestRemote_Fetch(t *testing.T) {
-	cleanfs := map[string]string{
-		CacheDir(): "",
-	}
-	cachefs := map[string]string{
-		filepath.Join(CacheDir(), "https_github_com_helmfile_helmfile_git.ref=v0.151.0/README.md"): "foo: bar",
-	}
+  cleanfs := map[string]string{
+    CacheDir(): "",
+  }
+  cachefs := map[string]string{
+    filepath.Join(CacheDir(), "https_github_com_helmfile_helmfile_git.ref=v0.151.0/README.md"): "foo: bar",
+  }
 
-	type testcase struct {
-		files          map[string]string
-		expectCacheHit bool
-		cacheDirOpt    string
-	}
+  type testcase struct {
+    files          map[string]string
+    expectCacheHit bool
+    cacheDirOpt    string
+  }
 
-	testcases := []testcase{
-		{files: cleanfs, expectCacheHit: false, cacheDirOpt: ""},
-		{files: cachefs, expectCacheHit: true, cacheDirOpt: ""},
-		{files: cleanfs, expectCacheHit: false, cacheDirOpt: "states"},
-		{files: cachefs, expectCacheHit: true, cacheDirOpt: "states"},
-	}
+  testcases := []testcase{
+    {files: cleanfs, expectCacheHit: false, cacheDirOpt: ""},
+    {files: cachefs, expectCacheHit: true, cacheDirOpt: ""},
+    {files: cleanfs, expectCacheHit: false, cacheDirOpt: "states"},
+    {files: cachefs, expectCacheHit: true, cacheDirOpt: "states"},
+  }
 
-	for i := range testcases {
-		testcase := testcases[i]
+  for i := range testcases {
+    testcase := testcases[i]
 
-		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			testfs := testhelper.NewTestFs(testcase.files)
+    t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+      testfs := testhelper.NewTestFs(testcase.files)
 
-			hit := true
+      hit := true
 
-			get := func(wd, src, dst string) error {
-				if wd != CacheDir() {
-					return fmt.Errorf("unexpected wd: %s", wd)
-				}
-				if src != "git::https://github.com/helmfile/helmfile.git?ref=v0.151.0" {
-					return fmt.Errorf("unexpected src: %s", src)
-				}
+      get := func(wd, src, dst string) error {
+        if wd != CacheDir() {
+          return fmt.Errorf("unexpected wd: %s", wd)
+        }
+        if src != "git::https://github.com/helmfile/helmfile.git?ref=v0.151.0" {
+          return fmt.Errorf("unexpected src: %s", src)
+        }
 
-				hit = false
+        hit = false
 
-				return nil
-			}
+        return nil
+      }
 
-			getter := &testGetter{
-				get: get,
-			}
-			remote := &Remote{
-				Logger: helmexec.NewLogger(io.Discard, "debug"),
-				Home:   CacheDir(),
-				Getter: getter,
-				fs:     testfs.ToFileSystem(),
-			}
+      getter := &testGetter{
+        get: get,
+      }
+      remote := &Remote{
+        Logger: helmexec.NewLogger(io.Discard, "debug"),
+        Home:   CacheDir(),
+        Getter: getter,
+        fs:     testfs.ToFileSystem(),
+      }
 
-			url := "git::https://github.com/helmfile/helmfile.git@README.md?ref=v0.151.0"
-			file, err := remote.Fetch(url)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+      url := "git::https://github.com/helmfile/helmfile.git@README.md?ref=v0.151.0"
+      file, err := remote.Fetch(url)
+      if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+      }
 
-			expectedFile := filepath.Join(CacheDir(), "https_github_com_helmfile_helmfile_git.ref=v0.151.0/README.md")
-			if file != expectedFile {
-				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
-			}
+      expectedFile := filepath.Join(CacheDir(), "https_github_com_helmfile_helmfile_git.ref=v0.151.0/README.md")
+      if file != expectedFile {
+        t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
+      }
 
-			if testcase.expectCacheHit && !hit {
-				t.Errorf("unexpected result: unexpected cache miss")
-			}
-			if !testcase.expectCacheHit && hit {
-				t.Errorf("unexpected result: unexpected cache hit")
-			}
-		})
-	}
+      if testcase.expectCacheHit && !hit {
+        t.Errorf("unexpected result: unexpected cache miss")
+      }
+      if !testcase.expectCacheHit && hit {
+        t.Errorf("unexpected result: unexpected cache hit")
+      }
+    })
+  }
 }

--- a/pkg/remote/remote_test.go
+++ b/pkg/remote/remote_test.go
@@ -1,507 +1,507 @@
 package remote
 
 import (
-  "fmt"
-  "io"
-  "path/filepath"
-  "testing"
+	"fmt"
+	"io"
+	"path/filepath"
+	"testing"
 
-  "github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp"
 
-  "github.com/helmfile/helmfile/pkg/helmexec"
-  "github.com/helmfile/helmfile/pkg/testhelper"
+	"github.com/helmfile/helmfile/pkg/helmexec"
+	"github.com/helmfile/helmfile/pkg/testhelper"
 )
 
 func TestRemote_HttpsGitHub(t *testing.T) {
-  cleanfs := map[string]string{
-    CacheDir(): "",
-  }
-  cachefs := map[string]string{
-    filepath.Join(CacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
-  }
+	cleanfs := map[string]string{
+		CacheDir(): "",
+	}
+	cachefs := map[string]string{
+		filepath.Join(CacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
+	}
 
-  type testcase struct {
-    files          map[string]string
-    expectCacheHit bool
-  }
+	type testcase struct {
+		files          map[string]string
+		expectCacheHit bool
+	}
 
-  testcases := []testcase{
-    {files: cleanfs, expectCacheHit: false},
-    {files: cachefs, expectCacheHit: true},
-  }
+	testcases := []testcase{
+		{files: cleanfs, expectCacheHit: false},
+		{files: cachefs, expectCacheHit: true},
+	}
 
-  for i := range testcases {
-    testcase := testcases[i]
+	for i := range testcases {
+		testcase := testcases[i]
 
-    t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-      testfs := testhelper.NewTestFs(testcase.files)
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			testfs := testhelper.NewTestFs(testcase.files)
 
-      hit := true
+			hit := true
 
-      get := func(wd, src, dst string) error {
-        if wd != CacheDir() {
-          return fmt.Errorf("unexpected wd: %s", wd)
-        }
-        if src != "git::https://github.com/cloudposse/helmfiles.git?ref=0.40.0" {
-          return fmt.Errorf("unexpected src: %s", src)
-        }
+			get := func(wd, src, dst string) error {
+				if wd != CacheDir() {
+					return fmt.Errorf("unexpected wd: %s", wd)
+				}
+				if src != "git::https://github.com/cloudposse/helmfiles.git?ref=0.40.0" {
+					return fmt.Errorf("unexpected src: %s", src)
+				}
 
-        hit = false
+				hit = false
 
-        return nil
-      }
+				return nil
+			}
 
-      getter := &testGetter{
-        get: get,
-      }
-      remote := &Remote{
-        Logger: helmexec.NewLogger(io.Discard, "debug"),
-        Home:   CacheDir(),
-        Getter: getter,
-        fs:     testfs.ToFileSystem(),
-      }
+			getter := &testGetter{
+				get: get,
+			}
+			remote := &Remote{
+				Logger: helmexec.NewLogger(io.Discard, "debug"),
+				Home:   CacheDir(),
+				Getter: getter,
+				fs:     testfs.ToFileSystem(),
+			}
 
-      // FYI, go-getter in the `dir` mode accepts URL like the below. So helmfile expects URLs similar to it:
-      //   go-getter -mode dir git::https://github.com/cloudposse/helmfiles.git?ref=0.40.0 gettertest1/b
+			// FYI, go-getter in the `dir` mode accepts URL like the below. So helmfile expects URLs similar to it:
+			//   go-getter -mode dir git::https://github.com/cloudposse/helmfiles.git?ref=0.40.0 gettertest1/b
 
-      // We use `@` to separate dir and the file path. This is a good idea borrowed from helm-git:
-      //   https://github.com/aslafy-z/helm-git
+			// We use `@` to separate dir and the file path. This is a good idea borrowed from helm-git:
+			//   https://github.com/aslafy-z/helm-git
 
-      url := "git::https://github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0"
-      file, err := remote.Locate(url)
-      if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-      }
+			url := "git::https://github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0"
+			file, err := remote.Locate(url)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-      expectedFile := filepath.Join(CacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
-      if file != expectedFile {
-        t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
-      }
+			expectedFile := filepath.Join(CacheDir(), "https_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
+			if file != expectedFile {
+				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
+			}
 
-      if testcase.expectCacheHit && !hit {
-        t.Errorf("unexpected result: unexpected cache miss")
-      }
-      if !testcase.expectCacheHit && hit {
-        t.Errorf("unexpected result: unexpected cache hit")
-      }
-    })
-  }
+			if testcase.expectCacheHit && !hit {
+				t.Errorf("unexpected result: unexpected cache miss")
+			}
+			if !testcase.expectCacheHit && hit {
+				t.Errorf("unexpected result: unexpected cache hit")
+			}
+		})
+	}
 }
 
 func TestRemote_SShGitHub(t *testing.T) {
-  cleanfs := map[string]string{
-    CacheDir(): "",
-  }
-  cachefs := map[string]string{
-    filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
-  }
+	cleanfs := map[string]string{
+		CacheDir(): "",
+	}
+	cachefs := map[string]string{
+		filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml"): "foo: bar",
+	}
 
-  type testcase struct {
-    files          map[string]string
-    expectCacheHit bool
-  }
+	type testcase struct {
+		files          map[string]string
+		expectCacheHit bool
+	}
 
-  testcases := []testcase{
-    {files: cleanfs, expectCacheHit: false},
-    {files: cachefs, expectCacheHit: true},
-  }
+	testcases := []testcase{
+		{files: cleanfs, expectCacheHit: false},
+		{files: cachefs, expectCacheHit: true},
+	}
 
-  for i := range testcases {
-    testcase := testcases[i]
+	for i := range testcases {
+		testcase := testcases[i]
 
-    t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-      testfs := testhelper.NewTestFs(testcase.files)
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			testfs := testhelper.NewTestFs(testcase.files)
 
-      hit := true
+			hit := true
 
-      get := func(wd, src, dst string) error {
-        if wd != CacheDir() {
-          return fmt.Errorf("unexpected wd: %s", wd)
-        }
-        if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0" {
-          return fmt.Errorf("unexpected src: %s", src)
-        }
+			get := func(wd, src, dst string) error {
+				if wd != CacheDir() {
+					return fmt.Errorf("unexpected wd: %s", wd)
+				}
+				if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0" {
+					return fmt.Errorf("unexpected src: %s", src)
+				}
 
-        hit = false
+				hit = false
 
-        return nil
-      }
+				return nil
+			}
 
-      getter := &testGetter{
-        get: get,
-      }
-      remote := &Remote{
-        Logger: helmexec.NewLogger(io.Discard, "debug"),
-        Home:   CacheDir(),
-        Getter: getter,
-        fs:     testfs.ToFileSystem(),
-      }
+			getter := &testGetter{
+				get: get,
+			}
+			remote := &Remote{
+				Logger: helmexec.NewLogger(io.Discard, "debug"),
+				Home:   CacheDir(),
+				Getter: getter,
+				fs:     testfs.ToFileSystem(),
+			}
 
-      url := "git::ssh://git@github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0"
-      file, err := remote.Locate(url)
-      if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-      }
+			url := "git::ssh://git@github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0"
+			file, err := remote.Locate(url)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-      expectedFile := filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
-      if file != expectedFile {
-        t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
-      }
+			expectedFile := filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0/releases/kiam.yaml")
+			if file != expectedFile {
+				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
+			}
 
-      if testcase.expectCacheHit && !hit {
-        t.Errorf("unexpected result: unexpected cache miss")
-      }
-      if !testcase.expectCacheHit && hit {
-        t.Errorf("unexpected result: unexpected cache hit")
-      }
-    })
-  }
+			if testcase.expectCacheHit && !hit {
+				t.Errorf("unexpected result: unexpected cache miss")
+			}
+			if !testcase.expectCacheHit && hit {
+				t.Errorf("unexpected result: unexpected cache hit")
+			}
+		})
+	}
 }
 
 func TestRemote_SShGitHub_WithSshKey(t *testing.T) {
-  cleanfs := map[string]string{
-    CacheDir(): "",
-  }
-  cachefs := map[string]string{
-    filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0_sshkey=redacted/releases/kiam.yaml"): "foo: bar",
-  }
+	cleanfs := map[string]string{
+		CacheDir(): "",
+	}
+	cachefs := map[string]string{
+		filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0_sshkey=redacted/releases/kiam.yaml"): "foo: bar",
+	}
 
-  type testcase struct {
-    files          map[string]string
-    expectCacheHit bool
-  }
+	type testcase struct {
+		files          map[string]string
+		expectCacheHit bool
+	}
 
-  testcases := []testcase{
-    {files: cleanfs, expectCacheHit: false},
-    {files: cachefs, expectCacheHit: true},
-  }
+	testcases := []testcase{
+		{files: cleanfs, expectCacheHit: false},
+		{files: cachefs, expectCacheHit: true},
+	}
 
-  for i := range testcases {
-    testcase := testcases[i]
+	for i := range testcases {
+		testcase := testcases[i]
 
-    t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-      testfs := testhelper.NewTestFs(testcase.files)
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			testfs := testhelper.NewTestFs(testcase.files)
 
-      hit := true
+			hit := true
 
-      get := func(wd, src, dst string) error {
-        if wd != CacheDir() {
-          return fmt.Errorf("unexpected wd: %s", wd)
-        }
-        if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0&sshkey=ZWNkc2Etc2hhMi1uaXN0cDI1NiBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEF5TlRZQUFBQUlibWx6ZEhBeU5UWUFBQUJCQkJTU3dOY2xoVzQ2Vm9VR3dMQ3JscVRHYUdOVWdRVUVEUEptc1ZzdUViL2RBNUcrQk9YMWxGaUVMYU9HQ2F6bS9KQkR2V3Y2Y0ZDQUtVRjVocVJOUjdJPSA=" {
-          return fmt.Errorf("unexpected src: %s", src)
-        }
+			get := func(wd, src, dst string) error {
+				if wd != CacheDir() {
+					return fmt.Errorf("unexpected wd: %s", wd)
+				}
+				if src != "git::ssh://git@github.com/cloudposse/helmfiles.git?ref=0.40.0&sshkey=ZWNkc2Etc2hhMi1uaXN0cDI1NiBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEF5TlRZQUFBQUlibWx6ZEhBeU5UWUFBQUJCQkJTU3dOY2xoVzQ2Vm9VR3dMQ3JscVRHYUdOVWdRVUVEUEptc1ZzdUViL2RBNUcrQk9YMWxGaUVMYU9HQ2F6bS9KQkR2V3Y2Y0ZDQUtVRjVocVJOUjdJPSA=" {
+					return fmt.Errorf("unexpected src: %s", src)
+				}
 
-        hit = false
+				hit = false
 
-        return nil
-      }
+				return nil
+			}
 
-      getter := &testGetter{
-        get: get,
-      }
-      remote := &Remote{
-        Logger: helmexec.NewLogger(io.Discard, "debug"),
-        Home:   CacheDir(),
-        Getter: getter,
-        fs:     testfs.ToFileSystem(),
-      }
+			getter := &testGetter{
+				get: get,
+			}
+			remote := &Remote{
+				Logger: helmexec.NewLogger(io.Discard, "debug"),
+				Home:   CacheDir(),
+				Getter: getter,
+				fs:     testfs.ToFileSystem(),
+			}
 
-      url := "git::ssh://git@github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0&sshkey=ZWNkc2Etc2hhMi1uaXN0cDI1NiBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEF5TlRZQUFBQUlibWx6ZEhBeU5UWUFBQUJCQkJTU3dOY2xoVzQ2Vm9VR3dMQ3JscVRHYUdOVWdRVUVEUEptc1ZzdUViL2RBNUcrQk9YMWxGaUVMYU9HQ2F6bS9KQkR2V3Y2Y0ZDQUtVRjVocVJOUjdJPSA="
-      file, err := remote.Locate(url)
-      if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-      }
+			url := "git::ssh://git@github.com/cloudposse/helmfiles.git@releases/kiam.yaml?ref=0.40.0&sshkey=ZWNkc2Etc2hhMi1uaXN0cDI1NiBBQUFBRTJWalpITmhMWE5vWVRJdGJtbHpkSEF5TlRZQUFBQUlibWx6ZEhBeU5UWUFBQUJCQkJTU3dOY2xoVzQ2Vm9VR3dMQ3JscVRHYUdOVWdRVUVEUEptc1ZzdUViL2RBNUcrQk9YMWxGaUVMYU9HQ2F6bS9KQkR2V3Y2Y0ZDQUtVRjVocVJOUjdJPSA="
+			file, err := remote.Locate(url)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-      expectedFile := filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0_sshkey=redacted/releases/kiam.yaml")
-      if file != expectedFile {
-        t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
-      }
+			expectedFile := filepath.Join(CacheDir(), "ssh_github_com_cloudposse_helmfiles_git.ref=0.40.0_sshkey=redacted/releases/kiam.yaml")
+			if file != expectedFile {
+				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
+			}
 
-      if testcase.expectCacheHit && !hit {
-        t.Errorf("unexpected result: unexpected cache miss")
-      }
-      if !testcase.expectCacheHit && hit {
-        t.Errorf("unexpected result: unexpected cache hit")
-      }
-    })
-  }
+			if testcase.expectCacheHit && !hit {
+				t.Errorf("unexpected result: unexpected cache miss")
+			}
+			if !testcase.expectCacheHit && hit {
+				t.Errorf("unexpected result: unexpected cache hit")
+			}
+		})
+	}
 }
 
 func TestRemote_S3(t *testing.T) {
-  cleanfs := map[string]string{
-    CacheDir(): "",
-  }
-  cachefs := map[string]string{
-    filepath.Join(CacheDir(), "s3_helm-s3-values-example/subdir/values.yaml"): "foo: bar",
-  }
+	cleanfs := map[string]string{
+		CacheDir(): "",
+	}
+	cachefs := map[string]string{
+		filepath.Join(CacheDir(), "s3_helm-s3-values-example/subdir/values.yaml"): "foo: bar",
+	}
 
-  type testcase struct {
-    files          map[string]string
-    expectCacheHit bool
-  }
+	type testcase struct {
+		files          map[string]string
+		expectCacheHit bool
+	}
 
-  testcases := []testcase{
-    {files: cleanfs, expectCacheHit: false},
-    {files: cachefs, expectCacheHit: true},
-  }
+	testcases := []testcase{
+		{files: cleanfs, expectCacheHit: false},
+		{files: cachefs, expectCacheHit: true},
+	}
 
-  for i := range testcases {
-    testcase := testcases[i]
+	for i := range testcases {
+		testcase := testcases[i]
 
-    t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-      testfs := testhelper.NewTestFs(testcase.files)
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			testfs := testhelper.NewTestFs(testcase.files)
 
-      hit := true
+			hit := true
 
-      get := func(wd, src, dst string) error {
-        if wd != CacheDir() {
-          return fmt.Errorf("unexpected wd: %s", wd)
-        }
-        if src != "s3://helm-s3-values-example/subdir/values.yaml" {
-          return fmt.Errorf("unexpected src: %s", src)
-        }
+			get := func(wd, src, dst string) error {
+				if wd != CacheDir() {
+					return fmt.Errorf("unexpected wd: %s", wd)
+				}
+				if src != "s3://helm-s3-values-example/subdir/values.yaml" {
+					return fmt.Errorf("unexpected src: %s", src)
+				}
 
-        hit = false
+				hit = false
 
-        return nil
-      }
+				return nil
+			}
 
-      getter := &testGetter{
-        get: get,
-      }
-      remote := &Remote{
-        Logger:     helmexec.NewLogger(io.Discard, "debug"),
-        Home:       CacheDir(),
-        Getter:     getter,
-        S3Getter:   getter,
-        HttpGetter: getter,
-        fs:         testfs.ToFileSystem(),
-      }
+			getter := &testGetter{
+				get: get,
+			}
+			remote := &Remote{
+				Logger:     helmexec.NewLogger(io.Discard, "debug"),
+				Home:       CacheDir(),
+				Getter:     getter,
+				S3Getter:   getter,
+				HttpGetter: getter,
+				fs:         testfs.ToFileSystem(),
+			}
 
-      url := "s3://helm-s3-values-example/subdir/values.yaml"
-      file, err := remote.Locate(url)
-      if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-      }
+			url := "s3://helm-s3-values-example/subdir/values.yaml"
+			file, err := remote.Locate(url)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-      expectedFile := filepath.Join(CacheDir(), "s3_helm-s3-values-example/subdir/values.yaml")
-      if file != expectedFile {
-        t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
-      }
+			expectedFile := filepath.Join(CacheDir(), "s3_helm-s3-values-example/subdir/values.yaml")
+			if file != expectedFile {
+				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
+			}
 
-      if testcase.expectCacheHit && !hit {
-        t.Errorf("unexpected result: unexpected cache miss")
-      }
-      if !testcase.expectCacheHit && hit {
-        t.Errorf("unexpected result: unexpected cache hit")
-      }
-    })
-  }
+			if testcase.expectCacheHit && !hit {
+				t.Errorf("unexpected result: unexpected cache miss")
+			}
+			if !testcase.expectCacheHit && hit {
+				t.Errorf("unexpected result: unexpected cache hit")
+			}
+		})
+	}
 }
 
 func TestParse(t *testing.T) {
-  type testcase struct {
-    input                            string
-    getter, scheme, dir, file, query string
-    err                              string
-  }
+	type testcase struct {
+		input                            string
+		getter, scheme, dir, file, query string
+		err                              string
+	}
 
-  testcases := []testcase{
-    {
-      input: "raw/incubator",
-      err:   "parse url: missing scheme - probably this is a local file path? raw/incubator",
-    },
-    {
-      input:  "git::https://github.com/stakater/Forecastle.git@deployments/kubernetes/chart/forecastle?ref=v1.0.54",
-      getter: "git",
-      scheme: "https",
-      dir:    "/stakater/Forecastle.git",
-      file:   "deployments/kubernetes/chart/forecastle",
-      query:  "ref=v1.0.54",
-    },
-    {
-      input:  "s3://helm-s3-values-example/values.yaml",
-      getter: "normal",
-      scheme: "s3",
-      dir:    "",
-      file:   "values.yaml",
-      query:  "",
-    },
-    {
-      input:  "s3://helm-s3-values-example/subdir/values.yaml",
-      getter: "normal",
-      scheme: "s3",
-      dir:    "subdir",
-      file:   "values.yaml",
-      query:  "",
-    },
-    {
-      input:  "http::http://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
-      getter: "http",
-      scheme: "http",
-      dir:    "",
-      file:   "values.yaml",
-      query:  "",
-    },
-    {
-      input:  "http::http://helm-s3-values-example.s3.us-east-2.amazonaws.com/subdir/values.yaml",
-      getter: "http",
-      scheme: "http",
-      dir:    "subdir",
-      file:   "values.yaml",
-      query:  "",
-    },
-    {
-      input:  "http::https://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
-      getter: "http",
-      scheme: "https",
-      dir:    "",
-      file:   "values.yaml",
-      query:  "",
-    },
-    {
-      input:  "http://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
-      getter: "normal",
-      scheme: "http",
-      dir:    "",
-      file:   "values.yaml",
-      query:  "",
-    },
-    {
-      input:  "https://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
-      getter: "normal",
-      scheme: "https",
-      dir:    "",
-      file:   "values.yaml",
-      query:  "",
-    },
-  }
+	testcases := []testcase{
+		{
+			input: "raw/incubator",
+			err:   "parse url: missing scheme - probably this is a local file path? raw/incubator",
+		},
+		{
+			input:  "git::https://github.com/stakater/Forecastle.git@deployments/kubernetes/chart/forecastle?ref=v1.0.54",
+			getter: "git",
+			scheme: "https",
+			dir:    "/stakater/Forecastle.git",
+			file:   "deployments/kubernetes/chart/forecastle",
+			query:  "ref=v1.0.54",
+		},
+		{
+			input:  "s3://helm-s3-values-example/values.yaml",
+			getter: "normal",
+			scheme: "s3",
+			dir:    "",
+			file:   "values.yaml",
+			query:  "",
+		},
+		{
+			input:  "s3://helm-s3-values-example/subdir/values.yaml",
+			getter: "normal",
+			scheme: "s3",
+			dir:    "subdir",
+			file:   "values.yaml",
+			query:  "",
+		},
+		{
+			input:  "http::http://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
+			getter: "http",
+			scheme: "http",
+			dir:    "",
+			file:   "values.yaml",
+			query:  "",
+		},
+		{
+			input:  "http::http://helm-s3-values-example.s3.us-east-2.amazonaws.com/subdir/values.yaml",
+			getter: "http",
+			scheme: "http",
+			dir:    "subdir",
+			file:   "values.yaml",
+			query:  "",
+		},
+		{
+			input:  "http::https://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
+			getter: "http",
+			scheme: "https",
+			dir:    "",
+			file:   "values.yaml",
+			query:  "",
+		},
+		{
+			input:  "http://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
+			getter: "normal",
+			scheme: "http",
+			dir:    "",
+			file:   "values.yaml",
+			query:  "",
+		},
+		{
+			input:  "https://helm-s3-values-example.s3.us-east-2.amazonaws.com/values.yaml",
+			getter: "normal",
+			scheme: "https",
+			dir:    "",
+			file:   "values.yaml",
+			query:  "",
+		},
+	}
 
-  for i := range testcases {
-    tc := testcases[i]
+	for i := range testcases {
+		tc := testcases[i]
 
-    t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-      src, err := Parse(tc.input)
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			src, err := Parse(tc.input)
 
-      var errMsg string
-      if err != nil {
-        errMsg = err.Error()
-      }
+			var errMsg string
+			if err != nil {
+				errMsg = err.Error()
+			}
 
-      if diff := cmp.Diff(tc.err, errMsg); diff != "" {
-        t.Fatalf("Unexpected error:\n%s", diff)
-      }
+			if diff := cmp.Diff(tc.err, errMsg); diff != "" {
+				t.Fatalf("Unexpected error:\n%s", diff)
+			}
 
-      var getter, scheme, dir, file, query string
-      if src != nil {
-        getter = src.Getter
-        scheme = src.Scheme
-        dir = src.Dir
-        file = src.File
-        query = src.RawQuery
-      }
+			var getter, scheme, dir, file, query string
+			if src != nil {
+				getter = src.Getter
+				scheme = src.Scheme
+				dir = src.Dir
+				file = src.File
+				query = src.RawQuery
+			}
 
-      if diff := cmp.Diff(tc.getter, getter); diff != "" {
-        t.Fatalf("Unexpected getter:\n%s", diff)
-      }
+			if diff := cmp.Diff(tc.getter, getter); diff != "" {
+				t.Fatalf("Unexpected getter:\n%s", diff)
+			}
 
-      if diff := cmp.Diff(tc.scheme, scheme); diff != "" {
-        t.Fatalf("Unexpected scheme:\n%s", diff)
-      }
+			if diff := cmp.Diff(tc.scheme, scheme); diff != "" {
+				t.Fatalf("Unexpected scheme:\n%s", diff)
+			}
 
-      if diff := cmp.Diff(tc.file, file); diff != "" {
-        t.Fatalf("Unexpected file:\n%s", diff)
-      }
+			if diff := cmp.Diff(tc.file, file); diff != "" {
+				t.Fatalf("Unexpected file:\n%s", diff)
+			}
 
-      if diff := cmp.Diff(tc.dir, dir); diff != "" {
-        t.Fatalf("Unexpected dir:\n%s", diff)
-      }
+			if diff := cmp.Diff(tc.dir, dir); diff != "" {
+				t.Fatalf("Unexpected dir:\n%s", diff)
+			}
 
-      if diff := cmp.Diff(tc.query, query); diff != "" {
-        t.Fatalf("Unexpected query:\n%s", diff)
-      }
-    })
-  }
+			if diff := cmp.Diff(tc.query, query); diff != "" {
+				t.Fatalf("Unexpected query:\n%s", diff)
+			}
+		})
+	}
 }
 
 type testGetter struct {
-  get func(wd, src, dst string) error
+	get func(wd, src, dst string) error
 }
 
 func (t *testGetter) Get(wd, src, dst string) error {
-  return t.get(wd, src, dst)
+	return t.get(wd, src, dst)
 }
 
 func TestRemote_Fetch(t *testing.T) {
-  cleanfs := map[string]string{
-    CacheDir(): "",
-  }
-  cachefs := map[string]string{
-    filepath.Join(CacheDir(), "https_github_com_helmfile_helmfile_git.ref=v0.151.0/README.md"): "foo: bar",
-  }
+	cleanfs := map[string]string{
+		CacheDir(): "",
+	}
+	cachefs := map[string]string{
+		filepath.Join(CacheDir(), "https_github_com_helmfile_helmfile_git.ref=v0.151.0/README.md"): "foo: bar",
+	}
 
-  type testcase struct {
-    files          map[string]string
-    expectCacheHit bool
-    cacheDirOpt    string
-  }
+	type testcase struct {
+		files          map[string]string
+		expectCacheHit bool
+		cacheDirOpt    string
+	}
 
-  testcases := []testcase{
-    {files: cleanfs, expectCacheHit: false, cacheDirOpt: ""},
-    {files: cachefs, expectCacheHit: true, cacheDirOpt: ""},
-    {files: cleanfs, expectCacheHit: false, cacheDirOpt: "states"},
-    {files: cachefs, expectCacheHit: true, cacheDirOpt: "states"},
-  }
+	testcases := []testcase{
+		{files: cleanfs, expectCacheHit: false, cacheDirOpt: ""},
+		{files: cachefs, expectCacheHit: true, cacheDirOpt: ""},
+		{files: cleanfs, expectCacheHit: false, cacheDirOpt: "states"},
+		{files: cachefs, expectCacheHit: true, cacheDirOpt: "states"},
+	}
 
-  for i := range testcases {
-    testcase := testcases[i]
+	for i := range testcases {
+		testcase := testcases[i]
 
-    t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-      testfs := testhelper.NewTestFs(testcase.files)
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			testfs := testhelper.NewTestFs(testcase.files)
 
-      hit := true
+			hit := true
 
-      get := func(wd, src, dst string) error {
-        if wd != CacheDir() {
-          return fmt.Errorf("unexpected wd: %s", wd)
-        }
-        if src != "git::https://github.com/helmfile/helmfile.git?ref=v0.151.0" {
-          return fmt.Errorf("unexpected src: %s", src)
-        }
+			get := func(wd, src, dst string) error {
+				if wd != CacheDir() {
+					return fmt.Errorf("unexpected wd: %s", wd)
+				}
+				if src != "git::https://github.com/helmfile/helmfile.git?ref=v0.151.0" {
+					return fmt.Errorf("unexpected src: %s", src)
+				}
 
-        hit = false
+				hit = false
 
-        return nil
-      }
+				return nil
+			}
 
-      getter := &testGetter{
-        get: get,
-      }
-      remote := &Remote{
-        Logger: helmexec.NewLogger(io.Discard, "debug"),
-        Home:   CacheDir(),
-        Getter: getter,
-        fs:     testfs.ToFileSystem(),
-      }
+			getter := &testGetter{
+				get: get,
+			}
+			remote := &Remote{
+				Logger: helmexec.NewLogger(io.Discard, "debug"),
+				Home:   CacheDir(),
+				Getter: getter,
+				fs:     testfs.ToFileSystem(),
+			}
 
-      url := "git::https://github.com/helmfile/helmfile.git@README.md?ref=v0.151.0"
-      file, err := remote.Fetch(url)
-      if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-      }
+			url := "git::https://github.com/helmfile/helmfile.git@README.md?ref=v0.151.0"
+			file, err := remote.Fetch(url)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-      expectedFile := filepath.Join(CacheDir(), "https_github_com_helmfile_helmfile_git.ref=v0.151.0/README.md")
-      if file != expectedFile {
-        t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
-      }
+			expectedFile := filepath.Join(CacheDir(), "https_github_com_helmfile_helmfile_git.ref=v0.151.0/README.md")
+			if file != expectedFile {
+				t.Errorf("unexpected file located: %s vs expected: %s", file, expectedFile)
+			}
 
-      if testcase.expectCacheHit && !hit {
-        t.Errorf("unexpected result: unexpected cache miss")
-      }
-      if !testcase.expectCacheHit && hit {
-        t.Errorf("unexpected result: unexpected cache hit")
-      }
-    })
-  }
+			if testcase.expectCacheHit && !hit {
+				t.Errorf("unexpected result: unexpected cache miss")
+			}
+			if !testcase.expectCacheHit && hit {
+				t.Errorf("unexpected result: unexpected cache hit")
+			}
+		})
+	}
 }


### PR DESCRIPTION
> fork #834

This adds support for s3:// http:// https:// and most other go-getter style urls by

Adding http downloader
Adding s3 downloader that authenticates with aws sdk shared credentials
Changing the parser to accept remote formats that do not include '::'
Removing validation that required go-getter urls to contain '@' which is not required by go-getter spec
Resolves https://github.com/helmfile/helmfile/issues/831