### PR TITLE
test: fix running tests locally

### DIFF
--- a/test/e2e/template/helmfile/snapshot_test.go
+++ b/test/e2e/template/helmfile/snapshot_test.go
@@ -295,8 +295,9 @@ func testHelmfileTemplateWithBuildCommand(t *testing.T, goccyGoYaml bool) {
 
 			if stat, _ := os.Stat(outputFile); stat != nil {
 				want, err := os.ReadFile(outputFile)
+				wantStr := strings.ReplaceAll(string(want), "__workingdir__", wd)
 				require.NoError(t, err)
-				require.Equal(t, string(want), gotStr)
+				require.Equal(t, wantStr, gotStr)
 			} else {
 				// To update the test golden image(output.yaml), just remove it and rerun this test.
 				// We automatically capture the output to `output.yaml` in the test case directory

--- a/test/e2e/template/helmfile/testdata/snapshot/issue_2098_release_template_needs/output.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/issue_2098_release_template_needs/output.yaml
@@ -1,5 +1,5 @@
 ---
-#  Source: /home/runner/work/helmfile/helmfile/test/e2e/template/helmfile/testdata/snapshot/issue_2098_release_template_needs/input.yaml
+#  Source: __workingdir__/testdata/snapshot/issue_2098_release_template_needs/input.yaml
 
 filepath: input.yaml
 helmBinary: helm


### PR DESCRIPTION
One of the tests were not portable and would only work in GitHub Actions.
This makes such test more portable.
