### PR TITLE
fix: args ignore in diff subcommand

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1591,6 +1591,8 @@ func (a *App) diff(r *Run, c DiffConfigProvider) (*string, bool, bool, []error) 
 
 		var errs []error
 
+		helm.SetExtraArgs(GetArgs(c.Args(), r.state)...)
+
 		opts := &state.DiffOpts{
 			Context:           c.Context(),
 			Output:            c.DiffOutput(),


### PR DESCRIPTION
fix #1116 