### PR TITLE
Fix failing docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,9 @@ mkdocs:
   configuration: mkdocs.yml
   fail_on_warning: false
 
+build:
+  os: ubuntu-22.04
+
 python:
    install:
    - requirements: docs/requirements.txt


### PR DESCRIPTION
The [readthedocs build](https://readthedocs.org/projects/helmfile/builds/) is failing due to a missing required `build.os`

```
Error
Problem in your project's configuration. Invalid configuration option "build.os": build not found
```