### PR TITLE
chore: add bluelabs to list of helmfile users

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -36,4 +36,5 @@ information to this file.
 | [subshell](https://subshell.com) | production | We're using helmfile since 2021 to deploy all our Kubernetes workloads into our clusters. We love helmfile for its simplicity and power. Thank you! | Hamburg, Germany | August 2022 |
 | [Norddeutscher Rundfunk](https://www.ndr.de) | production | Using Helmfile since 2020 to deploy workloads to several similar clusters (dev, qa, prod, test, etc.) for sites tagesschau.de and sportschau.de. Thank you so much for your awesome work! | Hamburg, Germany | August 2022 |
 | [Dealhub](https://dealhub.io/) | production | Helmfile was an essential part of our k8s migration. Keep up the good work! | Holon, Israel | January 2023 |
+| [BlueLabs](https://bluelabs.eu/) | production | Helmfile is the cornerstone of our lightweight, auditable and centralized GKE deployments. | Europe | February 2021 |
 <!-- TABLE_END -->


### PR DESCRIPTION
### Description

Add [BlueLabs](https://bluelabs.eu/) to the list of `Helmfile` users. We have been using `Helmfile` since early 2021 to perform deployments to all our environments, including production. In early 2023 we started using it together with GitHub Actions to fully automate our deployments.