### PR TITLE
fix: prevent preparing chart for disabled releases

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2203,15 +2203,18 @@ func markExcludedReleases(releases []ReleaseSpec, selectors []string, commonLabe
 		if r.Labels == nil {
 			r.Labels = map[string]string{}
 		}
-		// Let the release name, namespace, and chart be used as a tag
-		r.Labels["name"] = r.Name
-		r.Labels["namespace"] = r.Namespace
-		// Strip off just the last portion for the name stable/newrelic would give newrelic
-		chartSplit := strings.Split(r.Chart, "/")
-		r.Labels["chart"] = chartSplit[len(chartSplit)-1]
-		// Merge CommonLabels into release labels
-		for k, v := range commonLabels {
-			r.Labels[k] = v
+		// Do not add any label without any filter, see #276
+		if len(filters) > 0 {
+			// Let the release name, namespace, and chart be used as a tag
+			r.Labels["name"] = r.Name
+			r.Labels["namespace"] = r.Namespace
+			// Strip off just the last portion for the name stable/newrelic would give newrelic
+			chartSplit := strings.Split(r.Chart, "/")
+			r.Labels["chart"] = chartSplit[len(chartSplit)-1]
+			// Merge CommonLabels into release labels
+			for k, v := range commonLabels {
+				r.Labels[k] = v
+			}
 		}
 		var filterMatch bool
 		for _, f := range filters {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1125,17 +1125,13 @@ type PrepareChartKey struct {
 func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurrency int, helmfileCommand string, opts ChartPrepareOptions) (map[PrepareChartKey]string, []error) {
 	var selected []ReleaseSpec
 
-	if len(st.Selectors) > 0 {
-		var err error
+	var err error
 
-		// This and releasesNeedCharts ensures that we run operations like helm-dep-build and prepare-hook calls only on
-		// releases that are (1) selected by the selectors and (2) to be installed.
-		selected, err = st.GetSelectedReleases(opts.IncludeTransitiveNeeds)
-		if err != nil {
-			return nil, []error{err}
-		}
-	} else {
-		selected = st.Releases
+	// This and releasesNeedCharts ensures that we run operations like helm-dep-build and prepare-hook calls only on
+	// releases that are (1) selected by the selectors and (2) to be installed.
+	selected, err = st.GetSelectedReleases(opts.IncludeTransitiveNeeds)
+	if err != nil {
+		return nil, []error{err}
 	}
 
 	if !opts.SkipResolve {

--- a/test/integration/test-cases/happypath/input/environment.values.yaml
+++ b/test/integration/test-cases/happypath/input/environment.values.yaml
@@ -1,3 +1,5 @@
 mysecret: MYSECRET
 raw2:
   enabled: false
+release-disabled:
+  enabled: false

--- a/test/integration/test-cases/happypath/input/happypath.yaml
+++ b/test/integration/test-cases/happypath/input/happypath.yaml
@@ -54,3 +54,20 @@ releases:
     values:
       - mysecret: {{ .Environment.Values.mysecret }}
       - values.yaml
+
+  - name: release-disabled
+    chart: ../../../charts/helmx
+    namespace: release-disabled
+    condition: release-disabled.enabled
+    values:
+      - values-not-found.yaml
+    jsonPatches:
+      - target:
+          version: v1
+          kind: ConfigMap
+          name: release-name
+        patch:
+          - op: add
+            path: /metadata/annotations
+            value:
+              foo: bar


### PR DESCRIPTION
## What does it fix?

Prevent following things from
- using any unnecessary computing resources for disabled charts
- throwing any error from wrong configurations for disabled charts

## Previous behavior

PrepareCharts does not filter any releases whose condition is disabled with no selectors, so it use unnecessary computing resources
