### PR TITLE
feat: adding ability for for charts to be pulled without HTTPS

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -161,6 +161,10 @@ repositories:
 - name: skipTLS
   url: https://ss.my-insecure-domain.com
   skipTLSVerify: true
+# Advanced configuration: If you Repo only supports Plain HTTP
+- name: plainHTTP
+  url: http://just.http.domain.com
+  plainHttp: true
 
 # context: kube-context # this directive is deprecated, please consider using helmDefaults.kubeContext
 
@@ -221,6 +225,8 @@ helmDefaults:
   cascade: "background"
   # insecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
   insecureSkipTLSVerify: false
+  # plainHttp is true if fetching the remote shart should be done using HTTP
+  plainHttp: true
   # --wait flag for destroy/delete, if set to true, will wait until all resources are deleted before mark delete command as successful
   deleteWait: false
   # Timeout is the time in seconds to wait for helmfile destroy/delete (default 300)
@@ -334,6 +340,8 @@ releases:
     cascade: "background"
     # insecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
     insecureSkipTLSVerify: false
+    # plainHttp is true if fetching the remote shart should be done using HTTP
+    plainHttp: true
     # suppressDiff skip the helm diff output. Useful for charts which produces large not helpful diff, default: false
     suppressDiff: false
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -192,6 +192,8 @@ type HelmSpec struct {
 	DisableOpenAPIValidation *bool `yaml:"disableOpenAPIValidation,omitempty"`
 	// InsecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
 	InsecureSkipTLSVerify bool `yaml:"insecureSkipTLSVerify,omitempty"`
+	// PlainHttp is true if the remote charte should be fetched using HTTP and not HTTPS
+	PlainHttp             bool `yaml:"plainHttp,omitempty"`
 	// Wait, if set to true, will wait until all resources are deleted before mark delete command as successful
 	DeleteWait bool `yaml:"deleteWait"`
 	// Timeout is the time in seconds to wait for helmfile delete command (default 300)
@@ -213,6 +215,7 @@ type RepositorySpec struct {
 	Keyring         string `yaml:"keyring,omitempty"`
 	PassCredentials bool   `yaml:"passCredentials,omitempty"`
 	SkipTLSVerify   bool   `yaml:"skipTLSVerify,omitempty"`
+	PlainHttp       bool   `yaml:"plainHttp,omitempty"`
 }
 
 type Inherit struct {
@@ -319,6 +322,9 @@ type ReleaseSpec struct {
 
 	// InsecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart.
 	InsecureSkipTLSVerify bool `yaml:"insecureSkipTLSVerify,omitempty"`
+
+	// PlainHttp is true if the remote charte should be fetched using HTTP and not HTTPS
+	PlainHttp             bool `yaml:"plainHttp,omitempty"`
 
 	// These values are used in templating
 	VerifyTemplate    *string `yaml:"verifyTemplate,omitempty"`
@@ -2164,6 +2170,7 @@ func (st *HelmState) TestReleases(helm helmexec.Interface, cleanup bool, timeout
 
 		flags = st.appendConnectionFlags(flags, &release)
 		flags = st.appendChartDownloadTLSFlags(flags, &release)
+		flags = st.appendChartDownloadPlainHttpFlags(flags, release)
 
 		return helm.TestRelease(st.createHelmContext(&release, workerIndex), release.Name, flags...)
 	})
@@ -2542,6 +2549,16 @@ func (st *HelmState) appendChartDownloadTLSFlags(flags []string, release *Releas
 	return flags
 }
 
+func (st *HelmState) appendChartDownloadPlainHttpFlags(flags []string, release *ReleaseSpec) []string {
+	switch {
+	case release.PlainHttp:
+		flags = append(flags, "--plain-http")
+	case st.HelmDefaults.PlainHttp:
+		flags = append(flags, "--plain-http")
+	}
+	return flags
+}
+
 func (st *HelmState) timeoutFlags(release *ReleaseSpec) []string {
 	var flags []string
 
@@ -2609,6 +2626,7 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 
 	flags = st.appendConnectionFlags(flags, release)
 	flags = st.appendChartDownloadTLSFlags(flags, release)
+	flags = st.appendChartDownloadPlainHttpFlags(flags, release)
 
 	flags = st.appendHelmXFlags(flags, release)
 
@@ -2650,6 +2668,7 @@ func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseS
 	flags = st.appendPostRenderArgsFlags(flags, release, postRendererArgs)
 	flags = st.appendApiVersionsFlags(flags, release, kubeVersion)
 	flags = st.appendChartDownloadTLSFlags(flags, release)
+	flags = st.appendChartDownloadPlainHttpFlags(flags, release)
 
 	common, files, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {
@@ -2704,6 +2723,7 @@ func (st *HelmState) flagsForDiff(helm helmexec.Interface, release *ReleaseSpec,
 	}
 
 	flags = st.appendChartDownloadTLSFlags(flags, release)
+	flags = st.appendChartDownloadPlainHttpFlags(flags, release)
 
 	flags = st.appendHelmXFlags(flags, release)
 
@@ -3533,6 +3553,29 @@ func (st *HelmState) Reverse() {
 	}
 }
 
+func (st *HelmState) appendGetOCIChartFlags(release *ReleaseSpec) {
+	flags := []string{}
+	repo, _ := st.GetRepositoryAndNameFromChartName(release.Chart)
+	if repo != nil {
+		if repo.CaFile != "" {
+			flags = append(flags, "--ca-file", repo.CaFile)
+		}
+		if repo.CertFile != "" && repo.KeyFile != "" {
+			flags = append(flags, "--cert-file", repo.CertFile, "--key-file", repo.KeyFile)
+		}
+		if repo.SkipTLSVerify {
+			flags = append(flags, "--insecure-skip-tls-verify")
+		}
+		if repo.Verify {
+			flags = append(flags, "--verify")
+		}
+		if repo.Keyring != "" {
+			flags = append(flags, "--keyring", repo.Keyring)
+		}
+	}
+	return flags
+}
+
 func (st *HelmState) getOCIChart(release *ReleaseSpec, tempDir string, helm helmexec.Interface) (*string, error) {
 	qualifiedChartName, chartName, chartVersion, err := st.getOCIQualifiedChartName(release, helm)
 	if err != nil {
@@ -3562,25 +3605,7 @@ func (st *HelmState) getOCIChart(release *ReleaseSpec, tempDir string, helm helm
 	if st.fs.DirectoryExistsAt(chartPath) {
 		st.logger.Debugf("chart already exists at %s", chartPath)
 	} else {
-		flags := []string{}
-		repo, _ := st.GetRepositoryAndNameFromChartName(release.Chart)
-		if repo != nil {
-			if repo.CaFile != "" {
-				flags = append(flags, "--ca-file", repo.CaFile)
-			}
-			if repo.CertFile != "" && repo.KeyFile != "" {
-				flags = append(flags, "--cert-file", repo.CertFile, "--key-file", repo.KeyFile)
-			}
-			if repo.SkipTLSVerify {
-				flags = append(flags, "--insecure-skip-tls-verify")
-			}
-			if repo.Verify {
-				flags = append(flags, "--verify")
-			}
-			if repo.Keyring != "" {
-				flags = append(flags, "--keyring", repo.Keyring)
-			}
-		}
+		flags := st.appendGetOCIChartFlags(releaese)
 
 		err := helm.ChartPull(qualifiedChartName, chartPath, flags...)
 		if err != nil {


### PR DESCRIPTION
accomplished by:

- Adding PlainHttp attribute to RepositorySpec., HelmDefault, ReleaseSpec
- Adding UnitTests for getOCIChart Flags.
- Adding funciton and unitTests for getChartDownload
- Changing and refactoring how Flags are added to getOCIChart.

Resolves #1224