### PR TITLE
feat: respect helmfile.lock with ad-hoc kustimzation

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1138,6 +1138,14 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 		selected = st.Releases
 	}
 
+	if !opts.SkipResolve {
+		updated, err := st.ResolveDeps()
+		if err != nil {
+			return nil, []error{err}
+		}
+		*st = *updated
+	}
+
 	releases := releasesNeedCharts(selected)
 
 	var prepareChartInfoMutex sync.Mutex
@@ -1148,14 +1156,6 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 
 	jobQueue := make(chan *ReleaseSpec, len(releases))
 	results := make(chan *chartPrepareResult, len(releases))
-
-	if !opts.SkipResolve {
-		updated, err := st.ResolveDeps()
-		if err != nil {
-			return nil, []error{err}
-		}
-		*st = *updated
-	}
 
 	var builds []*chartPrepareResult
 

--- a/test/e2e/template/helmfile/testdata/snapshot/issue_1229_template_strategic_merge_with_lockfile/config.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/issue_1229_template_strategic_merge_with_lockfile/config.yaml
@@ -1,0 +1,6 @@
+localChartRepoServer:
+  enabled: true
+  port: 18083
+chartifyTempDir: temp1
+helmfileArgs:
+- template

--- a/test/e2e/template/helmfile/testdata/snapshot/issue_1229_template_strategic_merge_with_lockfile/input.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/issue_1229_template_strategic_merge_with_lockfile/input.yaml
@@ -1,0 +1,28 @@
+repositories:
+- name: myrepo
+  url: http://localhost:18083/
+
+---
+lockFilePath: test-lock-file
+
+releases:
+- name: raw
+  chart: myrepo/raw
+  strategicMergePatches:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: foo
+    data:
+      foo: baz
+  values:
+  - templates:
+    - |
+      chartVersion: {{`{{ .Chart.Version }}`}}
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: foo
+      data:
+        foo: bar
+

--- a/test/e2e/template/helmfile/testdata/snapshot/issue_1229_template_strategic_merge_with_lockfile/output.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/issue_1229_template_strategic_merge_with_lockfile/output.yaml
@@ -1,0 +1,14 @@
+Adding repo myrepo http://localhost:18083/
+"myrepo" has been added to your repositories
+
+Templating release=raw, chart=$WD/temp1/raw/raw
+---
+# Source: raw/templates/patched_resources.yaml
+apiVersion: v1
+chartVersion: 0.0.1
+data:
+  foo: baz
+kind: ConfigMap
+metadata:
+  name: foo
+

--- a/test/e2e/template/helmfile/testdata/snapshot/issue_1229_template_strategic_merge_with_lockfile/test-lock-file
+++ b/test/e2e/template/helmfile/testdata/snapshot/issue_1229_template_strategic_merge_with_lockfile/test-lock-file
@@ -1,0 +1,7 @@
+version: 0.0.0-dev
+dependencies:
+  - name: raw
+    repository: http://localhost:18083/
+    version: 0.0.1
+digest: sha256:5401817b653c4eeb186cbfbb8d77dda6b72f84a548fc9cd128cbd478d5b2e705
+generated: "2022-10-12T20:17:15.98786845+03:00"


### PR DESCRIPTION
Change ensures that dependencies are resolved in state.go prior to creating releases.
That way releases has proper version when helmfile.lock is present.