### PR TITLE
feat: adding ability for for charts to be pulled without HTTPS

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -161,6 +161,10 @@ repositories:
 - name: skipTLS
   url: https://ss.my-insecure-domain.com
   skipTLSVerify: true
+# Advanced configuration: If you Repo only supports Plain HTTP
+- name: plainHTTP
+  url: http://just.http.domain.com
+  plainHttp: true
 
 # context: kube-context # this directive is deprecated, please consider using helmDefaults.kubeContext
 
@@ -221,6 +225,8 @@ helmDefaults:
   cascade: "background"
   # insecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
   insecureSkipTLSVerify: false
+  # plainHttp is true if fetching the remote shart should be done using HTTP
+  plainHttp: true
   # --wait flag for destroy/delete, if set to true, will wait until all resources are deleted before mark delete command as successful
   deleteWait: false
   # Timeout is the time in seconds to wait for helmfile destroy/delete (default 300)
@@ -334,6 +340,8 @@ releases:
     cascade: "background"
     # insecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
     insecureSkipTLSVerify: false
+    # plainHttp is true if fetching the remote shart should be done using HTTP
+    plainHttp: true
     # suppressDiff skip the helm diff output. Useful for charts which produces large not helpful diff, default: false
     suppressDiff: false
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -3598,7 +3598,7 @@ func (st *HelmState) getOCIChart(release *ReleaseSpec, tempDir string, helm helm
 		st.logger.Debugf("chart already exists at %s", chartPath)
 	} else {
 		flags := st.appendGetOCIChartFlags(release)
-		flags := st.appendChartDownloadPlainHttpFlags(flags, release)
+		flags = st.appendChartDownloadPlainHttpFlags(flags, release)
 
 		err := helm.ChartPull(qualifiedChartName, chartPath, flags...)
 		if err != nil {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -3598,6 +3598,7 @@ func (st *HelmState) getOCIChart(release *ReleaseSpec, tempDir string, helm helm
 		st.logger.Debugf("chart already exists at %s", chartPath)
 	} else {
 		flags := st.appendGetOCIChartFlags(release)
+		flags := st.appendChartDownloadPlainHttpFlags(flags, release)
 
 		err := helm.ChartPull(qualifiedChartName, chartPath, flags...)
 		if err != nil {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -193,7 +193,7 @@ type HelmSpec struct {
 	// InsecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
 	InsecureSkipTLSVerify bool `yaml:"insecureSkipTLSVerify,omitempty"`
 	// PlainHttp is true if the remote charte should be fetched using HTTP and not HTTPS
-	PlainHttp             bool `yaml:"plainHttp,omitempty"`
+	PlainHttp bool `yaml:"plainHttp,omitempty"`
 	// Wait, if set to true, will wait until all resources are deleted before mark delete command as successful
 	DeleteWait bool `yaml:"deleteWait"`
 	// Timeout is the time in seconds to wait for helmfile delete command (default 300)
@@ -324,7 +324,7 @@ type ReleaseSpec struct {
 	InsecureSkipTLSVerify bool `yaml:"insecureSkipTLSVerify,omitempty"`
 
 	// PlainHttp is true if the remote charte should be fetched using HTTP and not HTTPS
-	PlainHttp             bool `yaml:"plainHttp,omitempty"`
+	PlainHttp bool `yaml:"plainHttp,omitempty"`
 
 	// These values are used in templating
 	VerifyTemplate    *string `yaml:"verifyTemplate,omitempty"`
@@ -2159,7 +2159,7 @@ func (st *HelmState) TestReleases(helm helmexec.Interface, cleanup bool, timeout
 
 		flags = st.appendConnectionFlags(flags, &release)
 		flags = st.appendChartDownloadTLSFlags(flags, &release)
-		flags = st.appendChartDownloadPlainHttpFlags(flags, release)
+		flags = st.appendChartDownloadPlainHttpFlags(flags, &release)
 
 		return helm.TestRelease(st.createHelmContext(&release, workerIndex), release.Name, flags...)
 	})
@@ -3545,7 +3545,7 @@ func (st *HelmState) Reverse() {
 	}
 }
 
-func (st *HelmState) appendGetOCIChartFlags(release *ReleaseSpec) {
+func (st *HelmState) appendGetOCIChartFlags(release *ReleaseSpec) []string {
 	flags := []string{}
 	repo, _ := st.GetRepositoryAndNameFromChartName(release.Chart)
 	if repo != nil {
@@ -3597,7 +3597,7 @@ func (st *HelmState) getOCIChart(release *ReleaseSpec, tempDir string, helm helm
 	if st.fs.DirectoryExistsAt(chartPath) {
 		st.logger.Debugf("chart already exists at %s", chartPath)
 	} else {
-		flags := st.appendGetOCIChartFlags(releaese)
+		flags := st.appendGetOCIChartFlags(release)
 
 		err := helm.ChartPull(qualifiedChartName, chartPath, flags...)
 		if err != nil {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -3474,10 +3474,10 @@ func TestHelmState_appendGetOCIChartFlags(t *testing.T) {
 				},
 			},
 			release: &ReleaseSpec{
-				Chart: "oci://oci-repo/chart-path/chart-name",
+				Chart: "oci-repo/chart-path/chart-name",
 			},
 			expected: []string{
-				"--ca-file foo",
+				"--ca-file", "foo",
 			},
 		},
 		{
@@ -3493,9 +3493,7 @@ func TestHelmState_appendGetOCIChartFlags(t *testing.T) {
 			release: &ReleaseSpec{
 				Chart: "oci-repo/chart",
 			},
-			expected: []string{
-				"",
-			},
+			expected: []string{},
 		},
 		{
 			name: "CertFile disabled and KeyFile enabled",
@@ -3510,9 +3508,7 @@ func TestHelmState_appendGetOCIChartFlags(t *testing.T) {
 			release: &ReleaseSpec{
 				Chart: "oci-repo/chart",
 			},
-			expected: []string{
-				"",
-			},
+			expected: []string{},
 		},
 		{
 			name: "CertFile and KeyFile enabled",
@@ -3529,7 +3525,7 @@ func TestHelmState_appendGetOCIChartFlags(t *testing.T) {
 				Chart: "oci-repo/chart",
 			},
 			expected: []string{
-				"--cert-file foo --key-file bar",
+				"--cert-file", "foo", "--key-file", "bar",
 			},
 		},
 		{
@@ -3579,9 +3575,7 @@ func TestHelmState_appendGetOCIChartFlags(t *testing.T) {
 			release: &ReleaseSpec{
 				Chart: "oci-repo/chart",
 			},
-			expected: []string{
-				"",
-			},
+			expected: []string{},
 		},
 		{
 			name: "Keyring enabled",
@@ -3601,23 +3595,6 @@ func TestHelmState_appendGetOCIChartFlags(t *testing.T) {
 			},
 		},
 		{
-			name: "PlainHttp enabled",
-			repos: []RepositorySpec{
-				{
-					Name:      "oci-repo",
-					URL:       "registry/chart-path",
-					OCI:       true,
-					PlainHttp: true,
-				},
-			},
-			release: &ReleaseSpec{
-				Chart: "oci-repo/chart",
-			},
-			expected: []string{
-				"--plain-http",
-			},
-		},
-		{
 			name: "No Repo",
 			repos: []RepositorySpec{
 				{
@@ -3630,9 +3607,7 @@ func TestHelmState_appendGetOCIChartFlags(t *testing.T) {
 			release: &ReleaseSpec{
 				Chart: "chart",
 			},
-			expected: []string{
-				"",
-			},
+			expected: []string{},
 		},
 		{
 			name: "Repo there but doesn't match",
@@ -3647,9 +3622,7 @@ func TestHelmState_appendGetOCIChartFlags(t *testing.T) {
 			release: &ReleaseSpec{
 				Chart: "foo-repo/chart",
 			},
-			expected: []string{
-				"",
-			},
+			expected: []string{},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -3459,142 +3459,206 @@ func TestAppendChartDownloadTLSFlags(t *testing.T) {
 func TestHelmState_appendGetOCIChartFlags(t *testing.T) {
 	tests := []struct {
 		name     string
+		repos    []RepositorySpec
 		release  *ReleaseSpec
 		expected []string
 	}{
 		{
-			name:     "CaFile enabled",
-			release:  ReleaseSetSpec: ReleaseSetSpec{
-				Repositories: []RepositorySpec{
-					{
-						Name:   "oci-repo",
-						URL:    "registry/chart-path",
-						OCI:    true,
-						CaFile: "foo",
-					},
+			name: "CaFile enabled",
+			repos: []RepositorySpec{
+				{
+					Name:   "oci-repo",
+					URL:    "registry/chart-path",
+					OCI:    true,
+					CaFile: "foo",
 				},
-			},,
+			},
+			release: &ReleaseSpec{
+				Chart: "oci://oci-repo/chart-path/chart-name",
+			},
 			expected: []string{
 				"--ca-file foo",
 			},
 		},
 		{
-			name:     "CertFile endabled and KeyFile disabled",
-			release:  ReleaseSetSpec: ReleaseSetSpec{
-				Repositories: []RepositorySpec{
-					{
-						Name:   "oci-repo",
-						URL:    "registry/chart-path",
-						OCI:    true,
-						CertFile: "foo"
-					},
+			name: "CertFile endabled and KeyFile disabled",
+			repos: []RepositorySpec{
+				{
+					Name:     "oci-repo",
+					URL:      "registry/chart-path",
+					OCI:      true,
+					CertFile: "foo",
 				},
-			},,
+			},
+			release: &ReleaseSpec{
+				Chart: "oci-repo/chart",
+			},
 			expected: []string{
 				"",
 			},
 		},
 		{
-			name:     "CertFile disabled and KeyFile enabled",
-			release:  ReleaseSetSpec: ReleaseSetSpec{
-				Repositories: []RepositorySpec{
-					{
-						Name:   "oci-repo",
-						URL:    "registry/chart-path",
-						OCI:    true,
-						KeyFile: "bar",
-					},
+			name: "CertFile disabled and KeyFile enabled",
+			repos: []RepositorySpec{
+				{
+					Name:    "oci-repo",
+					URL:     "registry/chart-path",
+					OCI:     true,
+					KeyFile: "bar",
 				},
-			},,
+			},
+			release: &ReleaseSpec{
+				Chart: "oci-repo/chart",
+			},
 			expected: []string{
 				"",
 			},
 		},
 		{
-			name:     "CertFile and KeyFile enabled",
-			release:  ReleaseSetSpec: ReleaseSetSpec{
-				Repositories: []RepositorySpec{
-					{
-						Name:   "oci-repo",
-						URL:    "registry/chart-path",
-						OCI:    true,
-						CertFile: "foo"
-						KeyFile: "bar",
-					},
+			name: "CertFile and KeyFile enabled",
+			repos: []RepositorySpec{
+				{
+					Name:     "oci-repo",
+					URL:      "registry/chart-path",
+					OCI:      true,
+					CertFile: "foo",
+					KeyFile:  "bar",
 				},
-			},,
+			},
+			release: &ReleaseSpec{
+				Chart: "oci-repo/chart",
+			},
 			expected: []string{
 				"--cert-file foo --key-file bar",
 			},
 		},
 		{
-			name:     "SkipTLSVerify enabled",
-			release:  ReleaseSetSpec: ReleaseSetSpec{
-				Repositories: []RepositorySpec{
-					{
-						Name:          "oci-repo",
-						URL:           "registry/chart-path",
-						OCI:           true,
-						SkipTLSVerify: true,
-					},
+			name: "SkipTLSVerify enabled",
+			repos: []RepositorySpec{
+				{
+					Name:          "oci-repo",
+					URL:           "registry/chart-path",
+					OCI:           true,
+					SkipTLSVerify: true,
 				},
-			},,
+			},
+			release: &ReleaseSpec{
+				Chart: "oci-repo/chart",
+			},
 			expected: []string{
 				"--insecure-skip-tls-verify",
 			},
 		},
 		{
-			name:     "Verify enabled",
-			release:  ReleaseSetSpec: ReleaseSetSpec{
-				Repositories: []RepositorySpec{
-					{
-						Name:   "oci-repo",
-						URL:    "registry/chart-path",
-						OCI:    true,
-						Verify: true,
-					},
+			name: "Verify enabled",
+			repos: []RepositorySpec{
+				{
+					Name:   "oci-repo",
+					URL:    "registry/chart-path",
+					OCI:    true,
+					Verify: true,
 				},
-			},,
+			},
+			release: &ReleaseSpec{
+				Chart: "oci-repo/chart",
+			},
 			expected: []string{
 				"--verify",
 			},
 		},
 		{
-			name:     "Keyring enabled",
-			release:  ReleaseSetSpec: ReleaseSetSpec{
-				Repositories: []RepositorySpec{
-					{
-						Name:    "oci-repo",   
-						URL:     "registry/chart-path",
-						OCI:     true,
-						Keyring: true
-					},
+			name: "Keyring disabled",
+			repos: []RepositorySpec{
+				{
+					Name:    "oci-repo",
+					URL:     "registry/chart-path",
+					OCI:     true,
+					Keyring: "",
 				},
 			},
+			release: &ReleaseSpec{
+				Chart: "oci-repo/chart",
+			},
 			expected: []string{
-				"--keyring",
+				"",
 			},
 		},
 		{
-			name:     "PlainHttp enabled",
-			release:  ReleaseSetSpec: ReleaseSetSpec{
-				Repositories: []RepositorySpec{
-					{
-						Name:    "oci-repo",   
-						URL:     "registry/chart-path",
-						OCI:     true,
-						PlainHttp: true
-					},
+			name: "Keyring enabled",
+			repos: []RepositorySpec{
+				{
+					Name:    "oci-repo",
+					URL:     "registry/chart-path",
+					OCI:     true,
+					Keyring: "foo",
 				},
+			},
+			release: &ReleaseSpec{
+				Chart: "oci-repo/chart",
+			},
+			expected: []string{
+				"--keyring", "foo",
+			},
+		},
+		{
+			name: "PlainHttp enabled",
+			repos: []RepositorySpec{
+				{
+					Name:      "oci-repo",
+					URL:       "registry/chart-path",
+					OCI:       true,
+					PlainHttp: true,
+				},
+			},
+			release: &ReleaseSpec{
+				Chart: "oci-repo/chart",
 			},
 			expected: []string{
 				"--plain-http",
 			},
 		},
+		{
+			name: "No Repo",
+			repos: []RepositorySpec{
+				{
+					Name:    "oci-repo",
+					URL:     "registry/chart-path",
+					OCI:     true,
+					Keyring: "foo",
+				},
+			},
+			release: &ReleaseSpec{
+				Chart: "chart",
+			},
+			expected: []string{
+				"",
+			},
+		},
+		{
+			name: "Repo there but doesn't match",
+			repos: []RepositorySpec{
+				{
+					Name:    "oci-repo",
+					URL:     "registry/chart-path",
+					OCI:     true,
+					Keyring: "foo",
+				},
+			},
+			release: &ReleaseSpec{
+				Chart: "foo-repo/chart",
+			},
+			expected: []string{
+				"",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			st := &HelmState{}
+			st := &HelmState{
+				ReleaseSetSpec: ReleaseSetSpec{
+					Repositories: tt.repos,
+				},
+			}
 			flags := st.appendGetOCIChartFlags(tt.release)
 			require.Equal(t, tt.expected, flags)
 		})
@@ -3603,28 +3667,28 @@ func TestHelmState_appendGetOCIChartFlags(t *testing.T) {
 
 func TestAppendChartDownloadPlainHttpFlags(t *testing.T) {
 	tests := []struct {
-		name                         string
+		name             string
 		defaultPlainHttp bool
 		releasePlainHttp bool
-		expected                     []string
+		expected         []string
 	}{
 		{
-			name:                         "defaultPlainHttp true and releasePlainHttp is false",
+			name:             "defaultPlainHttp true and releasePlainHttp is false",
 			defaultPlainHttp: true,
 			releasePlainHttp: false,
-			expected:                     []string{"--plain-http"},
+			expected:         []string{"--plain-http"},
 		},
 		{
-			name:                         "defaultPlainHttp is false and releasePlainHttp is true",
+			name:             "defaultPlainHttp is false and releasePlainHttp is true",
 			defaultPlainHttp: false,
 			releasePlainHttp: true,
-			expected:                     []string{"--plain-http"},
+			expected:         []string{"--plain-http"},
 		},
 		{
-			name:                         "defaultPlainHttp is false and releasePlainHttp is false",
+			name:             "defaultPlainHttp is false and releasePlainHttp is false",
 			defaultPlainHttp: false,
 			releasePlainHttp: false,
-			expected:                     []string{},
+			expected:         []string{},
 		},
 	}
 

--- a/pkg/state/temp_test.go
+++ b/pkg/state/temp_test.go
@@ -38,39 +38,39 @@ func TestGenerateID(t *testing.T) {
 	run(testcase{
 		subject: "baseline",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
-		want:    "foo-values-b5df4fc58",
+		want:    "foo-values-f849bf554",
 	})
 
 	run(testcase{
 		subject: "different bytes content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    []byte(`{"k":"v"}`),
-		want:    "foo-values-5bd95d98d5",
+		want:    "foo-values-5bcdc6cbcc",
 	})
 
 	run(testcase{
 		subject: "different map content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    map[string]any{"k": "v"},
-		want:    "foo-values-5cb8d75d9f",
+		want:    "foo-values-74bf4d8cf",
 	})
 
 	run(testcase{
 		subject: "different chart",
 		release: ReleaseSpec{Name: "foo", Chart: "stable/envoy"},
-		want:    "foo-values-5f6b44cff5",
+		want:    "foo-values-5bf84b8bcf",
 	})
 
 	run(testcase{
 		subject: "different name",
 		release: ReleaseSpec{Name: "bar", Chart: "incubator/raw"},
-		want:    "bar-values-546889667f",
+		want:    "bar-values-7c86f8f47f",
 	})
 
 	run(testcase{
 		subject: "specific ns",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw", Namespace: "myns"},
-		want:    "myns-foo-values-78f4c8794f",
+		want:    "myns-foo-values-7bcff58789",
 	})
 
 	for id, n := range ids {


### PR DESCRIPTION
    accomplished by:

    - Adding PlainHttp attribute to RepositorySpec., HelmDefault, ReleaseSpec
    - Adding UnitTests for getOCIChart Flags.
    - Adding funciton and unitTests for getChartDownload
    - Changing and refactoring how Flags are added to getOCIChart.

    Resolves #1224