### PR TITLE
fix checker error message

### DIFF
--- a/pkg/policy/checker.go
+++ b/pkg/policy/checker.go
@@ -116,7 +116,7 @@ func TopConfigKeysVerifier(filePath string, helmfileContent []byte) (bool, error
 		preKey := orderKeys[i-1]
 		currentKey := orderKeys[i]
 		if topkeysPriority[preKey] > topkeysPriority[currentKey] {
-			return runtime.V1Mode, fmt.Errorf("top-level config key %s must be defined before %s in %s", preKey, currentKey, filePath)
+			return runtime.V1Mode, fmt.Errorf("top-level config key %s must be defined before %s in %s", currentKey, preKey, filePath)
 		}
 	}
 	return false, nil


### PR DESCRIPTION
At the moment the error message thrown when keys are in the wrong order provides the reverse error message to which it should be giving. This PR simply switches the format inputs of the provided error message (no unit tests affected). This gave me a few headaches until I worked through the logic of the code manually and noticed the bug in the error message 😄 

Simplified Helmfile example:
```yaml
releases: [...]
bases: [...]
```

Current error message provided when running a Helmfile command, e.g. `helmfile diff`:

```
in ./helmfile.yaml: top-level config key releases must be defined before bases in pre-install.yaml.gotmpl
```