### PR TITLE
Speed up isReleaseInstalled

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -702,10 +702,12 @@ func (st *HelmState) isReleaseInstalled(context helmexec.HelmContext, helm helme
 		flags = append(flags, "--namespace", release.Namespace)
 	}
 
-	_, err := helm.ReleaseStatus(context, release.Name, flags...)
+	err := helm.ReleaseStatus(context, release.Name, flags...)
+	if err != nil && strings.Contains(err.Error(), "Error: release: not found") {
+		return false, nil
+	}
 
-	// `helm status release-name` returns error when release is not known.
-	return err != nil, nil
+	return false, err
 }
 
 func (st *HelmState) DetectReleasesToBeDeletedForSync(helm helmexec.Interface, releases []ReleaseSpec) ([]ReleaseSpec, error) {


### PR DESCRIPTION
We are facing an issue where we have tens (up to 100) of releases, and around 20% of those are `installed: false`.

The `isReleaseInstalled` check makes applying chart upgrades extremely slow for us, because `helm list ...`  turns out to be the a really slow operation in Helm.

Given that `helm list ...` is invoked for each individual release, we can use a more performant endpoint like `helm status ...` here.