### PR TITLE
Make it clear that the plugin install prompt is a question

### DIFF
--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -171,7 +171,7 @@ func (h *HelmfileInit) CheckHelmPlugins() error {
 				return err
 			}
 
-			err = h.WhetherContinue(fmt.Sprintf("The helm plugin %s is not installed, do you need to install it", p.name))
+			err = h.WhetherContinue(fmt.Sprintf("The helm plugin %q is not installed, do you want to install it?", p.name))
 			if err != nil {
 				return err
 			}
@@ -184,7 +184,7 @@ func (h *HelmfileInit) CheckHelmPlugins() error {
 		}
 		requiredVersion, _ := semver.NewVersion(p.version)
 		if pluginVersion.LessThan(requiredVersion) {
-			err = h.WhetherContinue(fmt.Sprintf("The helm plugin %s version is too low, do you need to update it", p.name))
+			err = h.WhetherContinue(fmt.Sprintf("The helm plugin %q version is too low, do you want to update it?", p.name))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes: #1350 
 * #1350

Here's how it looks now:

* Install 
```sh
$ go run ./ init
The helm plugin "secrets" is not installed, do you want to install it? [y/n]: y
Install helm plugin secrets
Installed plugin: secrets

helmfile initialization completed!
```

* Upgrade
```sh
$ helm plugin  uninstall secrets
Uninstalled plugin: secrets

$ helm plugin install https://github.com/jkroepke/helm-secrets --version v4.0.0
Installed plugin: secrets
```

```
$ go run ./ init
The helm plugin "secrets" version is too low, do you want to update it? [y/n]: y
Update helm plugin secrets
Updated plugin: secrets

helmfile initialization completed!
```