### PR TITLE
Allow for conditions to have a deeper nested structure.

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2294,8 +2294,10 @@ func ConditionEnabled(r ReleaseSpec, values map[string]any) (bool, error) {
 		}
 	}
 
-	var ok bool
 	enabled, ok := iValues["enabled"]
+	if !ok {
+	    return false, nil
+	}
 	e, ok := enabled.(bool)
 
 	if !ok {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2294,12 +2294,12 @@ func ConditionEnabled(r ReleaseSpec, values map[string]any) (bool, error) {
 		}
 	}
 
-    enabled, ok := iValues["enabled"]
-    
-    if !ok {
-        return false, nil
-    }
-    
+	enabled, ok := iValues["enabled"]
+
+	if !ok {
+		return false, nil
+	}
+
 	e, ok := enabled.(bool)
 
 	if !ok {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2294,6 +2294,7 @@ func ConditionEnabled(r ReleaseSpec, values map[string]any) (bool, error) {
 		}
 	}
 
+	var ok bool
 	enabled, ok := iValues["enabled"]
 	e, ok := enabled.(bool)
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2294,12 +2294,14 @@ func ConditionEnabled(r ReleaseSpec, values map[string]any) (bool, error) {
 		}
 	}
 
-	enabled, ok := iValues["enabled"].(bool)
+	enabled, ok := iValues["enabled"]
+	e, ok := enabled.(bool)
+
 	if !ok {
 		return false, nil
 	}
 
-	return enabled, nil
+	return e, nil
 }
 
 func unmarkNeedsAndTransitives(filteredReleases []Release, allReleases []ReleaseSpec) {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2294,10 +2294,12 @@ func ConditionEnabled(r ReleaseSpec, values map[string]any) (bool, error) {
 		}
 	}
 
-	enabled, ok := iValues["enabled"]
-	if !ok {
-	    return false, nil
-	}
+    enabled, ok := iValues["enabled"]
+    
+    if !ok {
+        return false, nil
+    }
+    
 	e, ok := enabled.(bool)
 
 	if !ok {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -2500,10 +2500,50 @@ func TestConditionEnabled(t *testing.T) {
 			wantErr:   true,
 		},
 		{
-			name:      "too long condition",
+			name:      "nested values",
 			condition: "rnd42.really.enabled",
+			values: map[string]any{
+				"rnd42": map[string]any{
+					"really": map[string]any{
+						"enabled": true,
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:      "nested values enabled missing",
+			condition: "rnd42.really.ok",
 			want:      false,
 			wantErr:   true,
+		},
+		{
+			name:      "nested values unknown key",
+			condition: "rnd42.unknown.enabled",
+			values: map[string]any{
+				"rnd42": map[string]any{
+					"really": map[string]any{
+						"enabled": true,
+					},
+				},
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:      "nested values invalid type",
+			condition: "rnd42.invalid.enabled",
+			values: map[string]any{
+				"rnd42": map[string]any{
+					"invalid": "hello",
+					"really": map[string]any{
+						"enabled": true,
+					},
+				},
+			},
+			want:    false,
+			wantErr: true,
 		},
 		{
 			name:      "empty",


### PR DESCRIPTION
At the moment a condition is only allowed to be 2 deep eg: `foo.enabled`. This is a bit unfortunate because sometimes I work on projects where I have more deeply nested environment values to provide better structure. At the moment I kinda need maintain a separate configuration structure at the top to be able to have the condition work. For example

```yaml
# This doesn't work when enabled is passed to a condition.
apps:
  my_app:
    enabled: true

support:
  something:
    enabled: true

# Instead I currently have to lift all these to the top:
my_app:
  enabled: true
something:
  enabled: true
```

I traced the initial implementation back to this PR: https://github.com/roboll/helmfile/pull/1190. The limit of 2 deep is already set at this point, although no reason for it is mentioned. The current implementation can definitely be improved so feedback is welcome. But I was thinking to get the conversation started over a PR than an issue.