### PR TITLE
feat: add helm flag --plain-http as RepositorySpec.PlainHTTP

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1686,6 +1686,16 @@ export MY_OCI_REGISTRY_USERNAME=spongebob
 export MY_OCI_REGISTRY_PASSWORD=squarepants
 ```
 
+To use an OCI registry via HTTP, helm requires an extra flag: `--plain-http`.
+
+```yaml
+repositories:
+  - name: myOCIRegistry
+    url: myregistry.azurecr.io
+    oci: true
+    plainHTTP: true
+```
+
 ## Attribution
 
 We use:

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -216,6 +216,7 @@ type RepositorySpec struct {
 	Keyring         string `yaml:"keyring,omitempty"`
 	PassCredentials bool   `yaml:"passCredentials,omitempty"`
 	SkipTLSVerify   bool   `yaml:"skipTLSVerify,omitempty"`
+	PlainHTTP       bool   `yaml:"plainHTTP,omitempty"`
 }
 
 type Inherit struct {
@@ -3620,6 +3621,9 @@ func (st *HelmState) getOCIChart(release *ReleaseSpec, tempDir string, helm helm
 			}
 			if repo.Keyring != "" {
 				flags = append(flags, "--keyring", repo.Keyring)
+			}
+			if repo.PlainHTTP {
+				flags = append(flags, "--plain-http")
 			}
 		}
 


### PR DESCRIPTION
When using an OCI registry over HTTP, Helm requires an extra flag `$ helm <verb> --plain-http`, else we get the following error:

```
http: server gave HTTP response to HTTPS client
```