### PR TITLE
Add the SyncArgs option and --sync-args flag

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -42,6 +42,7 @@ func NewApplyCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 	f.BoolVar(&applyOptions.DetailedExitcode, "detailed-exitcode", false, "return a non-zero exit code 2 instead of 0 when there were changes detected AND the changes are synced successfully")
 	f.BoolVar(&applyOptions.StripTrailingCR, "strip-trailing-cr", false, "strip trailing carriage return on input")
 	f.StringVar(&applyOptions.DiffArgs, "diff-args", "", `pass args to helm helm-diff`)
+	f.StringVar(&applyOptions.SyncArgs, "sync-args", "", `pass args to helm upgrade`)
 	f.StringVar(&globalCfg.GlobalOptions.Args, "args", "", "pass args to helm exec")
 	if !runtime.V1Mode {
 		// TODO: Remove this function once Helmfile v0.x

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -32,6 +32,7 @@ func NewSyncCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 
 	f := cmd.Flags()
 	f.StringVar(&globalCfg.GlobalOptions.Args, "args", "", "pass args to helm sync")
+	f.StringVar(&syncOptions.SyncArgs, "sync-args", "", "pass args to helm upgrade")
 	f.StringArrayVar(&syncOptions.Set, "set", nil, "additional values to be merged into the helm command --set flag")
 	f.StringArrayVar(&syncOptions.Values, "values", nil, "additional value files to be merged into the helm command --values flag")
 	f.IntVar(&syncOptions.Concurrency, "concurrency", 0, "maximum number of concurrent helm processes to run, 0 is unlimited")

--- a/docs/index.md
+++ b/docs/index.md
@@ -184,6 +184,8 @@ helmDefaults:
     - "--set k=v"
   diffArgs:
     - "--suppress-secrets"
+  syncArgs:
+    - "--labels=app.kubernetes.io/managed-by=helmfile"
   # verify the chart before upgrading (only works with packaged charts not directories) (default false)
   verify: true
   keyring: path/to/keyring.gpg

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1476,6 +1476,7 @@ Do you really want to apply?
 					ResetValues:      c.ResetValues(),
 					PostRenderer:     c.PostRenderer(),
 					PostRendererArgs: c.PostRendererArgs(),
+					SyncArgs:         c.SyncArgs(),
 				}
 				return subst.SyncReleases(&affectedReleases, helm, c.Values(), c.Concurrency(), syncOpts)
 			}))
@@ -1869,6 +1870,7 @@ Do you really want to sync?
 					ResetValues:      c.ResetValues(),
 					PostRenderer:     c.PostRenderer(),
 					PostRendererArgs: c.PostRendererArgs(),
+					SyncArgs:         c.SyncArgs(),
 				}
 				return subst.SyncReleases(&affectedReleases, helm, c.Values(), c.Concurrency(), opts)
 			}))

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2220,6 +2220,7 @@ type applyConfig struct {
 	stripTrailingCR         bool
 	interactive             bool
 	skipDiffOnInstall       bool
+	syncArgs                string
 	diffArgs                string
 	logger                  *zap.SugaredLogger
 	wait                    bool
@@ -2354,6 +2355,10 @@ func (a applyConfig) RetainValuesFiles() bool {
 
 func (a applyConfig) SkipDiffOnInstall() bool {
 	return a.skipDiffOnInstall
+}
+
+func (a applyConfig) SyncArgs() string {
+	return a.syncArgs
 }
 
 func (a applyConfig) DiffArgs() string {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -83,6 +83,7 @@ type ApplyConfigProvider interface {
 	SkipDiffOnInstall() bool
 
 	DiffArgs() string
+	SyncArgs() string
 
 	DAGConfig
 
@@ -104,6 +105,7 @@ type SyncConfigProvider interface {
 	SkipDeps() bool
 	Wait() bool
 	WaitForJobs() bool
+	SyncArgs() string
 
 	Validate() bool
 

--- a/pkg/config/apply.go
+++ b/pkg/config/apply.go
@@ -64,6 +64,8 @@ type ApplyOptions struct {
 	Cascade string
 	// SuppressOutputLineRegex is a list of regexes to suppress output lines
 	SuppressOutputLineRegex []string
+	// SyncArgs is the list of arguments to pass to helm upgrade.
+	SyncArgs string
 }
 
 // NewApply creates a new Apply
@@ -239,4 +241,9 @@ func (a *ApplyImpl) Cascade() string {
 // SuppressOutputLineRegex returns the SuppressOutputLineRegex.
 func (a *ApplyImpl) SuppressOutputLineRegex() []string {
 	return a.ApplyOptions.SuppressOutputLineRegex
+}
+
+// SyncArgs returns the SyncArgs.
+func (a *ApplyImpl) SyncArgs() string {
+	return a.ApplyOptions.SyncArgs
 }

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -32,6 +32,8 @@ type SyncOptions struct {
 	PostRendererArgs []string
 	// Cascade '--cascade' to helmv3 delete, available values: background, foreground, or orphan, default: background
 	Cascade string
+	// SyncArgs is the list of arguments to pass to the helm upgrade command.
+	SyncArgs string
 }
 
 // NewSyncOptions creates a new Apply
@@ -131,4 +133,9 @@ func (t *SyncImpl) PostRendererArgs() []string {
 // Cascade returns cascade flag
 func (t *SyncImpl) Cascade() string {
 	return t.SyncOptions.Cascade
+}
+
+// SyncArgs returns the sync args
+func (t *SyncImpl) SyncArgs() string {
+	return t.SyncOptions.SyncArgs
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -740,6 +740,7 @@ type SyncOpts struct {
 	ResetValues      bool
 	PostRenderer     string
 	PostRendererArgs []string
+	SyncArgs         string
 }
 
 type SyncOpt interface{ Apply(*SyncOpts) }
@@ -2569,6 +2570,10 @@ func (st *HelmState) timeoutFlags(release *ReleaseSpec) []string {
 
 func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSpec, workerIndex int, opt *SyncOpts) ([]string, []string, error) {
 	flags := st.chartVersionFlags(release)
+
+	if opt != nil && opt.SyncArgs != "" {
+		flags = append(flags, argparser.CollectArgs(opt.SyncArgs)...)
+	}
 
 	if release.Verify != nil && *release.Verify || release.Verify == nil && st.HelmDefaults.Verify {
 		flags = append(flags, "--verify")

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -3477,3 +3477,99 @@ func TestHideChartURL(t *testing.T) {
 		}
 	}
 }
+
+func Test_appendExtraDiffFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputFlags    []string
+		inputOpts     *DiffOpts
+		inputDefaults []string
+
+		expected []string
+	}{
+		{
+			name:       "Skipping default flags, because diffOpts is provided",
+			inputFlags: []string{"aaaaa"},
+			inputOpts: &DiffOpts{
+				DiffArgs: "-bbbb --cccc",
+			},
+			inputDefaults: []string{"-dddd", "--eeee"},
+			expected:      []string{"aaaaa", "-bbbb", "--cccc"},
+		},
+		{
+			name:          "Use default flags, because diffOpts is not provided",
+			inputFlags:    []string{"aaaaa"},
+			inputDefaults: []string{"-dddd", "--eeee"},
+			expected:      []string{"aaaaa", "-dddd", "--eeee"},
+		},
+		{
+			name:          "Don't add non-flag arguments",
+			inputFlags:    []string{"aaaaa"},
+			inputDefaults: []string{"-d=ddd", "non-flag", "--eeee"},
+			expected:      []string{"aaaaa", "-d=ddd", "--eeee"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := (&HelmState{
+				ReleaseSetSpec: ReleaseSetSpec{
+					HelmDefaults: HelmSpec{
+						DiffArgs: test.inputDefaults,
+					},
+				},
+			}).appendExtraDiffFlags(test.inputFlags, test.inputOpts)
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("For input %v %v, expected %v, but got %v", test.inputFlags, test.inputOpts, test.expected, result)
+			}
+		})
+	}
+}
+
+func Test_appendExtraSyncFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputFlags    []string
+		inputOpts     *SyncOpts
+		inputDefaults []string
+
+		expected []string
+	}{
+		{
+			name:       "Skipping default flags, because diffOpts is provided",
+			inputFlags: []string{"aaaaa"},
+			inputOpts: &SyncOpts{
+				SyncArgs: "-bbbb --cccc",
+			},
+			inputDefaults: []string{"-dddd", "--eeee"},
+			expected:      []string{"aaaaa", "-bbbb", "--cccc"},
+		},
+		{
+			name:          "Use default flags, because diffOpts is not provided",
+			inputFlags:    []string{"aaaaa"},
+			inputDefaults: []string{"-dddd", "--eeee"},
+			expected:      []string{"aaaaa", "-dddd", "--eeee"},
+		},
+		{
+			name:          "Don't add non-flag arguments",
+			inputFlags:    []string{"aaaaa"},
+			inputDefaults: []string{"-d=ddd", "non-flag", "--eeee"},
+			expected:      []string{"aaaaa", "-d=ddd", "--eeee"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := (&HelmState{
+				ReleaseSetSpec: ReleaseSetSpec{
+					HelmDefaults: HelmSpec{
+						SyncArgs: test.inputDefaults,
+					},
+				},
+			}).appendExtraSyncFlags(test.inputFlags, test.inputOpts)
+			if !reflect.DeepEqual(result, test.expected) {
+				t.Errorf("For input %v %v, expected %v, but got %v", test.inputFlags, test.inputOpts, test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently there is no option to add arguments to the `helm upgrade` command without adding them to `helm diff` too.
This PR aims to solve this problem.

My usecase:
I would like to add the `--labels` flag to all `helm upgrade` invocations.
If I use `--args`, the diff fails because the `--labels` flag is unknown for the diff command.