### PR TITLE
Add `--kubeconfig` flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,6 +125,7 @@ func setGlobalOptionsForRootCmd(fs *pflag.FlagSet, globalOptions *config.GlobalO
 	fs.BoolVar(&globalOptions.StripArgsValuesOnExitError, "strip-args-values-on-exit-error", true, `Strip the potential secret values of the helm command args contained in a helmfile error message`)
 	fs.BoolVar(&globalOptions.DisableForceUpdate, "disable-force-update", false, `do not force helm repos to update when executing "helm repo add"`)
 	fs.BoolVarP(&globalOptions.Quiet, "quiet", "q", false, "Silence output. Equivalent to log-level warn")
+	fs.StringVar(&globalOptions.Kubeconfig, "kubeconfig", "", "Use a particular kubeconfig file")
 	fs.StringVar(&globalOptions.KubeContext, "kube-context", "", "Set kubectl context. Uses current context by default")
 	fs.BoolVar(&globalOptions.Debug, "debug", false, "Enable verbose output for Helm and set log-level to debug, this disables --quiet/-q effect")
 	fs.BoolVar(&globalOptions.Color, "color", false, "Output with color")

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -37,6 +37,7 @@ type App struct {
 	DisableForceUpdate         bool
 
 	Logger      *zap.SugaredLogger
+	Kubeconfig  string
 	Env         string
 	Namespace   string
 	Chart       string
@@ -81,6 +82,7 @@ func New(conf ConfigProvider) *App {
 		StripArgsValuesOnExitError: conf.StripArgsValuesOnExitError(),
 		DisableForceUpdate:         conf.DisableForceUpdate(),
 		Logger:                     conf.Logger(),
+		Kubeconfig:                 conf.Kubeconfig(),
 		Env:                        conf.Env(),
 		Namespace:                  conf.Namespace(),
 		Chart:                      conf.Chart(),
@@ -789,12 +791,13 @@ func (a *App) getHelm(st *state.HelmState) helmexec.Interface {
 	}
 
 	bin := st.DefaultHelmBinary
+	kubeconfig := a.Kubeconfig
 	kubectx := st.HelmDefaults.KubeContext
 
 	key := createHelmKey(bin, kubectx)
 
 	if _, ok := a.helms[key]; !ok {
-		a.helms[key] = helmexec.New(bin, helmexec.HelmExecOptions{EnableLiveOutput: a.EnableLiveOutput, DisableForceUpdate: a.DisableForceUpdate}, a.Logger, kubectx, &helmexec.ShellRunner{
+		a.helms[key] = helmexec.New(bin, helmexec.HelmExecOptions{EnableLiveOutput: a.EnableLiveOutput, DisableForceUpdate: a.DisableForceUpdate}, a.Logger, kubeconfig, kubectx, &helmexec.ShellRunner{
 			Logger:                     a.Logger,
 			Ctx:                        a.ctx,
 			StripArgsValuesOnExitError: a.StripArgsValuesOnExitError,

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2441,7 +2441,7 @@ func (mock *mockRunner) Execute(cmd string, args []string, env map[string]string
 }
 
 func MockExecer(logger *zap.SugaredLogger, kubeContext string) helmexec.Interface {
-	execer := helmexec.New("helm", helmexec.HelmExecOptions{}, logger, kubeContext, &mockRunner{})
+	execer := helmexec.New("helm", helmexec.HelmExecOptions{}, logger, "", kubeContext, &mockRunner{})
 	return execer
 }
 

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -18,6 +18,7 @@ type ConfigProvider interface {
 	Selectors() []string
 	StateValuesSet() map[string]any
 	StateValuesFiles() []string
+	Kubeconfig() string
 	Env() string
 
 	loggingConfig

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -163,7 +163,7 @@ func (h *HelmfileInit) WhetherContinue(ask string) error {
 
 func (h *HelmfileInit) CheckHelmPlugins() error {
 	settings := cli.New()
-	helm := helmexec.New(h.helmBinary, helmexec.HelmExecOptions{}, h.logger, "", h.runner)
+	helm := helmexec.New(h.helmBinary, helmexec.HelmExecOptions{}, h.logger, "", "", h.runner)
 	for _, p := range helmPlugins {
 		pluginVersion, err := helmexec.GetPluginVersion(p.name, settings.PluginsDirectory)
 		if err != nil {

--- a/pkg/config/global.go
+++ b/pkg/config/global.go
@@ -37,6 +37,8 @@ type GlobalOptions struct {
 	DisableForceUpdate bool
 	// Quiet is true if the output should be quiet.
 	Quiet bool
+	// Kubeconfig is the path to the kubeconfig file to use.
+	Kubeconfig string
 	// KubeContext is the name of the kubectl context to use.
 	KubeContext string
 	// Debug is true if the output should be verbose.
@@ -102,6 +104,11 @@ func (g *GlobalImpl) HelmBinary() string {
 // KustomizeBinary returns the path to the Kustomize binary.
 func (g *GlobalImpl) KustomizeBinary() string {
 	return g.GlobalOptions.KustomizeBinary
+}
+
+// Kubeconfig returns the path to the kubeconfig file to use.
+func (g *GlobalImpl) Kubeconfig() string {
+	return g.GlobalOptions.Kubeconfig
 }
 
 // KubeContext returns the name of the kubectl context to use.


### PR DESCRIPTION
Similar to Helm and kubectl, I propose we add a kubeconfig flag.
This makes it also easier to run multiple Helmfile instances (eg. as a go library) without messing with the environment variables.