### PR TITLE
Still attempt upgrades on non-deployed releases

### DIFF
--- a/pkg/app/app_apply_hooks_test.go
+++ b/pkg/app/app_apply_hooks_test.go
@@ -28,7 +28,7 @@ func TestApply_hooks(t *testing.T) {
 		error             string
 		files             map[string]string
 		selectors         []string
-		lists             map[exectest.ListKey]string
+		lists             map[exectest.ListKey]helmexec.HelmReleaseOutput
 		diffs             map[exectest.DiffKey]error
 		upgraded          []exectest.Release
 		deleted           []exectest.Release
@@ -384,13 +384,9 @@ releases:
 `,
 			},
 			selectors: []string{"app=test"},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("default", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: listFlags("default", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{
 				{Name: "foo"},
@@ -434,11 +430,9 @@ releases:
 `,
 			},
 			selectors: []string{"app=test"},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: listFlags("default", "default")}: ``,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("default", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: listFlags("default", "default")}: {},
 			},
 			upgraded: []exectest.Release{
 				{Name: "foo"},

--- a/pkg/app/app_apply_nokubectx_test.go
+++ b/pkg/app/app_apply_nokubectx_test.go
@@ -29,7 +29,7 @@ func TestApply_3(t *testing.T) {
 		error             string
 		files             map[string]string
 		selectors         []string
-		lists             map[exectest.ListKey]string
+		lists             map[exectest.ListKey]helmexec.HelmReleaseOutput
 		diffs             map[exectest.DiffKey]error
 		upgraded          []exectest.Release
 		deleted           []exectest.Release
@@ -180,13 +180,9 @@ releases:
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--namespace default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "my-release", Chart: "incubator/raw", Flags: "--namespace default --detailed-exitcode --reset-values"}:       helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^external-secrets$", Flags: listFlags("default", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^my-release$", Flags: listFlags("default", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^external-secrets$", Flags: listFlags("default", "")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "")}:       {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -228,10 +224,9 @@ releases:
 			upgraded: []exectest.Release{
 				{Name: "external-secrets", Flags: []string{"--namespace", "default"}},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^external-secrets$", Flags: listFlags("default", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-^external-secrets$ 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^external-secrets$", Flags: listFlags("default", "")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "")}:       {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			diffs: map[exectest.DiffKey]error{
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--namespace default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
@@ -282,16 +277,10 @@ releases:
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--namespace default --detailed-exitcode --reset-values"}:                helmexec.ExitError{Code: 2},
 				{Name: "my-release", Chart: "incubator/raw", Flags: "--namespace default --detailed-exitcode --reset-values"}:                      helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-kubernetes-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^external-secrets$", Flags: listFlags("default", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^my-release$", Flags: listFlags("default", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^external-secrets$", Flags: listFlags("default", "")}:                {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "")}:                      {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -338,13 +327,10 @@ releases:
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--namespace default --detailed-exitcode --reset-values"}:                helmexec.ExitError{Code: 2},
 				{Name: "my-release", Chart: "incubator/raw", Flags: "--namespace default --detailed-exitcode --reset-values"}:                      helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^external-secrets$", Flags: listFlags("default", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^my-release$", Flags: listFlags("default", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^external-secrets$", Flags: listFlags("default", "")}:                {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "")}:                      {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -387,16 +373,10 @@ releases:
 			},
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-				kubernetes-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^external-secrets$", Flags: listFlags("default", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^my-release$", Flags: listFlags("default", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^external-secrets$", Flags: listFlags("default", "")}:                {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "")}:                      {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			diffs: map[exectest.DiffKey]error{
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--namespace default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
@@ -443,14 +423,10 @@ releases:
 			},
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "")}: ``,
-				{Filter: "^external-secrets$", Flags: listFlags("default", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^my-release$", Flags: listFlags("default", "")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "")}: {},
+				{Filter: "^external-secrets$", Flags: listFlags("default", "")}:                {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "")}:                      {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			diffs: map[exectest.DiffKey]error{
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--namespace default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},

--- a/pkg/app/app_apply_test.go
+++ b/pkg/app/app_apply_test.go
@@ -29,7 +29,7 @@ func TestApply_2(t *testing.T) {
 		error             string
 		files             map[string]string
 		selectors         []string
-		lists             map[exectest.ListKey]string
+		lists             map[exectest.ListKey]helmexec.HelmReleaseOutput
 		diffs             map[exectest.DiffKey]error
 		upgraded          []exectest.Release
 		deleted           []exectest.Release
@@ -180,13 +180,9 @@ releases:
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-context default --namespace default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "my-release", Chart: "incubator/raw", Flags: "--kube-context default --namespace default --detailed-exitcode --reset-values"}:       helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^my-release$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "default")}:       {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -228,10 +224,10 @@ releases:
 			upgraded: []exectest.Release{
 				{Name: "external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-^external-secrets$ 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}:                {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "default")}:                      {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			diffs: map[exectest.DiffKey]error{
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-context default --namespace default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
@@ -282,16 +278,10 @@ releases:
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-context default --namespace default --detailed-exitcode --reset-values"}:                helmexec.ExitError{Code: 2},
 				{Name: "my-release", Chart: "incubator/raw", Flags: "--kube-context default --namespace default --detailed-exitcode --reset-values"}:                      helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-kubernetes-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^my-release$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}:                {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "default")}:                      {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -338,13 +328,10 @@ releases:
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-context default --namespace default --detailed-exitcode --reset-values"}:                helmexec.ExitError{Code: 2},
 				{Name: "my-release", Chart: "incubator/raw", Flags: "--kube-context default --namespace default --detailed-exitcode --reset-values"}:                      helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^my-release$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}:                {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "default")}:                      {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -387,16 +374,10 @@ releases:
 			},
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-kubernetes-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
-				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^my-release$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}:                {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "default")}:                      {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			diffs: map[exectest.DiffKey]error{
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-context default --namespace default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
@@ -443,14 +424,10 @@ releases:
 			},
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: ``,
-				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^my-release$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: {},
+				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}:                {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "default")}:                      {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			diffs: map[exectest.DiffKey]error{
 				{Name: "external-secrets", Chart: "incubator/raw", Flags: "--kube-context default --namespace default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
@@ -498,16 +475,10 @@ releases:
 				{Name: "serviceB", Chart: "my/chart", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "serviceC", Chart: "my/chart", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^serviceA$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-serviceA 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	chart-3.1.0	3.1.0      	default
-`,
-				{Filter: "^serviceB$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-serviceB 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	chart-3.1.0	3.1.0      	default
-`,
-				{Filter: "^serviceC$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-serviceC 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	chart-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^serviceA$", Flags: listFlags("", "default")}: {Chart: "chart-3.1.0", Status: "deployed"},
+				{Filter: "^serviceB$", Flags: listFlags("", "default")}: {Chart: "chart-3.1.0", Status: "deployed"},
+				{Filter: "^serviceC$", Flags: listFlags("", "default")}: {Chart: "chart-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -643,10 +614,8 @@ releases:
 			diffs: map[exectest.DiffKey]error{
 				{Name: "foo", Chart: "incubator/raw", Flags: "--kube-context default --namespace default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("default", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			error: "",
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
@@ -709,10 +678,8 @@ releases:
 			diffs: map[exectest.DiffKey]error{
 				{Name: "foo", Chart: "incubator/raw", Flags: "--kube-context default --namespace default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("default", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			error: "",
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result

--- a/pkg/app/app_diff_test.go
+++ b/pkg/app/app_diff_test.go
@@ -301,7 +301,7 @@ func TestDiffWithInstalled(t *testing.T) {
 		ns        string
 		error     string
 		selectors []string
-		lists     map[exectest.ListKey]string
+		lists     map[exectest.ListKey]helmexec.HelmReleaseOutput
 		diffed    []exectest.Release
 	}
 
@@ -386,10 +386,8 @@ releases:
   namespace: default
 `,
 			selectors: []string{"name=a"},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^a$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^a$", Flags: listFlags("default", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			diffed: []exectest.Release{
 				{Name: "a", Flags: []string{"--kube-context", "default", "--namespace", "default", "--reset-values"}},
@@ -410,8 +408,8 @@ releases:
   namespace: default
 `,
 			selectors: []string{"name=a"},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^a$", Flags: listFlags("default", "default")}: ``,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^a$", Flags: listFlags("default", "default")}: {},
 			},
 		})
 	})

--- a/pkg/app/app_sync_test.go
+++ b/pkg/app/app_sync_test.go
@@ -29,7 +29,7 @@ func TestSync(t *testing.T) {
 		error             string
 		files             map[string]string
 		selectors         []string
-		lists             map[exectest.ListKey]string
+		lists             map[exectest.ListKey]helmexec.HelmReleaseOutput
 		upgraded          []exectest.Release
 		deleted           []exectest.Release
 		log               string
@@ -172,13 +172,9 @@ releases:
 				{Name: "external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 				{Name: "my-release", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
-				{Filter: "^my-release$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "default")}:       {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -303,7 +299,7 @@ releases:
         - postsync
       showlogs: true
       command: sleep
-      args: [5s]
+      args: [5]
 `,
 			},
 			selectors: []string{"app=test"},
@@ -311,13 +307,9 @@ releases:
 				{Name: "external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 				{Name: "my-release", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
-				{Filter: "^my-release$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "default")}:       {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -355,7 +347,7 @@ first-pass rendering output of "helmfile.yaml.part.0":
 26:         - postsync
 27:       showlogs: true
 28:       command: sleep
-29:       args: [5s]
+29:       args: [5]
 30: 
 
 first-pass produced: &{default  map[] map[]}
@@ -393,7 +385,7 @@ second-pass rendering result of "helmfile.yaml.part.0":
 26:         - postsync
 27:       showlogs: true
 28:       command: sleep
-29:       args: [5s]
+29:       args: [5]
 30: 
 
 merged environment: &{default  map[] map[]}
@@ -464,16 +456,10 @@ releases:
 			},
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-kubernetes-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
-				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
-				{Filter: "^my-release$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}:                {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "default")}:                      {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -598,16 +584,10 @@ releases:
 			},
 			selectors: []string{"name=serviceA"},
 			upgraded:  []exectest.Release{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^serviceC$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-serviceC 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	chart-3.1.0	3.1.0      	default
-				`,
-				{Filter: "^serviceB$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-serviceB 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	chart-3.1.0	3.1.0      	default
-				`,
-				{Filter: "^serviceA$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-serviceA 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	chart-3.1.0	3.1.0      	default
-				`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^serviceC$", Flags: listFlags("", "default")}: {Chart: "chart-3.1.0", Status: "deployed"},
+				{Filter: "^serviceB$", Flags: listFlags("", "default")}: {Chart: "chart-3.1.0", Status: "deployed"},
+				{Filter: "^serviceA$", Flags: listFlags("", "default")}: {Chart: "chart-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -730,16 +710,10 @@ releases:
 			},
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-kubernetes-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
-				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
-				{Filter: "^my-release$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}:                {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "default")}:                      {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -881,15 +855,11 @@ releases:
 			},
 			selectors: []string{"app=test"},
 			upgraded:  []exectest.Release{},
-			lists: map[exectest.ListKey]string{
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
 				// delete frontend-v1 and backend-v1
-				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: ``,
-				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
-				{Filter: "^my-release$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-				`,
+				{Filter: "^kubernetes-external-secrets$", Flags: listFlags("kube-system", "default")}: {},
+				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}:                {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "default")}:                      {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2517,8 +2517,8 @@ func (helm *mockHelmExec) DeleteRelease(context helmexec.HelmContext, name strin
 	return nil
 }
 
-func (helm *mockHelmExec) List(context helmexec.HelmContext, filter string, flags ...string) (string, error) {
-	return "", nil
+func (helm *mockHelmExec) List(context helmexec.HelmContext, filter string, flags ...string) (helmexec.HelmReleaseOutput, error) {
+	return helmexec.HelmReleaseOutput{}, nil
 }
 
 func (helm *mockHelmExec) DecryptSecret(context helmexec.HelmContext, name string, flags ...string) (string, error) {
@@ -2716,7 +2716,7 @@ func TestApply(t *testing.T) {
 		error             string
 		files             map[string]string
 		selectors         []string
-		lists             map[exectest.ListKey]string
+		lists             map[exectest.ListKey]helmexec.HelmReleaseOutput
 		diffs             map[exectest.DiffKey]error
 		upgraded          []exectest.Release
 		deleted           []exectest.Release
@@ -2798,35 +2798,18 @@ releases:
 				{Name: "backend-v2", Chart: "charts/backend", Flags: "--kube-context default --detailed-exitcode --reset-values"}:            helmexec.ExitError{Code: 2},
 				{Name: "anotherbackend", Chart: "charts/anotherbackend", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
 				// delete frontend-v1 and backend-v1
-				{Filter: "^logging$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-logging 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	fluent-bit-3.1.0	3.1.0      	default
-`,
-				{Filter: "^front-proxy$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-front-proxy 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	envoy-3.1.0	3.1.0      	default
-`,
-				{Filter: "^database$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-database 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mysql-3.1.0	3.1.0      	default
-`,
-				{Filter: "^servicemesh$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-servicemesh 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	istio-3.1.0	3.1.0      	default
-`,
-				{Filter: "^anotherbackend$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-anotherbackend 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	anotherbackend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^frontend-v1$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-frontend-v1 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	frontend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^frontend-v3$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-frontend-v3 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	frontend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^backend-v1$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-backend-v1 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^backend-v2$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-backend-v2 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
-`,
+				{Filter: "^logging$", Flags: listFlags("", "default")}:        {Chart: "fluent-bit-3.1.0", Status: "deployed"},
+				{Filter: "^front-proxy$", Flags: listFlags("", "default")}:    {Chart: "envoy-3.1.0", Status: "deployed"},
+				{Filter: "^database$", Flags: listFlags("", "default")}:       {Chart: "mysql-3.1.0", Status: "deployed"},
+				{Filter: "^servicemesh$", Flags: listFlags("", "default")}:    {Chart: "istio-3.1.0", Status: "deployed"},
+				{Filter: "^anotherbackend$", Flags: listFlags("", "default")}: {Chart: "anotherbackend-3.1.0", Status: "deployed"},
+				{Filter: "^frontend-v1$", Flags: listFlags("", "default")}:    {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^frontend-v2$", Flags: listFlags("", "default")}:    {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^frontend-v3$", Flags: listFlags("", "default")}:    {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^backend-v1$", Flags: listFlags("", "default")}:     {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^backend-v2$", Flags: listFlags("", "default")}:     {Chart: "backend-3.1.0", Status: "deployed"},
 			},
 			// Disable concurrency to avoid in-deterministic result
 			concurrency: 1,
@@ -2864,11 +2847,9 @@ releases:
 			diffs: map[exectest.DiffKey]error{
 				{Name: "bar", Chart: "stable/mychart2", Flags: "--kube-context default --detailed-exitcode --reset-values"}: nil,
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("", "default")}: ``,
-				{Filter: "^bar$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("", "default")}: {},
+				{Filter: "^bar$", Flags: listFlags("", "default")}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{},
 			deleted:  []exectest.Release{},
@@ -2897,7 +2878,7 @@ releases:
 				{Name: "bar", Chart: "stable/mychart2", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "baz", Chart: "stable/mychart3", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{},
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{},
 			upgraded: []exectest.Release{
 				{Name: "baz", Flags: []string{}},
 				{Name: "bar", Flags: []string{}},
@@ -2933,14 +2914,10 @@ releases:
 				{Name: "foo", Chart: "stable/mychart1", Flags: "--disable-validation --kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "bar", Chart: "stable/mychart2", Flags: "--disable-validation --kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("", "default")}: ``,
-				{Filter: "^bar$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
-				{Filter: "^baz$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-baz 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart3-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("", "default")}: {},
+				{Filter: "^bar$", Flags: listFlags("", "default")}: {Chart: "mychart2-3.1.0", Status: "deployed"},
+				{Filter: "^baz$", Flags: listFlags("", "default")}: {Chart: "mychart3-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{
 				{Name: "baz", Flags: []string{"--kube-context", "default"}},
@@ -2977,14 +2954,10 @@ releases:
 				{Name: "baz", Chart: "stable/mychart3", Flags: "--kube-context default --detailed-exitcode --reset-values"}:                      helmexec.ExitError{Code: 2},
 				{Name: "bar", Chart: "stable/mychart2", Flags: "--disable-validation --kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("", "default")}: ``,
-				{Filter: "^bar$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
-				{Filter: "^baz$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-baz 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart3-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("", "default")}: {},
+				{Filter: "^bar$", Flags: listFlags("", "default")}: {Chart: "mychart2-3.1.0", Status: "deployed"},
+				{Filter: "^baz$", Flags: listFlags("", "default")}: {Chart: "mychart3-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{
 				{Name: "baz", Flags: []string{"--kube-context", "default"}},
@@ -3164,13 +3137,9 @@ releases:
 				{Name: "bar", Chart: "stable/mychart2", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "stable/mychart1", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("", "default")}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: listFlags("", "default")}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			deleted: []exectest.Release{
 				{Name: "foo", Flags: []string{}},
@@ -3197,13 +3166,9 @@ releases:
 				{Name: "bar", Chart: "stable/mychart2", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "stable/mychart1", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("", "default")}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: listFlags("", "default")}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			deleted: []exectest.Release{
 				{Name: "bar", Flags: []string{}},
@@ -3232,13 +3197,9 @@ releases:
 				{Name: "bar", Chart: "stable/mychart2", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "stable/mychart1", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("", "default")}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: listFlags("", "default")}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{
 				{Name: "bar", Flags: []string{}},
@@ -3266,13 +3227,9 @@ releases:
 				{Name: "bar", Chart: "stable/mychart2", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "stable/mychart1", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("", "default")}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: listFlags("", "default")}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{
 				{Name: "foo", Flags: []string{}},
@@ -3300,13 +3257,9 @@ releases:
 				{Name: "bar", Chart: "stable/mychart2", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "stable/mychart1", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("", "default")}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: listFlags("", "default")}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{
 				{Name: "bar", Flags: []string{}},
@@ -3334,13 +3287,9 @@ releases:
 				{Name: "bar", Chart: "stable/mychart2", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "stable/mychart1", Flags: "--kube-context default --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: listFlags("", "default")}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: listFlags("", "default")}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{
 				{Name: "foo", Flags: []string{}},
@@ -3394,13 +3343,9 @@ releases:
 				{Name: "external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 				{Name: "my-release", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-external-secrets 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
-				{Filter: "^my-release$", Flags: listFlags("default", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-my-release 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	raw-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^external-secrets$", Flags: listFlags("default", "default")}: {Chart: "raw-3.1.0", Status: "deployed"},
+				{Filter: "^my-release$", Flags: listFlags("default", "default")}:       {Chart: "raw-3.1.0", Status: "deployed"},
 			},
 			// as we check for log output, set concurrency to 1 to avoid non-deterministic test result
 			concurrency: 1,
@@ -3642,7 +3587,7 @@ releases:
 				{Name: "baz", Chart: "mychart3", Flags: "--kube-context default --namespace ns1 --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--kube-context default --detailed-exitcode --reset-values"}:                 helmexec.ExitError{Code: 2},
 			},
-			lists:       map[exectest.ListKey]string{},
+			lists:       map[exectest.ListKey]helmexec.HelmReleaseOutput{},
 			upgraded:    []exectest.Release{},
 			deleted:     []exectest.Release{},
 			concurrency: 1,
@@ -3706,7 +3651,7 @@ releases:
 				{Name: "bar", Chart: "mychart3", Flags: "--kube-context default --namespace ns1 --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--kube-context default --detailed-exitcode --reset-values"}:                 helmexec.ExitError{Code: 2},
 			},
-			lists:       map[exectest.ListKey]string{},
+			lists:       map[exectest.ListKey]helmexec.HelmReleaseOutput{},
 			upgraded:    []exectest.Release{},
 			deleted:     []exectest.Release{},
 			concurrency: 1,
@@ -3775,7 +3720,7 @@ releases:
 				{Name: "bar", Chart: "mychart3", Flags: "--kube-context default --namespace ns1 --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--kube-context default --detailed-exitcode --reset-values"}:                 helmexec.ExitError{Code: 2},
 			},
-			lists:       map[exectest.ListKey]string{},
+			lists:       map[exectest.ListKey]helmexec.HelmReleaseOutput{},
 			upgraded:    []exectest.Release{},
 			deleted:     []exectest.Release{},
 			concurrency: 1,

--- a/pkg/app/destroy_nokubectx_test.go
+++ b/pkg/app/destroy_nokubectx_test.go
@@ -20,7 +20,7 @@ func TestDestroy_2(t *testing.T) {
 		error         string
 		files         map[string]string
 		selectors     []string
-		lists         map[exectest.ListKey]string
+		lists         map[exectest.ListKey]helmexec.HelmReleaseOutput
 		diffs         map[exectest.DiffKey]error
 		upgraded      []exectest.Release
 		deleted       []exectest.Release
@@ -208,35 +208,17 @@ releases:
 		check(t, testcase{
 			files: files,
 			diffs: map[exectest.DiffKey]error{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^frontend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
-				{Filter: "^frontend-v2$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-frontend-v2 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	frontend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^frontend-v3$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-frontend-v3 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	frontend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^backend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
-				{Filter: "^backend-v2$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-backend-v2 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^logging$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-logging	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	fluent-bit-3.1.0	3.1.0      	default
-`,
-				{Filter: "^front-proxy$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-front-proxy 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	envoy-3.1.0	3.1.0      	default
-`,
-				{Filter: "^servicemesh$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-servicemesh 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	istio-3.1.0	3.1.0      	default
-`,
-				{Filter: "^database$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-database 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mysql-3.1.0	3.1.0      	default
-`,
-				{Filter: "^anotherbackend$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-anotherbackend 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	anotherbackend-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^frontend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}:    {},
+				{Filter: "^frontend-v2$", Flags: helmV3ListFlagsWithoutKubeContext}:    {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^frontend-v3$", Flags: helmV3ListFlagsWithoutKubeContext}:    {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^backend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}:     {},
+				{Filter: "^backend-v2$", Flags: helmV3ListFlagsWithoutKubeContext}:     {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^logging$", Flags: helmV3ListFlagsWithoutKubeContext}:        {Chart: "fluent-bit-3.1.0", Status: "deployed"},
+				{Filter: "^front-proxy$", Flags: helmV3ListFlagsWithoutKubeContext}:    {Chart: "envoy-3.1.0", Status: "deployed"},
+				{Filter: "^servicemesh$", Flags: helmV3ListFlagsWithoutKubeContext}:    {Chart: "istio-3.1.0", Status: "deployed"},
+				{Filter: "^database$", Flags: helmV3ListFlagsWithoutKubeContext}:       {Chart: "mysql-3.1.0", Status: "deployed"},
+				{Filter: "^anotherbackend$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "anotherbackend-3.1.0", Status: "deployed"},
 			},
 			// Disable concurrency to avoid in-deterministic result
 			concurrency: 1,
@@ -244,9 +226,7 @@ anotherbackend 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	anotherbackend-3.1.0	
 			deleted: []exectest.Release{
 				{Name: "frontend-v3", Flags: []string{}},
 				{Name: "frontend-v2", Flags: []string{}},
-				{Name: "frontend-v1", Flags: []string{}},
 				{Name: "backend-v2", Flags: []string{}},
-				{Name: "backend-v1", Flags: []string{}},
 				{Name: "anotherbackend", Flags: []string{}},
 				{Name: "servicemesh", Flags: []string{}},
 				{Name: "database", Flags: []string{}},
@@ -382,20 +362,17 @@ WARNING: release frontend-v1 needs backend-v1, but backend-v1 is not installed d
 
 processing 5 groups of releases in this order:
 GROUP RELEASES
-1     frontend-v3, frontend-v2, frontend-v1
-2     backend-v2, backend-v1
+1     frontend-v3, frontend-v2
+2     backend-v2
 3     anotherbackend
 4     servicemesh, database
 5     front-proxy, logging
 
-processing releases in group 1/5: frontend-v3, frontend-v2, frontend-v1
+processing releases in group 1/5: frontend-v3, frontend-v2
 release "frontend-v3" processed
 release "frontend-v2" processed
-WARNING: release frontend-v1 needs backend-v1, but backend-v1 is not installed due to installed: false. Either mark backend-v1 as installed or remove backend-v1 from frontend-v1's needs
-release "frontend-v1" processed
-processing releases in group 2/5: backend-v2, backend-v1
+processing releases in group 2/5: backend-v2
 release "backend-v2" processed
-release "backend-v1" processed
 processing releases in group 3/5: anotherbackend
 release "anotherbackend" processed
 processing releases in group 4/5: servicemesh, database
@@ -409,9 +386,7 @@ DELETED RELEASES:
 NAME             DURATION
 frontend-v3            0s
 frontend-v2            0s
-frontend-v1            0s
 backend-v2             0s
-backend-v1             0s
 anotherbackend         0s
 servicemesh            0s
 database               0s
@@ -428,35 +403,17 @@ changing working directory back to "/path/to"
 			files:     files,
 			selectors: []string{"name=logging"},
 			diffs:     map[exectest.DiffKey]error{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^frontend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
-				{Filter: "^frontend-v2$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-frontend-v2 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	frontend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^frontend-v3$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-frontend-v3 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	frontend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^backend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
-				{Filter: "^backend-v2$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-backend-v2 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^logging$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-logging	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	fluent-bit-3.1.0	3.1.0      	default
-`,
-				{Filter: "^front-proxy$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-front-proxy 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	envoy-3.1.0	3.1.0      	default
-`,
-				{Filter: "^servicemesh$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-servicemesh 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	istio-3.1.0	3.1.0      	default
-`,
-				{Filter: "^database$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-database 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mysql-3.1.0	3.1.0      	default
-`,
-				{Filter: "^anotherbackend$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-anotherbackend 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	anotherbackend-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^frontend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}:    {},
+				{Filter: "^frontend-v2$", Flags: helmV3ListFlagsWithoutKubeContext}:    {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^frontend-v3$", Flags: helmV3ListFlagsWithoutKubeContext}:    {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^backend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}:     {},
+				{Filter: "^backend-v2$", Flags: helmV3ListFlagsWithoutKubeContext}:     {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^logging$", Flags: helmV3ListFlagsWithoutKubeContext}:        {Chart: "fluent-bit-3.1.0", Status: "deployed"},
+				{Filter: "^front-proxy$", Flags: helmV3ListFlagsWithoutKubeContext}:    {Chart: "envoy-3.1.0", Status: "deployed"},
+				{Filter: "^servicemesh$", Flags: helmV3ListFlagsWithoutKubeContext}:    {Chart: "istio-3.1.0", Status: "deployed"},
+				{Filter: "^database$", Flags: helmV3ListFlagsWithoutKubeContext}:       {Chart: "mysql-3.1.0", Status: "deployed"},
+				{Filter: "^anotherbackend$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "anotherbackend-3.1.0", Status: "deployed"},
 			},
 			// Enable wait and set timeout for destroy
 			deleteWait:    true,
@@ -614,11 +571,9 @@ changing working directory back to "/path/to"
 		check(t, testcase{
 			files: filesForTwoReleases,
 			diffs: map[exectest.DiffKey]error{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^frontend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
-				{Filter: "^backend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^frontend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^backend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}:  {},
 			},
 			// Disable concurrency to avoid in-deterministic result
 			concurrency: 1,
@@ -663,21 +618,17 @@ merged environment: &{default  map[] map[]}
 WARNING: release frontend-v1 needs backend-v1, but backend-v1 is not installed due to installed: false. Either mark backend-v1 as installed or remove backend-v1 from frontend-v1's needs
 2 release(s) found in helmfile.yaml
 
-processing 2 groups of releases in this order:
+processing 1 groups of releases in this order:
 GROUP RELEASES
 1     frontend-v1
-2     backend-v1
 
-processing releases in group 1/2: frontend-v1
+processing releases in group 1/1: frontend-v1
 WARNING: release frontend-v1 needs backend-v1, but backend-v1 is not installed due to installed: false. Either mark backend-v1 as installed or remove backend-v1 from frontend-v1's needs
 release "frontend-v1" processed
-processing releases in group 2/2: backend-v1
-release "backend-v1" processed
 
 DELETED RELEASES:
 NAME          DURATION
 frontend-v1         0s
-backend-v1          0s
 
 changing working directory back to "/path/to"
 `,
@@ -688,11 +639,9 @@ changing working directory back to "/path/to"
 		check(t, testcase{
 			files: filesForTwoReleases,
 			diffs: map[exectest.DiffKey]error{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^frontend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
-				{Filter: "^backend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^frontend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^backend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}:  {},
 			},
 			// Disable concurrency to avoid in-deterministic result
 			concurrency: 1,
@@ -737,21 +686,17 @@ merged environment: &{default  map[] map[]}
 WARNING: release frontend-v1 needs backend-v1, but backend-v1 is not installed due to installed: false. Either mark backend-v1 as installed or remove backend-v1 from frontend-v1's needs
 2 release(s) found in helmfile.yaml
 
-processing 2 groups of releases in this order:
+processing 1 groups of releases in this order:
 GROUP RELEASES
 1     frontend-v1
-2     backend-v1
 
-processing releases in group 1/2: frontend-v1
+processing releases in group 1/1: frontend-v1
 WARNING: release frontend-v1 needs backend-v1, but backend-v1 is not installed due to installed: false. Either mark backend-v1 as installed or remove backend-v1 from frontend-v1's needs
 release "frontend-v1" processed
-processing releases in group 2/2: backend-v1
-release "backend-v1" processed
 
 DELETED RELEASES:
 NAME          DURATION
 frontend-v1         0s
-backend-v1          0s
 
 changing working directory back to "/path/to"
 `,

--- a/pkg/app/destroy_test.go
+++ b/pkg/app/destroy_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	helmV3ListFlags                   = "--kube-context default --uninstalling --deployed --failed --pending"
-	helmV3ListFlagsWithoutKubeContext = "--uninstalling --deployed --failed --pending"
+	helmV3ListFlags                   = "--kube-context default --uninstalling --deployed --failed --pending -o yaml"
+	helmV3ListFlagsWithoutKubeContext = "--uninstalling --deployed --failed --pending -o yaml"
 )
 
 func listFlags(namespace, kubeContext string) string {
@@ -27,7 +27,7 @@ func listFlags(namespace, kubeContext string) string {
 	if namespace != "" {
 		flags = append(flags, "--namespace", namespace)
 	}
-	flags = append(flags, "--uninstalling --deployed --failed --pending")
+	flags = append(flags, "--uninstalling --deployed --failed --pending -o yaml")
 
 	return strings.Join(flags, " ")
 }
@@ -92,7 +92,7 @@ func TestDestroy(t *testing.T) {
 		error         string
 		files         map[string]string
 		selectors     []string
-		lists         map[exectest.ListKey]string
+		lists         map[exectest.ListKey]helmexec.HelmReleaseOutput
 		diffs         map[exectest.DiffKey]error
 		upgraded      []exectest.Release
 		deleted       []exectest.Release
@@ -277,35 +277,17 @@ releases:
 		check(t, testcase{
 			files: files,
 			diffs: map[exectest.DiffKey]error{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^frontend-v1$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
-				{Filter: "^frontend-v2$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-frontend-v2 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	frontend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^frontend-v3$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-frontend-v3 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	frontend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^backend-v1$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
-				{Filter: "^backend-v2$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-backend-v2 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^logging$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-logging	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	fluent-bit-3.1.0	3.1.0      	default
-`,
-				{Filter: "^front-proxy$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-front-proxy 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	envoy-3.1.0	3.1.0      	default
-`,
-				{Filter: "^servicemesh$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-servicemesh 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	istio-3.1.0	3.1.0      	default
-`,
-				{Filter: "^database$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-database 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mysql-3.1.0	3.1.0      	default
-`,
-				{Filter: "^anotherbackend$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-anotherbackend 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	anotherbackend-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^frontend-v1$", Flags: listFlags("", "default")}:    {},
+				{Filter: "^frontend-v2$", Flags: listFlags("", "default")}:    {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^frontend-v3$", Flags: listFlags("", "default")}:    {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^backend-v1$", Flags: listFlags("", "default")}:     {},
+				{Filter: "^backend-v2$", Flags: listFlags("", "default")}:     {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^logging$", Flags: listFlags("", "default")}:        {Chart: "fluent-bit-3.1.0", Status: "deployed"},
+				{Filter: "^front-proxy$", Flags: listFlags("", "default")}:    {Chart: "envoy-3.1.0", Status: "deployed"},
+				{Filter: "^servicemesh$", Flags: listFlags("", "default")}:    {Chart: "istio-3.1.0", Status: "deployed"},
+				{Filter: "^database$", Flags: listFlags("", "default")}:       {Chart: "mysql-3.1.0", Status: "deployed"},
+				{Filter: "^anotherbackend$", Flags: listFlags("", "default")}: {Chart: "anotherbackend-3.1.0", Status: "deployed"},
 			},
 			// Disable concurrency to avoid in-deterministic result
 			concurrency: 1,
@@ -316,9 +298,7 @@ anotherbackend 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	anotherbackend-3.1.0	
 			deleted: []exectest.Release{
 				{Name: "frontend-v3", Flags: []string{}},
 				{Name: "frontend-v2", Flags: []string{}},
-				{Name: "frontend-v1", Flags: []string{}},
 				{Name: "backend-v2", Flags: []string{}},
-				{Name: "backend-v1", Flags: []string{}},
 				{Name: "anotherbackend", Flags: []string{}},
 				{Name: "servicemesh", Flags: []string{}},
 				{Name: "database", Flags: []string{}},
@@ -454,20 +434,17 @@ WARNING: release frontend-v1 needs backend-v1, but backend-v1 is not installed d
 
 processing 5 groups of releases in this order:
 GROUP RELEASES
-1     default//frontend-v3, default//frontend-v2, default//frontend-v1
-2     default//backend-v2, default//backend-v1
+1     default//frontend-v3, default//frontend-v2
+2     default//backend-v2
 3     default//anotherbackend
 4     default//servicemesh, default//database
 5     default//front-proxy, default//logging
 
-processing releases in group 1/5: default//frontend-v3, default//frontend-v2, default//frontend-v1
+processing releases in group 1/5: default//frontend-v3, default//frontend-v2
 release "frontend-v3" processed
 release "frontend-v2" processed
-WARNING: release frontend-v1 needs backend-v1, but backend-v1 is not installed due to installed: false. Either mark backend-v1 as installed or remove backend-v1 from frontend-v1's needs
-release "frontend-v1" processed
-processing releases in group 2/5: default//backend-v2, default//backend-v1
+processing releases in group 2/5: default//backend-v2
 release "backend-v2" processed
-release "backend-v1" processed
 processing releases in group 3/5: default//anotherbackend
 release "anotherbackend" processed
 processing releases in group 4/5: default//servicemesh, default//database
@@ -481,9 +458,7 @@ DELETED RELEASES:
 NAME             DURATION
 frontend-v3            0s
 frontend-v2            0s
-frontend-v1            0s
 backend-v2             0s
-backend-v1             0s
 anotherbackend         0s
 servicemesh            0s
 database               0s
@@ -500,35 +475,17 @@ changing working directory back to "/path/to"
 			files:     files,
 			selectors: []string{"name=logging"},
 			diffs:     map[exectest.DiffKey]error{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^frontend-v1$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
-				{Filter: "^frontend-v2$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-frontend-v2 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	frontend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^frontend-v3$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-frontend-v3 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	frontend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^backend-v1$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
-				{Filter: "^backend-v2$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-backend-v2 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^logging$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-logging	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	fluent-bit-3.1.0	3.1.0      	default
-`,
-				{Filter: "^front-proxy$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-front-proxy 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	envoy-3.1.0	3.1.0      	default
-`,
-				{Filter: "^servicemesh$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-servicemesh 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	istio-3.1.0	3.1.0      	default
-`,
-				{Filter: "^database$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-database 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mysql-3.1.0	3.1.0      	default
-`,
-				{Filter: "^anotherbackend$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-anotherbackend 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	anotherbackend-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^frontend-v1$", Flags: listFlags("", "default")}:    {},
+				{Filter: "^frontend-v2$", Flags: listFlags("", "default")}:    {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^frontend-v3$", Flags: listFlags("", "default")}:    {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^backend-v1$", Flags: listFlags("", "default")}:     {},
+				{Filter: "^backend-v2$", Flags: listFlags("", "default")}:     {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^logging$", Flags: listFlags("", "default")}:        {Chart: "fluent-bit-3.1.0", Status: "deployed"},
+				{Filter: "^front-proxy$", Flags: listFlags("", "default")}:    {Chart: "envoy-3.1.0", Status: "deployed"},
+				{Filter: "^servicemesh$", Flags: listFlags("", "default")}:    {Chart: "istio-3.1.0", Status: "deployed"},
+				{Filter: "^database$", Flags: listFlags("", "default")}:       {Chart: "mysql-3.1.0", Status: "deployed"},
+				{Filter: "^anotherbackend$", Flags: listFlags("", "default")}: {Chart: "anotherbackend-3.1.0", Status: "deployed"},
 			},
 			// Disable concurrency to avoid in-deterministic result
 			concurrency: 1,
@@ -683,11 +640,9 @@ changing working directory back to "/path/to"
 		check(t, testcase{
 			files: filesForTwoReleases,
 			diffs: map[exectest.DiffKey]error{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^frontend-v1$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
-				{Filter: "^backend-v1$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^frontend-v1$", Flags: listFlags("", "default")}: {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^backend-v1$", Flags: listFlags("", "default")}:  {},
 			},
 			// Disable concurrency to avoid in-deterministic result
 			concurrency: 1,
@@ -732,21 +687,17 @@ merged environment: &{default  map[] map[]}
 WARNING: release frontend-v1 needs backend-v1, but backend-v1 is not installed due to installed: false. Either mark backend-v1 as installed or remove backend-v1 from frontend-v1's needs
 2 release(s) found in helmfile.yaml
 
-processing 2 groups of releases in this order:
+processing 1 groups of releases in this order:
 GROUP RELEASES
 1     default//frontend-v1
-2     default//backend-v1
 
-processing releases in group 1/2: default//frontend-v1
+processing releases in group 1/1: default//frontend-v1
 WARNING: release frontend-v1 needs backend-v1, but backend-v1 is not installed due to installed: false. Either mark backend-v1 as installed or remove backend-v1 from frontend-v1's needs
 release "frontend-v1" processed
-processing releases in group 2/2: default//backend-v1
-release "backend-v1" processed
 
 DELETED RELEASES:
 NAME          DURATION
 frontend-v1         0s
-backend-v1          0s
 
 changing working directory back to "/path/to"
 `,
@@ -757,11 +708,9 @@ changing working directory back to "/path/to"
 		check(t, testcase{
 			files: filesForTwoReleases,
 			diffs: map[exectest.DiffKey]error{},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^frontend-v1$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
-				{Filter: "^backend-v1$", Flags: listFlags("", "default")}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^frontend-v1$", Flags: listFlags("", "default")}: {Chart: "frontend-3.1.0", Status: "deployed"},
+				{Filter: "^backend-v1$", Flags: listFlags("", "default")}:  {},
 			},
 			// Disable concurrency to avoid in-deterministic result
 			concurrency: 1,
@@ -809,21 +758,17 @@ merged environment: &{default  map[] map[]}
 WARNING: release frontend-v1 needs backend-v1, but backend-v1 is not installed due to installed: false. Either mark backend-v1 as installed or remove backend-v1 from frontend-v1's needs
 2 release(s) found in helmfile.yaml
 
-processing 2 groups of releases in this order:
+processing 1 groups of releases in this order:
 GROUP RELEASES
 1     default//frontend-v1
-2     default//backend-v1
 
-processing releases in group 1/2: default//frontend-v1
+processing releases in group 1/1: default//frontend-v1
 WARNING: release frontend-v1 needs backend-v1, but backend-v1 is not installed due to installed: false. Either mark backend-v1 as installed or remove backend-v1 from frontend-v1's needs
 release "frontend-v1" processed
-processing releases in group 2/2: default//backend-v1
-release "backend-v1" processed
 
 DELETED RELEASES:
 NAME          DURATION
 frontend-v1         0s
-backend-v1          0s
 
 changing working directory back to "/path/to"
 `,

--- a/pkg/app/diff_nokubectx_test.go
+++ b/pkg/app/diff_nokubectx_test.go
@@ -31,7 +31,7 @@ func TestDiff_2(t *testing.T) {
 		flags            flags
 		files            map[string]string
 		selectors        []string
-		lists            map[exectest.ListKey]string
+		lists            map[exectest.ListKey]helmexec.HelmReleaseOutput
 		diffs            map[exectest.DiffKey]error
 		upgraded         []exectest.Release
 		deleted          []exectest.Release
@@ -115,14 +115,18 @@ releases:
 				{Name: "backend-v2", Chart: "charts/backend", Flags: "--detailed-exitcode --reset-values"}:            helmexec.ExitError{Code: 2},
 				{Name: "anotherbackend", Chart: "charts/anotherbackend", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
 				// delete frontend-v1 and backend-v1
-				{Filter: "^frontend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-frontend-v1 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
-`,
-				{Filter: "^backend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-backend-v1 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	backend-3.1.0	3.1.0      	default
-`,
+				{Filter: "^frontend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}:    {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^frontend-v2$", Flags: helmV3ListFlagsWithoutKubeContext}:    {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^frontend-v3$", Flags: helmV3ListFlagsWithoutKubeContext}:    {},
+				{Filter: "^logging$", Flags: helmV3ListFlagsWithoutKubeContext}:        {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^front-proxy$", Flags: helmV3ListFlagsWithoutKubeContext}:    {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^servicemesh$", Flags: helmV3ListFlagsWithoutKubeContext}:    {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^database$", Flags: helmV3ListFlagsWithoutKubeContext}:       {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^backend-v1$", Flags: helmV3ListFlagsWithoutKubeContext}:     {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^backend-v2$", Flags: helmV3ListFlagsWithoutKubeContext}:     {Chart: "backend-3.1.0", Status: "deployed"},
+				{Filter: "^anotherbackend$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "backend-3.1.0", Status: "deployed"},
 			},
 			// Disable concurrency to avoid in-deterministic result
 			concurrency: 1,
@@ -152,11 +156,9 @@ releases:
 			diffs: map[exectest.DiffKey]error{
 				{Name: "bar", Chart: "mychart2", Flags: "--detailed-exitcode --reset-values"}: nil,
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: ``,
-				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: {},
+				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{},
 			deleted:  []exectest.Release{},
@@ -187,7 +189,11 @@ releases:
 				{Name: "bar", Chart: "mychart2", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "baz", Chart: "mychart3", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists:       map[exectest.ListKey]string{},
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart2-3.1.0", Status: "deployed"},
+				{Filter: "^baz$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart3-3.1.0", Status: "deployed"},
+			},
 			upgraded:    []exectest.Release{},
 			deleted:     []exectest.Release{},
 			concurrency: 1,
@@ -384,13 +390,9 @@ releases:
 				{Name: "bar", Chart: "mychart2", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			deleted: []exectest.Release{},
 		},
@@ -416,13 +418,9 @@ releases:
 				{Name: "bar", Chart: "mychart2", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			deleted: []exectest.Release{},
 		},
@@ -450,13 +448,9 @@ releases:
 				{Name: "bar", Chart: "mychart2", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{},
 			deleted:  []exectest.Release{},
@@ -482,13 +476,9 @@ releases:
 				{Name: "bar", Chart: "mychart2", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{},
 			deleted:  []exectest.Release{},
@@ -517,13 +507,9 @@ releases:
 				{Name: "bar", Chart: "mychart2", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{},
 			deleted:  []exectest.Release{},
@@ -552,13 +538,9 @@ releases:
 				{Name: "bar", Chart: "mychart2", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{},
 			deleted:  []exectest.Release{},
@@ -584,13 +566,9 @@ releases:
 				{Name: "bar", Chart: "mychart2", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{},
 			deleted:  []exectest.Release{},
@@ -616,13 +594,9 @@ releases:
 				{Name: "bar", Chart: "mychart2", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 			},
-			lists: map[exectest.ListKey]string{
-				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-foo 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart1-3.1.0	3.1.0      	default
-`,
-				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: `NAME	REVISION	UPDATED                 	STATUS  	CHART        	APP VERSION	NAMESPACE
-bar 	4       	Fri Nov  1 08:40:07 2019	DEPLOYED	mychart2-3.1.0	3.1.0      	default
-`,
+			lists: map[exectest.ListKey]helmexec.HelmReleaseOutput{
+				{Filter: "^foo$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart1-3.1.0", Status: "deployed"},
+				{Filter: "^bar$", Flags: helmV3ListFlagsWithoutKubeContext}: {Chart: "mychart2-3.1.0", Status: "deployed"},
 			},
 			upgraded: []exectest.Release{},
 			deleted:  []exectest.Release{},
@@ -907,7 +881,7 @@ releases:
 				{Name: "baz", Chart: "mychart3", Flags: "--namespace ns1 --detailed-exitcode --reset-values"}: helmexec.ExitError{Code: 2},
 				{Name: "foo", Chart: "mychart1", Flags: "--detailed-exitcode --reset-values"}:                 helmexec.ExitError{Code: 2},
 			},
-			lists:       map[exectest.ListKey]string{},
+			lists:       map[exectest.ListKey]helmexec.HelmReleaseOutput{},
 			upgraded:    []exectest.Release{},
 			deleted:     []exectest.Release{},
 			concurrency: 1,

--- a/pkg/app/testdata/testapply/install/log
+++ b/pkg/app/testdata/testapply/install/log
@@ -36,6 +36,9 @@ second-pass rendering result of "helmfile.yaml.part.0":
 merged environment: &{default  map[] map[]}
 3 release(s) found in helmfile.yaml
 
+confirming if the release is already installed or not: unexpected list key: listkey(filter=^baz$,flags=--kube-context default --uninstalling --deployed --failed --pending -o yaml) not found in 
+confirming if the release is already installed or not: unexpected list key: listkey(filter=^bar$,flags=--kube-context default --uninstalling --deployed --failed --pending -o yaml) not found in 
+confirming if the release is already installed or not: unexpected list key: listkey(filter=^foo$,flags=--kube-context default --uninstalling --deployed --failed --pending -o yaml) not found in 
 Affected releases are:
   bar (stable/mychart2) UPDATED
   baz (stable/mychart3) UPDATED
@@ -54,10 +57,10 @@ GROUP RELEASES
 2     default//foo
 
 processing releases in group 1/2: default//baz, default//bar
-getting deployed release version failed: unexpected list key: listkey(filter=^baz$,flags=--kube-context default --uninstalling --deployed --failed --pending) not found in 
-getting deployed release version failed: unexpected list key: listkey(filter=^bar$,flags=--kube-context default --uninstalling --deployed --failed --pending) not found in 
+getting deployed release version failed: unexpected list key: listkey(filter=^baz$,flags=--kube-context default --uninstalling --deployed --failed --pending -o yaml) not found in 
+getting deployed release version failed: unexpected list key: listkey(filter=^bar$,flags=--kube-context default --uninstalling --deployed --failed --pending -o yaml) not found in 
 processing releases in group 2/2: default//foo
-getting deployed release version failed: unexpected list key: listkey(filter=^foo$,flags=--kube-context default --uninstalling --deployed --failed --pending) not found in 
+getting deployed release version failed: unexpected list key: listkey(filter=^foo$,flags=--kube-context default --uninstalling --deployed --failed --pending -o yaml) not found in 
 
 UPDATED RELEASES:
 NAME   CHART             VERSION   DURATION

--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -34,7 +34,7 @@ type Helm struct {
 	Deleted              []Release
 	Linted               []Release
 	Templated            []Release
-	Lists                map[ListKey]string
+	Lists                map[ListKey]helmexec.HelmReleaseOutput
 	Diffs                map[DiffKey]error
 	Diffed               []Release
 	FailOnUnexpectedDiff bool
@@ -151,11 +151,11 @@ func (helm *Helm) DeleteRelease(context helmexec.HelmContext, name string, flags
 	helm.Deleted = append(helm.Deleted, Release{Name: name, Flags: flags})
 	return nil
 }
-func (helm *Helm) List(context helmexec.HelmContext, filter string, flags ...string) (string, error) {
+func (helm *Helm) List(context helmexec.HelmContext, filter string, flags ...string) (helmexec.HelmReleaseOutput, error) {
 	key := ListKey{Filter: filter, Flags: strings.Join(flags, " ")}
 
 	if helm.Lists == nil {
-		return "dummy non-empty helm-list output", nil
+		return helmexec.HelmReleaseOutput{Chart: "dummy-chart-1.0", Status: "deployed"}, nil
 	}
 
 	res, ok := helm.Lists[key]
@@ -164,7 +164,7 @@ func (helm *Helm) List(context helmexec.HelmContext, filter string, flags ...str
 		for k := range helm.Lists {
 			keys = append(keys, k.String())
 		}
-		return "", fmt.Errorf("unexpected list key: %v not found in %v", key, strings.Join(keys, ", "))
+		return helmexec.HelmReleaseOutput{}, fmt.Errorf("unexpected list key: %v not found in %v", key, strings.Join(keys, ", "))
 	}
 	return res, nil
 }

--- a/pkg/helmexec/helmexec.go
+++ b/pkg/helmexec/helmexec.go
@@ -31,7 +31,7 @@ type Interface interface {
 	ReleaseStatus(context HelmContext, name string, flags ...string) error
 	DeleteRelease(context HelmContext, name string, flags ...string) error
 	TestRelease(context HelmContext, name string, flags ...string) error
-	List(context HelmContext, filter string, flags ...string) (string, error)
+	List(context HelmContext, filter string, flags ...string) (HelmReleaseOutput, error)
 	DecryptSecret(context HelmContext, name string, flags ...string) (string, error)
 	IsHelm3() bool
 	GetVersion() Version

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -695,14 +695,17 @@ func (st *HelmState) prepareSyncReleases(helm helmexec.Interface, additionalValu
 	return res, errs
 }
 
-func (st *HelmState) isReleaseInstalled(context helmexec.HelmContext, helm helmexec.Interface, release ReleaseSpec) (bool, error) {
+// returns installed, deployed, err so apply can trigger non-diff upgrades on failed/non-deployed charts
+func (st *HelmState) isReleaseInstalled(context helmexec.HelmContext, helm helmexec.Interface, release ReleaseSpec) (bool, bool, error) {
 	out, err := st.listReleases(context, helm, &release)
 	if err != nil {
-		return false, err
-	} else if out != "" {
-		return true, nil
+		return false, false, err
+	} else if out.Status == "deployed" {
+		return true, true, nil
+	} else if out.Status != "" {
+		return true, false, nil
 	}
-	return false, nil
+	return false, false, nil
 }
 
 func (st *HelmState) DetectReleasesToBeDeletedForSync(helm helmexec.Interface, releases []ReleaseSpec) ([]ReleaseSpec, error) {
@@ -711,7 +714,7 @@ func (st *HelmState) DetectReleasesToBeDeletedForSync(helm helmexec.Interface, r
 		release := releases[i]
 
 		if !release.Desired() {
-			installed, err := st.isReleaseInstalled(st.createHelmContext(&release, 0), helm, release)
+			installed, _, err := st.isReleaseInstalled(st.createHelmContext(&release, 0), helm, release)
 			if err != nil {
 				return nil, err
 			}
@@ -730,7 +733,7 @@ func (st *HelmState) DetectReleasesToBeDeleted(helm helmexec.Interface, releases
 	for i := range releases {
 		release := releases[i]
 
-		installed, err := st.isReleaseInstalled(st.createHelmContext(&release, 0), helm, release)
+		installed, _, err := st.isReleaseInstalled(st.createHelmContext(&release, 0), helm, release)
 		if err != nil {
 			return nil, err
 		} else if installed {
@@ -950,7 +953,7 @@ func (st *HelmState) SyncReleases(affectedReleases *AffectedReleases, helm helme
 				if _, err := st.triggerPresyncEvent(release, "sync"); err != nil {
 					relErr = newReleaseFailedError(release, err)
 				} else if !release.Desired() {
-					installed, err := st.isReleaseInstalled(context, helm, *release)
+					installed, _, err := st.isReleaseInstalled(context, helm, *release)
 					if err != nil {
 						relErr = newReleaseFailedError(release, err)
 					} else if installed {
@@ -1030,13 +1033,14 @@ func (st *HelmState) SyncReleases(affectedReleases *AffectedReleases, helm helme
 	return nil
 }
 
-func (st *HelmState) listReleases(context helmexec.HelmContext, helm helmexec.Interface, release *ReleaseSpec) (string, error) {
+func (st *HelmState) listReleases(context helmexec.HelmContext, helm helmexec.Interface, release *ReleaseSpec) (helmexec.HelmReleaseOutput, error) {
 	flags := st.kubeConnectionFlags(release)
 	if release.Namespace != "" {
 		flags = append(flags, "--namespace", release.Namespace)
 	}
 	flags = append(flags, "--uninstalling")
 	flags = append(flags, "--deployed", "--failed", "--pending")
+	flags = append(flags, "-o", "yaml")
 	return helm.List(context, "^"+release.Name+"$", flags...)
 }
 
@@ -1044,9 +1048,8 @@ func (st *HelmState) getDeployedVersion(context helmexec.HelmContext, helm helme
 	//retrieve the version
 	if out, err := st.listReleases(context, helm, release); err == nil {
 		chartName := filepath.Base(release.Chart)
-		//the regexp without escapes : .*\s.*\s.*\s.*\schartName-(.*?)\s
-		pat := regexp.MustCompile(".*\\s.*\\s.*\\s.*\\s" + chartName + "-(.*?)\\s")
-		versions := pat.FindStringSubmatch(out)
+		pat := regexp.MustCompile(chartName + "-(.*)")
+		versions := pat.FindStringSubmatch(out.Chart)
 		if len(versions) > 0 {
 			return versions[1], nil
 		} else {
@@ -1725,6 +1728,7 @@ type diffPrepareResult struct {
 	files                   []string
 	upgradeDueToSkippedDiff bool
 	suppressDiff            bool
+	deployed                bool
 }
 
 // commonDiffFlags returns common flags for helm diff, not in release-specific context
@@ -1792,29 +1796,30 @@ func (st *HelmState) prepareDiffReleases(helm helmexec.Interface, additionalValu
 	}
 
 	mu := &sync.RWMutex{}
-	installedReleases := map[string]bool{}
+	deployedReleases := map[string]bool{}
 
-	isInstalled := func(r *ReleaseSpec) bool {
+	isDeployed := func(r *ReleaseSpec) bool {
 		id := ReleaseToID(r)
 
 		mu.RLock()
-		v, ok := installedReleases[id]
+		deployed, ok := deployedReleases[id]
 		mu.RUnlock()
 
 		if ok {
-			return v
+			return deployed
 		}
 
-		v, err := st.isReleaseInstalled(st.createHelmContext(r, 0), helm, *r)
+		_, deployed, err := st.isReleaseInstalled(st.createHelmContext(r, 0), helm, *r)
 		if err != nil {
 			st.logger.Warnf("confirming if the release is already installed or not: %v", err)
 		} else {
 			mu.Lock()
-			installedReleases[id] = v
+			deployedReleases[id] = deployed
 			mu.Unlock()
 		}
 
-		return v
+		// If in non-deployed state, and chart version is up to date, we still want to trigger upgrade
+		return deployed
 	}
 
 	releases := []*ReleaseSpec{}
@@ -1859,12 +1864,12 @@ func (st *HelmState) prepareDiffReleases(helm helmexec.Interface, additionalValu
 					suppressDiff = true
 				}
 
-				if opt.SkipDiffOnInstall && !isInstalled(release) {
+				if opt.SkipDiffOnInstall && !isDeployed(release) {
 					results <- diffPrepareResult{release: release, upgradeDueToSkippedDiff: true, suppressDiff: suppressDiff}
 					continue
 				}
 
-				disableValidation := release.DisableValidationOnInstall != nil && *release.DisableValidationOnInstall && !isInstalled(release)
+				disableValidation := release.DisableValidationOnInstall != nil && *release.DisableValidationOnInstall && !isDeployed(release)
 
 				// TODO We need a long-term fix for this :)
 				// See https://github.com/roboll/helmfile/issues/737
@@ -1897,7 +1902,7 @@ func (st *HelmState) prepareDiffReleases(helm helmexec.Interface, additionalValu
 					}
 					results <- diffPrepareResult{errors: rsErrs, files: files, suppressDiff: suppressDiff}
 				} else {
-					results <- diffPrepareResult{release: release, flags: flags, errors: []*ReleaseError{}, files: files, suppressDiff: suppressDiff}
+					results <- diffPrepareResult{release: release, flags: flags, errors: []*ReleaseError{}, files: files, suppressDiff: suppressDiff, deployed: isDeployed(release)}
 				}
 			}
 		},
@@ -2042,8 +2047,13 @@ func (st *HelmState) DiffReleases(helm helmexec.Interface, additionalValues []st
 						results <- diffResult{release, &ReleaseError{release, err, 0}, buf}
 					}
 				} else {
-					// diff succeeded, found no changes
-					results <- diffResult{release, nil, buf}
+					if prep.deployed {
+						// diff succeeded, found no changes
+						results <- diffResult{release, nil, buf}
+					} else {
+						// diff succeeded, found no changes, but release is non-deployed
+						results <- diffResult{release, &ReleaseError{ReleaseSpec: release, err: nil, Code: HelmDiffExitCodeChanged}, buf}
+					}
 				}
 
 				if triggerCleanupEvents {

--- a/pkg/testutil/mocks.go
+++ b/pkg/testutil/mocks.go
@@ -106,9 +106,9 @@ func (helm *noCallHelmExec) DeleteRelease(context helmexec.HelmContext, name str
 	return nil
 }
 
-func (helm *noCallHelmExec) List(context helmexec.HelmContext, filter string, flags ...string) (string, error) {
+func (helm *noCallHelmExec) List(context helmexec.HelmContext, filter string, flags ...string) (helmexec.HelmReleaseOutput, error) {
 	helm.doPanic()
-	return "", nil
+	return helmexec.HelmReleaseOutput{}, nil
 }
 
 func (helm *noCallHelmExec) DecryptSecret(context helmexec.HelmContext, name string, flags ...string) (string, error) {

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -45,9 +45,9 @@ function retry() {
     local -r max=${1}
     local -r command=${2}
     n=0
-    retry_result=0
     until [ ${n} -ge ${max} ]; do
         info "Executing: ${command} (attempt $((n+1)))"
+        retry_result=0
         ${command} && break  # substitute your command here
         retry_result=$?
         n=$[$n+1]

--- a/test/integration/test-cases/chart-needs.sh
+++ b/test/integration/test-cases/chart-needs.sh
@@ -41,7 +41,7 @@ done
 
 for i in $(seq 10); do
     info "Comparing diff/chart-needs #$i"
-    ${helmfile} -f ${chart_need_case_input_dir}/${config_file} diff --include-needs | grep -Ev "Comparing release=azuredisk-csi-storageclass, chart=/tmp/.*/azuredisk-csi-storageclass" > ${chart_needs_diff_reverse} || fail "\"helmfile diff\" shouldn't fail"
+    ${helmfile} -f ${chart_need_case_input_dir}/${config_file} diff --include-needs | grep -Ev "Comparing release=azuredisk-csi-storageclass, chart=/.*/azuredisk-csi-storageclass" > ${chart_needs_diff_reverse} || fail "\"helmfile diff\" shouldn't fail"
     diff -u ${diff_out_file} ${chart_needs_diff_reverse} || fail "\"helmfile diff\" should be consistent"
     echo code=$?
 done

--- a/test/integration/test-cases/diff-args/output/apply
+++ b/test/integration/test-cases/diff-args/output/apply
@@ -74,4 +74,3 @@ STATUS: deployed
 REVISION: 1
 TEST SUITE: None
 
-

--- a/test/integration/test-cases/diff-args/output/apply-live
+++ b/test/integration/test-cases/diff-args/output/apply-live
@@ -74,4 +74,3 @@ NAMESPACE: helmfile-tests
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None
-

--- a/test/integration/test-cases/postrender/output/diff-result
+++ b/test/integration/test-cases/postrender/output/diff-result
@@ -1,5 +1,7 @@
 Building dependency release=foo, chart=../../../charts/raw
 Building dependency release=baz, chart=../../../charts/raw
+Listing releases matching ^foo$
+Listing releases matching ^baz$
 Comparing release=foo, chart=../../../charts/raw
 ********************
 
@@ -49,4 +51,8 @@ helmfile-tests, cm1, ConfigMap (v1) has been added:
 +   name: cm1 
 + metadata:
 +   name: cm1
+
+Affected releases are:
+  baz (../../../charts/raw) UPDATED
+  foo (../../../charts/raw) UPDATED
 

--- a/test/integration/test-cases/postrender/output/diff-result-live
+++ b/test/integration/test-cases/postrender/output/diff-result-live
@@ -1,6 +1,8 @@
 Live output is enabled
 Building dependency release=foo, chart=../../../charts/raw
 Building dependency release=baz, chart=../../../charts/raw
+Listing releases matching ^foo$
+Listing releases matching ^baz$
 ********************
 
 	Release was not present in Helm.  Diff will show entire contents as new.
@@ -49,3 +51,7 @@ helmfile-tests, cm1, ConfigMap (v1) has been added:
 +   name: cm1
 Comparing release=foo, chart=../../../charts/raw
 Comparing release=baz, chart=../../../charts/raw
+Affected releases are:
+  baz (../../../charts/raw) UPDATED
+  foo (../../../charts/raw) UPDATED
+

--- a/test/integration/test-cases/secretssops.sh
+++ b/test/integration/test-cases/secretssops.sh
@@ -34,7 +34,7 @@ test_pass "secretssops.1"
 test_start "secretssops.2 - should succeed with secrets plugin"
 
 info "Ensure helm-secrets is installed"
-${helm} plugin install https://github.com/jkroepke/helm-secrets --version v${HELM_SECRETS_VERSION}
+${helm} plugin install https://github.com/jkroepke/helm-secrets.git --version v${HELM_SECRETS_VERSION}
 
 info "Ensure helmfile succeed when helm-secrets is installed"
 ${helmfile} -f ${secretssops_case_input_dir}/${config_file} -e direct build || fail "\"helmfile build\" shouldn't fail"

--- a/test/integration/test-cases/suppress-output-line-regex.sh
+++ b/test/integration/test-cases/suppress-output-line-regex.sh
@@ -22,7 +22,9 @@ else
     
     for i in $(seq 10); do
         info "Comparing suppress-output-line-regex diff log #$i"
-        ${helmfile} -f ${suppress_output_line_regex_input_dir}/helmfile.yaml.gotmpl diff > ${suppress_output_line_regex_reverse} || fail "\"helmfile diff\" shouldn't fail"
+        # Includes date/time in output, making consistent diff impossible
+        line_exclude_regex='ingress-nginx\s+helmfile-tests\s+1.*deployed\s+ingress-nginx-4.8.3\s+1.9.4'
+        ${helmfile} -f ${suppress_output_line_regex_input_dir}/helmfile.yaml.gotmpl diff | grep -Ev "$line_exclude_regex" > ${suppress_output_line_regex_reverse} || fail "\"helmfile diff\" shouldn't fail"
         diff -u ${diff_out_file} ${suppress_output_line_regex_reverse} || fail "\"helmfile diff\" should be consistent"
         echo code=$?
     done


### PR DESCRIPTION
Currently, if any helm release is extant in the cluster at all, "helmfile apply" will attempt to run a "helm diff" between the release in the cluster and the proposed release, and only run helm upgrade if the diff shows a change.

While this is a sensible check for "deployed" releases, for failed (and possibly any other) release states, if the diff hasn't changed (even though the release never succeded), it results in the worst possible outcome: helmfile appears to finish successfully, while completely ignoring the failed release.

This ensures we always trigger an upgrade on releases that are in a non-deployed state. This way, if re-running with the same chart would succeed, we have the opportunity to fix things on rerun (let's say a helm hook pre or post-upgrade job will succeed now due to fixing a service external to the chart); if it wouldn't, by rerunning the upgrade, we will again see the error rather than it going under the radar and giving the false impression that everything is hunky dory.

(This is another iteration of https://github.com/helmfile/helmfile/pull/1043, which was a replacement for https://github.com/helmfile/helmfile/pull/958, but I believe it's been lost in the shuffle so opening a new one for freshness--apologies for the dupe, not trying to game the system)

Have run an iteration of the CI tests in my own repo: https://github.com/Secretions/helmfile/pull/7