### PR TITLE
Fix typo and link for supported backends

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -14,7 +14,7 @@ Helmfile integrates [vals]() to import configuration parameters from following b
 - Vault
 - SOPS
 
-See [Vals "Suported Backends"](https://github.com/helmfile/vals#suported-backends) for the full list of available backends.
+See [Vals "Supported Backends"](https://github.com/helmfile/vals#supported-backends) for the full list of available backends.
 
 This feature was implemented in https://github.com/roboll/helmfile/pull/906.
 If you're curious how it's designed and how it works, please consult the pull request.


### PR DESCRIPTION
Noticed this when looking at the docs