### PR TITLE
chore: add tests for release filters

### DIFF
--- a/pkg/state/release_filters_test.go
+++ b/pkg/state/release_filters_test.go
@@ -1,0 +1,69 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLabelFilterMatchSuccessfulMatch(t *testing.T) {
+	lf := LabelFilter{
+		positiveLabels: [][]string{{"foo", "bar"}},
+		negativeLabels: [][]string{{"baz", "bat"}},
+	}
+
+	release := ReleaseSpec{
+		Labels: map[string]string{
+			"foo": "bar",
+			"baz": "notbat",
+		},
+	}
+
+	assert.True(t, lf.Match(release), "expected match but got no match")
+}
+
+func TestLabelFilterMatchWithNegativeLabels(t *testing.T) {
+	lf := LabelFilter{
+		positiveLabels: [][]string{{"foo", "bar"}},
+		negativeLabels: [][]string{{"baz", "bat"}},
+	}
+
+	release := ReleaseSpec{
+		Labels: map[string]string{
+			"foo": "bar",
+			"baz": "bat",
+		},
+	}
+
+	assert.False(t, lf.Match(release), "expected no match but got match")
+}
+
+func TestParseLabelsValidInput(t *testing.T) {
+	labelStr := "foo=bar,baz!=bat"
+	expectedPositive := [][]string{{"foo", "bar"}}
+	expectedNegative := [][]string{{"baz", "bat"}}
+
+	lf, err := ParseLabels(labelStr)
+	assert.NoError(t, err, "unexpected error")
+
+	assert.Equal(t, expectedPositive, lf.positiveLabels, "unexpected positive labels")
+	assert.Equal(t, expectedNegative, lf.negativeLabels, "unexpected negative labels")
+
+	release := ReleaseSpec{
+		Labels: map[string]string{
+			"foo": "bar",
+			"baz": "notbat",
+		},
+	}
+
+	assert.True(t, lf.Match(release), "expected match but got no match")
+}
+
+func TestParseLabelsInvalidFormat(t *testing.T) {
+	labelStr := "foo=bar,invalid_label"
+	_, err := ParseLabels(labelStr)
+	assert.Error(t, err, "expected error but got none")
+
+	expectedErrorMsg := "malformed label: invalid_label. Expected label in form k=v or k!=v"
+	assert.EqualError(t, err, expectedErrorMsg, "unexpected error message")
+}


### PR DESCRIPTION
**TestLabelFilterMatchSuccessfulMatch:**

This test verifies that the Match method of `LabelFilter` correctly identifies a match when a release meets the specified positive label criteria & does not meet the negative label criteria.

**TestLabelFilterMatchWithNegativeLabels:**

This test is testing the Match method of `LabelFilter` when a release contains a label that matches the negative label criteria, ensuring it returns false.

**TestParseLabelsValidInput:**

This test validates the `ParseLabels` func behavior with valid input, ensuring it correctly parses and separates positive and negative labels.

**TestParseLabelsInvalidFormat:**

This test, will test the `ParseLabels` func's error handling when provided with malformed input.
