### PR TITLE
fix(oci): use output-dir-template in path if specified

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -3743,11 +3743,7 @@ func (st *HelmState) FullFilePath() (string, error) {
 
 func (st *HelmState) getOCIChartPath(tempDir string, release *ReleaseSpec, chartName, chartVersion, outputDirTemplate string) (string, error) {
 	if outputDirTemplate != "" {
-		chartPath, err := generateChartPath(chartName, tempDir, release, outputDirTemplate)
-		if err != nil {
-			return "", err
-		}
-		return chartPath, nil
+		return generateChartPath(chartName, tempDir, release, outputDirTemplate)
 	}
 
 	pathElems := []string{tempDir}


### PR DESCRIPTION
fixes #928

Previously `--output-dir-template` was not used if the repository was OCI.

# Test case

## `helmfile.yaml`

```yaml
repositories:
  - name: karpenter
    url: public.ecr.aws/karpenter
    oci: true
  - name: gatekeeper
    url: https://open-policy-agent.github.io/gatekeeper/charts

releases:
  - name: karpenter
    chart: karpenter/karpenter
    version: "0.37.0"
  - name: gatekeeper
    chart: gatekeeper/gatekeeper
```

## Command

```
helmfile fetch --output-dir charts --output-dir-template "{{ .OutputDir }}/"
```


# Results

## Previously

```
charts
├── gatekeeper
│   ├── Chart.yaml
│   ├── README.md
│   ├── crds
│   │   ├── assign-customresourcedefinition.yaml
│   │   ├── assignimage-customresourcedefinition.yaml
│   │   ├── assignmetadata-customresourcedefinition.yaml
│   │   ├── config-customresourcedefinition.yaml
│   │   ├── constraintpodstatus-customresourcedefinition.yaml
│   │   ├── constrainttemplate-customresourcedefinition.yaml
│   │   ├── constrainttemplatepodstatus-customresourcedefinition.yaml
│   │   ├── expansiontemplate-customresourcedefinition.yaml
│   │   ├── expansiontemplatepodstatus-customresourcedefinition.yaml
│   │   ├── modifyset-customresourcedefinition.yaml
│   │   ├── mutatorpodstatus-customresourcedefinition.yaml
│   │   ├── provider-customresourcedefinition.yaml
│   │   └── syncset-customresourcedefinition.yaml
│   ├── templates
│   │   ├── _helpers.tpl
│   │   ├── gatekeeper-admin-podsecuritypolicy.yaml
│   │   ├── gatekeeper-admin-serviceaccount.yaml
│   │   ├── gatekeeper-audit-deployment.yaml
│   │   ├── gatekeeper-controller-manager-deployment.yaml
│   │   ├── gatekeeper-controller-manager-network-policy.yaml
│   │   ├── gatekeeper-controller-manager-poddisruptionbudget.yaml
│   │   ├── gatekeeper-critical-pods-resourcequota.yaml
│   │   ├── gatekeeper-manager-role-clusterrole.yaml
│   │   ├── gatekeeper-manager-role-role.yaml
│   │   ├── gatekeeper-manager-rolebinding-clusterrolebinding.yaml
│   │   ├── gatekeeper-manager-rolebinding-rolebinding.yaml
│   │   ├── gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
│   │   ├── gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
│   │   ├── gatekeeper-webhook-server-cert-secret.yaml
│   │   ├── gatekeeper-webhook-service-service.yaml
│   │   ├── namespace-post-install.yaml
│   │   ├── namespace-post-upgrade.yaml
│   │   ├── probe-webhook-post-install.yaml
│   │   ├── upgrade-crds-hook.yaml
│   │   └── webhook-configs-pre-delete.yaml
│   └── values.yaml
└── karpenter
    └── karpenter
        └── 0.37.0
            └── karpenter
                ├── Chart.lock
                ├── Chart.yaml
                ├── README.md
                ├── README.md.gotmpl
                ├── artifacthub-repo.yaml
                ├── crds
                │   ├── karpenter.k8s.aws_ec2nodeclasses.yaml
                │   ├── karpenter.sh_nodeclaims.yaml
                │   └── karpenter.sh_nodepools.yaml
                ├── templates
                │   ├── _helpers.tpl
                │   ├── aggregate-clusterrole.yaml
                │   ├── clusterrole-core.yaml
                │   ├── clusterrole.yaml
                │   ├── configmap-logging.yaml
                │   ├── deployment.yaml
                │   ├── poddisruptionbudget.yaml
                │   ├── role.yaml
                │   ├── rolebinding.yaml
                │   ├── secret-webhook-cert.yaml
                │   ├── service.yaml
                │   ├── serviceaccount.yaml
                │   ├── servicemonitor.yaml
                │   ├── webhooks-core.yaml
                │   └── webhooks.yaml
                └── values.yaml

10 directories, 61 files
```

## Now

```
charts
├── gatekeeper
│   ├── Chart.yaml
│   ├── README.md
│   ├── crds
│   │   ├── assign-customresourcedefinition.yaml
│   │   ├── assignimage-customresourcedefinition.yaml
│   │   ├── assignmetadata-customresourcedefinition.yaml
│   │   ├── config-customresourcedefinition.yaml
│   │   ├── constraintpodstatus-customresourcedefinition.yaml
│   │   ├── constrainttemplate-customresourcedefinition.yaml
│   │   ├── constrainttemplatepodstatus-customresourcedefinition.yaml
│   │   ├── expansiontemplate-customresourcedefinition.yaml
│   │   ├── expansiontemplatepodstatus-customresourcedefinition.yaml
│   │   ├── modifyset-customresourcedefinition.yaml
│   │   ├── mutatorpodstatus-customresourcedefinition.yaml
│   │   ├── provider-customresourcedefinition.yaml
│   │   └── syncset-customresourcedefinition.yaml
│   ├── templates
│   │   ├── _helpers.tpl
│   │   ├── gatekeeper-admin-podsecuritypolicy.yaml
│   │   ├── gatekeeper-admin-serviceaccount.yaml
│   │   ├── gatekeeper-audit-deployment.yaml
│   │   ├── gatekeeper-controller-manager-deployment.yaml
│   │   ├── gatekeeper-controller-manager-network-policy.yaml
│   │   ├── gatekeeper-controller-manager-poddisruptionbudget.yaml
│   │   ├── gatekeeper-critical-pods-resourcequota.yaml
│   │   ├── gatekeeper-manager-role-clusterrole.yaml
│   │   ├── gatekeeper-manager-role-role.yaml
│   │   ├── gatekeeper-manager-rolebinding-clusterrolebinding.yaml
│   │   ├── gatekeeper-manager-rolebinding-rolebinding.yaml
│   │   ├── gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
│   │   ├── gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
│   │   ├── gatekeeper-webhook-server-cert-secret.yaml
│   │   ├── gatekeeper-webhook-service-service.yaml
│   │   ├── namespace-post-install.yaml
│   │   ├── namespace-post-upgrade.yaml
│   │   ├── probe-webhook-post-install.yaml
│   │   ├── upgrade-crds-hook.yaml
│   │   └── webhook-configs-pre-delete.yaml
│   └── values.yaml
└── karpenter
    ├── Chart.lock
    ├── Chart.yaml
    ├── README.md
    ├── README.md.gotmpl
    ├── artifacthub-repo.yaml
    ├── crds
    │   ├── karpenter.k8s.aws_ec2nodeclasses.yaml
    │   ├── karpenter.sh_nodeclaims.yaml
    │   └── karpenter.sh_nodepools.yaml
    ├── templates
    │   ├── _helpers.tpl
    │   ├── aggregate-clusterrole.yaml
    │   ├── clusterrole-core.yaml
    │   ├── clusterrole.yaml
    │   ├── configmap-logging.yaml
    │   ├── deployment.yaml
    │   ├── poddisruptionbudget.yaml
    │   ├── role.yaml
    │   ├── rolebinding.yaml
    │   ├── secret-webhook-cert.yaml
    │   ├── service.yaml
    │   ├── serviceaccount.yaml
    │   ├── servicemonitor.yaml
    │   ├── webhooks-core.yaml
    │   └── webhooks.yaml
    └── values.yaml

7 directories, 61 files
```