### PR TITLE
build(deps): helm-s3: v0.16.0 -> v0.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN set -x && \
 
 RUN helm plugin install https://github.com/databus23/helm-diff --version v3.9.8 && \
     helm plugin install https://github.com/jkroepke/helm-secrets --version v4.6.0 && \
-    helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.16.0 && \
+    helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.16.2 && \
     helm plugin install https://github.com/aslafy-z/helm-git.git --version v0.16.0 && \
     rm -rf ${HELM_CACHE_HOME}/plugins
 

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -101,7 +101,7 @@ RUN set -x && \
 
 RUN helm plugin install https://github.com/databus23/helm-diff --version v3.9.8 && \
     helm plugin install https://github.com/jkroepke/helm-secrets --version v4.6.0 && \
-    helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.16.0 && \
+    helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.16.2 && \
     helm plugin install https://github.com/aslafy-z/helm-git.git --version v0.16.0 && \
     rm -rf ${HELM_CACHE_HOME}/plugins
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -101,7 +101,7 @@ RUN set -x && \
 
 RUN helm plugin install https://github.com/databus23/helm-diff --version v3.9.8 && \
     helm plugin install https://github.com/jkroepke/helm-secrets --version v4.6.0 && \
-    helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.16.0 && \
+    helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.16.2 && \
     helm plugin install https://github.com/aslafy-z/helm-git.git --version v0.16.0 && \
     rm -rf ${HELM_CACHE_HOME}/plugins
 


### PR DESCRIPTION
Update the versions of the helm plugins in the Dockerfile to the latest stable versions:
- helm-s3: v0.16.0 -> v0.16.2

This update ensures that the Docker image is using the most up-to-date versions of the helm plugins s3.