### PR TITLE
chore: Remove unnecessary field from StateCreator

### DIFF
--- a/pkg/state/create.go
+++ b/pkg/state/create.go
@@ -49,8 +49,6 @@ type StateCreator struct {
 
 	valsRuntime vals.Evaluator
 
-	Strict bool
-
 	LoadFile func(inheritedEnv, overrodeEnv *environment.Environment, baseDir, file string, evaluateBases bool) (*HelmState, error)
 
 	getHelm func(*HelmState) helmexec.Interface
@@ -68,9 +66,7 @@ type StateCreator struct {
 
 func NewCreator(logger *zap.SugaredLogger, fs *filesystem.FileSystem, valsRuntime vals.Evaluator, getHelm func(*HelmState) helmexec.Interface, overrideHelmBinary string, overrideKustomizeBinary string, remote *remote.Remote, enableLiveOutput bool, lockFile string) *StateCreator {
 	return &StateCreator{
-		logger: logger,
-
-		Strict:      true,
+		logger:      logger,
 		fs:          fs,
 		valsRuntime: valsRuntime,
 		getHelm:     getHelm,
@@ -95,7 +91,7 @@ func (c *StateCreator) Parse(content []byte, baseDir, file string) (*HelmState, 
 
 	state.LockFile = c.lockFile
 
-	decode := yaml.NewDecoder(content, c.Strict)
+	decode := yaml.NewDecoder(content, true)
 
 	i := 0
 	for {

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -18,7 +18,6 @@ func createFromYaml(content []byte, file string, env string, logger *zap.Sugared
 	c := &StateCreator{
 		logger: logger,
 		fs:     filesystem.DefaultFileSystem(),
-		Strict: true,
 	}
 	return c.ParseAndLoad(content, filepath.Dir(file), file, env, false, true, nil, nil)
 }


### PR DESCRIPTION
Although it was a public field, it has been true by default and no code turns it off.

Let's remove the field entirely, so that it's theoretically a little bit easier to understand the code.

If any third-party code is using this field, it will break, but it's unlikely- If you ever turned it off, you are likely to have a helmfile.yaml that can be parsed only with Strict=false, which is impossible to be parsed with the standard Helmfile; a portability issue!