### PR TITLE
chore: enhance TopKeys function & adding test cases for malformed lines scenario in TopKeys func 

### DIFF
--- a/pkg/policy/checker.go
+++ b/pkg/policy/checker.go
@@ -82,12 +82,15 @@ func TopKeys(helmfileContent []byte, hasSeparator bool) []string {
 	clines := bytes.Split(helmfileContent, []byte("\n"))
 
 	for _, line := range clines {
-		if topConfigKeysRegex.Match(line) {
-			lineStr := strings.Split(string(line), ":")[0]
-			topKeys = append(topKeys, lineStr)
+		lineStr := strings.TrimSpace(string(line))
+		if lineStr == "" {
+			continue // Skip empty lines
 		}
-		if hasSeparator && separatorRegex.Match(line) {
-			topKeys = append(topKeys, strings.TrimSpace(string(line)))
+		if hasSeparator && separatorRegex.MatchString(lineStr) {
+			topKeys = append(topKeys, lineStr)
+		} else if topConfigKeysRegex.MatchString(lineStr) {
+			topKey := strings.SplitN(lineStr, ":", 2)[0]
+			topKeys = append(topKeys, topKey)
 		}
 	}
 	return topKeys

--- a/pkg/policy/checker_test.go
+++ b/pkg/policy/checker_test.go
@@ -239,3 +239,30 @@ func TestTopKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestTopKeys_MalformedLines(t *testing.T) {
+	tests := []struct {
+		name            string
+		helmfileContent []byte
+		hasSeparator    bool
+		want            []string
+	}{
+		{
+			name:            "malformed lines with special characters",
+			helmfileContent: []byte("bas@es:\nenvironm*ents:\nrele#ases:\n"),
+			want:            nil, // This test expects no valid top keys
+		},
+		{
+			name:            "malformed lines with incomplete key",
+			helmfileContent: []byte("bases\nenvironments:\nreleases:\n"),
+			want:            []string{"environments", "releases"}, // This test expects only valid top keys
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TopKeys(tt.helmfileContent, tt.hasSeparator)
+			require.Equal(t, tt.want, got, "expected %v, got=%v", tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**Updating TopKeys func:**

**Trimming Whitespace:** Using `strings.TrimSpace` to remove any leading or trailing whitespace from the line before processing it. We need to do this because we want any accidental leading or trailing spaces removed before processing the line.

**Skipping Empty Lines:** Skipping over any empty lines to avoid unnecessary processing. We need to do this so we can avoid adding any empty keys to the list

**Consistent String Matching:** Using MatchString instead of Match to directly work with strings, improving readability.
Using SplitN: strings.SplitN with n=2 ensures that only the first occurrence of : is used to split the string, making it more efficient.

**Tests added:**

**Testing malformed lines with special characters:** This test scenario makes sure that lines with special characters or unusual formatting do not result in valid `TopKeys`

**Testing Malformed lines with incomplete key:** The test will make sure that lines missing a colon (:) are ignored, and only properly formatted lines are returned as `TopKeys`
