### PR TITLE
feat: update cache dir func with better error handling

### DIFF
--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	neturl "net/url"
 	"os"
@@ -36,20 +37,20 @@ func init() {
 
 func CacheDir() string {
 	if h := os.Getenv("CACHE_HOME"); h != "" {
-		fmt.Printf("Using CACHE_HOME: %s\n", h)
+		log.Printf("Using CACHE_HOME: %s\n", h)
 		return h
 	}
 
 	dir, err := os.UserCacheDir()
 	if err != nil {
-		fmt.Printf("Error getting user cache directory: %v\n", err)
-		fmt.Println("Falling back to relative path with hidden directory: .helmfile")
+		log.Printf("Error getting user cache directory: %v\n", err)
+		log.Println("Falling back to relative path with hidden directory: .helmfile")
 		// Fall back to relative path with hidden directory
 		return ".helmfile"
 	}
 
 	cacheDir := filepath.Join(dir, "helmfile")
-	fmt.Printf("Using user cache directory: %s\n", cacheDir)
+	log.Printf("Using user cache directory: %s\n", cacheDir)
 	return cacheDir
 }
 

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -35,16 +35,22 @@ func init() {
 }
 
 func CacheDir() string {
-	if h := os.Getenv(envvar.CacheHome); h != "" {
+	if h := os.Getenv("CACHE_HOME"); h != "" {
+		fmt.Printf("Using CACHE_HOME: %s\n", h)
 		return h
 	}
 
 	dir, err := os.UserCacheDir()
 	if err != nil {
-		// fall back to relative path with hidden directory
+		fmt.Printf("Error getting user cache directory: %v\n", err)
+		fmt.Println("Falling back to relative path with hidden directory: .helmfile")
+		// Fall back to relative path with hidden directory
 		return ".helmfile"
 	}
-	return filepath.Join(dir, "helmfile")
+
+	cacheDir := filepath.Join(dir, "helmfile")
+	fmt.Printf("Using user cache directory: %s\n", cacheDir)
+	return cacheDir
 }
 
 type Remote struct {


### PR DESCRIPTION
**Enhancements Compared to Original Function**

**Detailed Logging:**

**Before:** There was no logging for the CACHE_HOME environment variable or errors in os.UserCacheDir().

**After:**
Logs the value of the CACHE_HOME environment variable when it is set.
Logs the chosen cache directory path when using os.UserCacheDir().
Logs error details and the fallback path when os.UserCacheDir() fails.

**Error Handling and Fallback:**

**Before**: If os.UserCacheDir() fails, the function silently falls back to ".helmfile".

**After:**
Explicitly logs the error encountered when os.UserCacheDir() fails.
Provides a clear message that the fallback path is being used.
