### PR TITLE
chore: Update Dockerfile based on CI lint warning

### DIFF
--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -14,7 +14,7 @@ RUN make static-${TARGETOS}-${TARGETARCH}
 
 FROM debian:stable-slim
 
-LABEL org.opencontainers.image.source https://github.com/helmfile/helmfile
+LABEL org.opencontainers.image.source=https://github.com/helmfile/helmfile
 
 RUN apt update -qq && \
     apt install --no-install-recommends -y \


### PR DESCRIPTION

![Screenshot from 2024-08-12 10-33-12](https://github.com/user-attachments/assets/d4c1b94b-1c73-4396-b047-3c3731e01b12)

**On the following pull request:**

