### PR TITLE
feat: adding ability for for charts to be pulled with plain HTTP

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -161,7 +161,7 @@ repositories:
 - name: skipTLS
   url: https://ss.my-insecure-domain.com
   skipTLSVerify: true
-# Advanced configuration: If you Repo only supports Plain HTTP
+# Advanced configuration: Connect to a repo served over plain http (skipTLS must be set to false)
 - name: plainHTTP
   url: http://just.http.domain.com
   plainHttp: true
@@ -227,8 +227,8 @@ helmDefaults:
   cascade: "background"
   # insecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
   insecureSkipTLSVerify: false
-  # plainHttp is true if fetching the remote shart should be done using HTTP
-  plainHttp: true
+  # plainHttp is true if fetching the remote chart should be done using HTTP (insecureSkipTLSVerify must be set to false)
+  plainHttp: false
   # --wait flag for destroy/delete, if set to true, will wait until all resources are deleted before mark delete command as successful
   deleteWait: false
   # Timeout is the time in seconds to wait for helmfile destroy/delete (default 300)
@@ -345,8 +345,8 @@ releases:
     cascade: "background"
     # insecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
     insecureSkipTLSVerify: false
-    # plainHttp is true if fetching the remote shart should be done using HTTP
-    plainHttp: true
+    # plainHttp is true if fetching the remote chart should be done using HTTP (insecureSkipTLSVerify must be set to false)
+    plainHttp: false
     # suppressDiff skip the helm diff output. Useful for charts which produces large not helpful diff, default: false
     suppressDiff: false
     # suppressOutputLineRegex is a list of regex patterns to suppress output lines from helm diff (default []), available in helmfile v0.162.0 

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,7 +161,7 @@ repositories:
 - name: skipTLS
   url: https://ss.my-insecure-domain.com
   skipTLSVerify: true
-# Advanced configuration: Connect to a repo served over plain http (skipTLS must be set to false)
+# Advanced configuration: Connect to a repo served over plain http
 - name: plainHTTP
   url: http://just.http.domain.com
   plainHttp: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -227,7 +227,7 @@ helmDefaults:
   cascade: "background"
   # insecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
   insecureSkipTLSVerify: false
-  # plainHttp is true if fetching the remote chart should be done using HTTP (insecureSkipTLSVerify must be set to false)
+  # plainHttp is true if fetching the remote chart should be done using HTTP
   plainHttp: false
   # --wait flag for destroy/delete, if set to true, will wait until all resources are deleted before mark delete command as successful
   deleteWait: false
@@ -345,7 +345,7 @@ releases:
     cascade: "background"
     # insecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
     insecureSkipTLSVerify: false
-    # plainHttp is true if fetching the remote chart should be done using HTTP (insecureSkipTLSVerify must be set to false)
+    # plainHttp is true if fetching the remote chart should be done using HTTP
     plainHttp: false
     # suppressDiff skip the helm diff output. Useful for charts which produces large not helpful diff, default: false
     suppressDiff: false

--- a/docs/index.md
+++ b/docs/index.md
@@ -161,6 +161,10 @@ repositories:
 - name: skipTLS
   url: https://ss.my-insecure-domain.com
   skipTLSVerify: true
+# Advanced configuration: If you Repo only supports Plain HTTP
+- name: plainHTTP
+  url: http://just.http.domain.com
+  plainHttp: true
 
 # context: kube-context # this directive is deprecated, please consider using helmDefaults.kubeContext
 
@@ -223,6 +227,8 @@ helmDefaults:
   cascade: "background"
   # insecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
   insecureSkipTLSVerify: false
+  # plainHttp is true if fetching the remote shart should be done using HTTP
+  plainHttp: true
   # --wait flag for destroy/delete, if set to true, will wait until all resources are deleted before mark delete command as successful
   deleteWait: false
   # Timeout is the time in seconds to wait for helmfile destroy/delete (default 300)
@@ -339,6 +345,8 @@ releases:
     cascade: "background"
     # insecureSkipTLSVerify is true if the TLS verification should be skipped when fetching remote chart
     insecureSkipTLSVerify: false
+    # plainHttp is true if fetching the remote shart should be done using HTTP
+    plainHttp: true
     # suppressDiff skip the helm diff output. Useful for charts which produces large not helpful diff, default: false
     suppressDiff: false
     # suppressOutputLineRegex is a list of regex patterns to suppress output lines from helm diff (default []), available in helmfile v0.162.0 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2605,20 +2605,16 @@ func (st *HelmState) kubeConnectionFlags(release *ReleaseSpec) []string {
 }
 
 func (st *HelmState) appendChartDownloadTLSFlags(flags []string, release *ReleaseSpec) []string {
-	switch {
-	case release.InsecureSkipTLSVerify:
-		flags = append(flags, "--insecure-skip-tls-verify")
-	case st.HelmDefaults.InsecureSkipTLSVerify:
+	repo, _ := st.GetRepositoryAndNameFromChartName(release.Chart)
+	if release.InsecureSkipTLSVerify || st.HelmDefaults.InsecureSkipTLSVerify || repo.SkipTLSVerify {
 		flags = append(flags, "--insecure-skip-tls-verify")
 	}
 	return flags
 }
 
 func (st *HelmState) appendChartDownloadPlainHttpFlags(flags []string, release *ReleaseSpec) []string {
-	switch {
-	case release.PlainHttp:
-		flags = append(flags, "--plain-http")
-	case st.HelmDefaults.PlainHttp:
+	repo, _ := st.GetRepositoryAndNameFromChartName(release.Chart)
+	if release.PlainHttp || st.HelmDefaults.PlainHttp || repo.PlainHttp {
 		flags = append(flags, "--plain-http")
 	}
 	return flags

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2605,16 +2605,26 @@ func (st *HelmState) kubeConnectionFlags(release *ReleaseSpec) []string {
 }
 
 func (st *HelmState) appendChartDownloadTLSFlags(flags []string, release *ReleaseSpec) []string {
+	repoSkipTLSVerify := false
 	repo, _ := st.GetRepositoryAndNameFromChartName(release.Chart)
-	if release.InsecureSkipTLSVerify || st.HelmDefaults.InsecureSkipTLSVerify || repo.SkipTLSVerify {
+	if repo != nil {
+		repoSkipTLSVerify = repo.SkipTLSVerify
+	}
+
+	if release.InsecureSkipTLSVerify || st.HelmDefaults.InsecureSkipTLSVerify || repoSkipTLSVerify {
 		flags = append(flags, "--insecure-skip-tls-verify")
 	}
 	return flags
 }
 
 func (st *HelmState) appendChartDownloadPlainHttpFlags(flags []string, release *ReleaseSpec) []string {
+	repoPlainHttp := false
 	repo, _ := st.GetRepositoryAndNameFromChartName(release.Chart)
-	if release.PlainHttp || st.HelmDefaults.PlainHttp || repo.PlainHttp {
+	if repo != nil {
+		repoPlainHttp = repo.PlainHttp
+	}
+
+	if release.PlainHttp || st.HelmDefaults.PlainHttp || repoPlainHttp {
 		flags = append(flags, "--plain-http")
 	}
 	return flags

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2861,6 +2861,9 @@ func (st *HelmState) chartOCIFlags(r *ReleaseSpec) []string {
 		if repo.SkipTLSVerify {
 			flags = append(flags, "--insecure-skip-tls-verify")
 		}
+		if repo.PlainHttp {
+			flags = append(flags, "--plain-http")
+		}
 		if repo.Verify {
 			flags = append(flags, "--verify")
 		}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2613,8 +2613,11 @@ func (st *HelmState) appendChartDownloadFlags(flags []string, release *ReleaseSp
 
 	if release.PlainHttp || st.HelmDefaults.PlainHttp || repoPlainHttp {
 		flags = append(flags, "--plain-http")
-	} else if release.InsecureSkipTLSVerify || st.HelmDefaults.InsecureSkipTLSVerify || repoSkipTLSVerify {
 		// --insecure-skip-tls-verify nullifies --plain-http in helm, omit it if PlainHttp is specified
+		return flags
+	}
+
+	if release.InsecureSkipTLSVerify || st.HelmDefaults.InsecureSkipTLSVerify || repoSkipTLSVerify {
 		flags = append(flags, "--insecure-skip-tls-verify")
 	}
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2200,8 +2200,7 @@ func (st *HelmState) TestReleases(helm helmexec.Interface, cleanup bool, timeout
 		}
 
 		flags = st.appendConnectionFlags(flags, &release)
-		flags = st.appendChartDownloadTLSFlags(flags, &release)
-		flags = st.appendChartDownloadPlainHttpFlags(flags, &release)
+		flags = st.appendChartDownloadFlags(flags, &release)
 
 		return helm.TestRelease(st.createHelmContext(&release, workerIndex), release.Name, flags...)
 	})
@@ -2604,29 +2603,21 @@ func (st *HelmState) kubeConnectionFlags(release *ReleaseSpec) []string {
 	return flags
 }
 
-func (st *HelmState) appendChartDownloadTLSFlags(flags []string, release *ReleaseSpec) []string {
-	repoSkipTLSVerify := false
-	repo, _ := st.GetRepositoryAndNameFromChartName(release.Chart)
-	if repo != nil {
-		repoSkipTLSVerify = repo.SkipTLSVerify
-	}
-
-	if release.InsecureSkipTLSVerify || st.HelmDefaults.InsecureSkipTLSVerify || repoSkipTLSVerify {
-		flags = append(flags, "--insecure-skip-tls-verify")
-	}
-	return flags
-}
-
-func (st *HelmState) appendChartDownloadPlainHttpFlags(flags []string, release *ReleaseSpec) []string {
-	repoPlainHttp := false
+func (st *HelmState) appendChartDownloadFlags(flags []string, release *ReleaseSpec) []string {
+	var repoSkipTLSVerify, repoPlainHttp bool
 	repo, _ := st.GetRepositoryAndNameFromChartName(release.Chart)
 	if repo != nil {
 		repoPlainHttp = repo.PlainHttp
+		repoSkipTLSVerify = repo.SkipTLSVerify
 	}
 
 	if release.PlainHttp || st.HelmDefaults.PlainHttp || repoPlainHttp {
 		flags = append(flags, "--plain-http")
+	} else if release.InsecureSkipTLSVerify || st.HelmDefaults.InsecureSkipTLSVerify || repoSkipTLSVerify {
+		// --insecure-skip-tls-verify nullifies --plain-http in helm, omit it if PlainHttp is specified
+		flags = append(flags, "--insecure-skip-tls-verify")
 	}
+
 	return flags
 }
 
@@ -2696,8 +2687,7 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 	}
 
 	flags = st.appendConnectionFlags(flags, release)
-	flags = st.appendChartDownloadTLSFlags(flags, release)
-	flags = st.appendChartDownloadPlainHttpFlags(flags, release)
+	flags = st.appendChartDownloadFlags(flags, release)
 
 	flags = st.appendHelmXFlags(flags, release)
 
@@ -2742,9 +2732,8 @@ func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseS
 	flags = st.appendPostRenderFlags(flags, release, postRenderer)
 	flags = st.appendPostRenderArgsFlags(flags, release, postRendererArgs)
 	flags = st.appendApiVersionsFlags(flags, release, kubeVersion)
-	flags = st.appendChartDownloadTLSFlags(flags, release)
+	flags = st.appendChartDownloadFlags(flags, release)
 	flags = st.appendShowOnlyFlags(flags, showOnly)
-	flags = st.appendChartDownloadPlainHttpFlags(flags, release)
 
 	common, files, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {
@@ -2786,21 +2775,24 @@ func (st *HelmState) flagsForDiff(helm helmexec.Interface, release *ReleaseSpec,
 
 	flags = st.appendConnectionFlags(flags, release)
 
-	if st.HelmDefaults.InsecureSkipTLSVerify || release.InsecureSkipTLSVerify {
-		diffVersion, err := helmexec.GetPluginVersion("diff", settings.PluginsDirectory)
-		if err != nil {
-			return nil, nil, err
-		}
-		dv, _ := semver.NewVersion("v3.8.1")
+	flags = st.appendChartDownloadFlags(flags, release)
 
-		if diffVersion.LessThan(dv) {
-			return nil, nil, fmt.Errorf("insecureSkipTLSVerify is not supported by helm-diff plugin version %s, please use at least v3.8.1", diffVersion)
+	for _, flag := range flags {
+		if flag == "--insecure-skip-tls-verify" {
+			diffVersion, err := helmexec.GetPluginVersion("diff", settings.PluginsDirectory)
+			if err != nil {
+				return nil, nil, err
+			}
+			dv, _ := semver.NewVersion("v3.8.1")
+
+			if diffVersion.LessThan(dv) {
+				return nil, nil, fmt.Errorf("insecureSkipTLSVerify is not supported by helm-diff plugin version %s, please use at least v3.8.1", diffVersion)
+			}
+
+			break
 		}
-		flags = st.appendChartDownloadTLSFlags(flags, release)
 	}
 
-	flags = st.appendChartDownloadTLSFlags(flags, release)
-	flags = st.appendChartDownloadPlainHttpFlags(flags, release)
 	flags = st.appendHelmXFlags(flags, release)
 
 	postRenderer := ""
@@ -2858,17 +2850,19 @@ func (st *HelmState) chartOCIFlags(r *ReleaseSpec) []string {
 	flags := []string{}
 	repo, _ := st.GetRepositoryAndNameFromChartName(r.Chart)
 	if repo != nil {
-		if repo.CaFile != "" {
-			flags = append(flags, "--ca-file", repo.CaFile)
-		}
-		if repo.CertFile != "" && repo.KeyFile != "" {
-			flags = append(flags, "--cert-file", repo.CertFile, "--key-file", repo.KeyFile)
-		}
-		if repo.SkipTLSVerify {
-			flags = append(flags, "--insecure-skip-tls-verify")
-		}
 		if repo.PlainHttp {
 			flags = append(flags, "--plain-http")
+		} else {
+			// TLS options will nullify --plain-http in helm if passed, omit it them PlainHttp is specified
+			if repo.SkipTLSVerify {
+				flags = append(flags, "--insecure-skip-tls-verify")
+			}
+			if repo.CaFile != "" {
+				flags = append(flags, "--ca-file", repo.CaFile)
+			}
+			if repo.CertFile != "" && repo.KeyFile != "" {
+				flags = append(flags, "--cert-file", repo.CertFile, "--key-file", repo.KeyFile)
+			}
 		}
 		if repo.Verify {
 			flags = append(flags, "--verify")

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -3815,7 +3815,8 @@ func TestHelmState_chartOCIFlags(t *testing.T) {
 				},
 			},
 			expected: []string{
-				"--ca-file foo",
+				"--ca-file",
+				"foo",
 			},
 		},
 		{
@@ -3835,9 +3836,7 @@ func TestHelmState_chartOCIFlags(t *testing.T) {
 					},
 				},
 			},
-			expected: []string{
-				"",
-			},
+			expected: []string{},
 		},
 		{
 			name: "CertFile disabled and KeyFile enabled",
@@ -3856,9 +3855,7 @@ func TestHelmState_chartOCIFlags(t *testing.T) {
 					},
 				},
 			},
-			expected: []string{
-				"",
-			},
+			expected: []string{},
 		},
 		{
 			name: "CertFile and KeyFile enabled",
@@ -3879,7 +3876,10 @@ func TestHelmState_chartOCIFlags(t *testing.T) {
 				},
 			},
 			expected: []string{
-				"--cert-file foo --key-file bar",
+				"--cert-file",
+				"foo",
+				"--key-file",
+				"bar",
 			},
 		},
 		{
@@ -3970,7 +3970,9 @@ func TestHelmState_chartOCIFlags(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			st := &HelmState{}
+			st := &HelmState{
+				ReleaseSetSpec: *tt.spec,
+			}
 			flags := st.chartOCIFlags(&tt.spec.Releases[0])
 			require.Equal(t, tt.expected, flags)
 		})

--- a/pkg/state/temp_test.go
+++ b/pkg/state/temp_test.go
@@ -38,39 +38,39 @@ func TestGenerateID(t *testing.T) {
 	run(testcase{
 		subject: "baseline",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
-		want:    "foo-values-85888d5bcb",
+		want:    "foo-values-867bdd68d",
 	})
 
 	run(testcase{
 		subject: "different bytes content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    []byte(`{"k":"v"}`),
-		want:    "foo-values-77d5b4b567",
+		want:    "foo-values-55d7dc5f87",
 	})
 
 	run(testcase{
 		subject: "different map content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    map[string]any{"k": "v"},
-		want:    "foo-values-6b5c7d665c",
+		want:    "foo-values-58bdcf44f7",
 	})
 
 	run(testcase{
 		subject: "different chart",
 		release: ReleaseSpec{Name: "foo", Chart: "stable/envoy"},
-		want:    "foo-values-5b86b7bc7",
+		want:    "foo-values-67dcddd85",
 	})
 
 	run(testcase{
 		subject: "different name",
 		release: ReleaseSpec{Name: "bar", Chart: "incubator/raw"},
-		want:    "bar-values-bcb888989",
+		want:    "bar-values-6dd4989f97",
 	})
 
 	run(testcase{
 		subject: "specific ns",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw", Namespace: "myns"},
-		want:    "myns-foo-values-7599b8cdcf",
+		want:    "myns-foo-values-755d4487dc",
 	})
 
 	for id, n := range ids {


### PR DESCRIPTION
accomplished by:

- Adding PlainHttp attribute to RepositorySpec, HelmDefault, ReleaseSpec
- When set to true, pass `--plain-http` to helm commands

Tweaked https://github.com/helmfile/helmfile/pull/1228 by @hoangelos

Resolves https://github.com/helmfile/helmfile/discussions/1224