### PR TITLE
chore: Update Ubuntu image to LTS version 24.04

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -12,7 +12,7 @@ RUN make static-${TARGETOS}-${TARGETARCH}
 
 # -----------------------------------------------------------------------------
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 LABEL org.opencontainers.image.source=https://github.com/helmfile/helmfile
 


### PR DESCRIPTION
The Ubuntu version 20.04 (LTS) of the Ubuntu-based container image is pretty outdated (even though still supported). With this change the version is updated to version 24.04 (also LTS), which got released in April this year and will be supported until April 2029. This will be useful to everyone who builds on top of the image with more up-to-date packages.