### PR TITLE
feat(helm-version): Update helm version to v3.16.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,20 +71,20 @@ jobs:
             plugin-diff-version: 3.9.11
             extra-helmfile-flags: ''
             v1mode: ''
-          - helm-version: v3.16.1
+          - helm-version: v3.16.2
             kustomize-version: v5.2.1
             plugin-secrets-version: 3.15.0
             plugin-diff-version: 3.8.1
             extra-helmfile-flags: ''
             v1mode: ''
-          - helm-version: v3.16.1
+          - helm-version: v3.16.2
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.0
             plugin-diff-version: 3.9.11
             extra-helmfile-flags: ''
             v1mode: ''
           # Helmfile v1
-          - helm-version: v3.16.1
+          - helm-version: v3.16.2
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.0
             plugin-diff-version: 3.9.11
@@ -92,7 +92,7 @@ jobs:
             v1mode: 'true'
           # In case you need to test some optional helmfile features,
           # enable it via extra-helmfile-flags below.
-          - helm-version: v3.16.1
+          - helm-version: v3.16.2
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.0
             plugin-diff-version: 3.9.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.16.1"
+ARG HELM_VERSION="v3.16.2"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -38,8 +38,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="e57e826410269d72be3113333dbfaac0d8dfdd1b0cc4e9cb08bdf97722731ca9"  ;; \
-    "linux/arm64")  HELM_SHA256="780b5b86f0db5546769b3e9f0204713bbdd2f6696dfdaac122fbe7f2f31541d2"  ;; \
+    "linux/amd64")  HELM_SHA256="9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb"  ;; \
+    "linux/arm64")  HELM_SHA256="1888301aeb7d08a03b6d9f4d2b73dcd09b89c41577e80e3455c113629fc657a4"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -35,7 +35,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.16.1"
+ARG HELM_VERSION="v3.16.2"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -43,8 +43,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="e57e826410269d72be3113333dbfaac0d8dfdd1b0cc4e9cb08bdf97722731ca9"  ;; \
-    "linux/arm64")  HELM_SHA256="780b5b86f0db5546769b3e9f0204713bbdd2f6696dfdaac122fbe7f2f31541d2"  ;; \
+    "linux/amd64")  HELM_SHA256="9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb"  ;; \
+    "linux/arm64")  HELM_SHA256="1888301aeb7d08a03b6d9f4d2b73dcd09b89c41577e80e3455c113629fc657a4"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -35,7 +35,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.16.1"
+ARG HELM_VERSION="v3.16.2"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -43,8 +43,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="e57e826410269d72be3113333dbfaac0d8dfdd1b0cc4e9cb08bdf97722731ca9"  ;; \
-    "linux/arm64")  HELM_SHA256="780b5b86f0db5546769b3e9f0204713bbdd2f6696dfdaac122fbe7f2f31541d2"  ;; \
+    "linux/amd64")  HELM_SHA256="9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb"  ;; \
+    "linux/arm64")  HELM_SHA256="1888301aeb7d08a03b6d9f4d2b73dcd09b89c41577e80e3455c113629fc657a4"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	HelmRequiredVersion           = "v3.15.4"
-	HelmRecommendedVersion        = "v3.16.1"
+	HelmRecommendedVersion        = "v3.16.2"
 	HelmDiffRecommendedVersion    = "v3.9.11"
 	HelmSecretsRecommendedVersion = "v4.6.0"
 	HelmGitRecommendedVersion     = "v0.15.1"


### PR DESCRIPTION
This pull request includes updates to the Helm version across multiple files to ensure consistency and compatibility. The changes primarily involve updating the Helm version from `v3.16.1` to `v3.16.2` and updating the corresponding SHA256 checksums.

### Updates to Helm Version:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL74-R95): Updated Helm version from `v3.16.1` to `v3.16.2` in multiple sections to ensure the CI workflow uses the latest version.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L33-R42): Changed Helm version to `v3.16.2` and updated SHA256 checksums for `linux/amd64` and `linux/arm64`.

* [`Dockerfile.debian-stable-slim`](diffhunk://#diff-ba602f969c43d8bdc4cbe0c2243476dfcc51f818d28f079418302e94cf7e791aL38-R47): Updated Helm version to `v3.16.2` and modified SHA256 checksums for `linux/amd64` and `linux/arm64` architectures.

* [`Dockerfile.ubuntu`](diffhunk://#diff-b4c6189f9184e61338a887d10410ec33e466f2fdba640cb632fab869dcb8b289L38-R47): Set Helm version to `v3.16.2` and revised SHA256 checksums for `linux/amd64` and `linux/arm64` platforms.

* [`pkg/app/init.go`](diffhunk://#diff-a8d88c94aa5b407b495d262c095333250dae969e2cdde4db3d3783394e742e9bL21-R21): Updated `HelmRecommendedVersion` constant to `v3.16.2` to reflect the new recommended version.