### PR TITLE
feat: improve summary for releases failed to delete

### DIFF
--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -2808,7 +2808,7 @@ func TestHelmState_Delete(t *testing.T) {
 			affectedReleases := AffectedReleases{}
 			errs := state.DeleteReleases(&affectedReleases, helm, 1, tt.purge, "")
 			if errs != nil {
-				if !tt.wantErr || len(affectedReleases.Failed) != 1 || affectedReleases.Failed[0].Name != release.Name {
+				if !tt.wantErr || len(affectedReleases.DeleteFailed) != 1 || affectedReleases.DeleteFailed[0].Name != release.Name {
 					t.Errorf("DeleteReleases() for %s error = %v, wantErr %v", tt.name, errs, tt.wantErr)
 					return
 				}


### PR DESCRIPTION
I believe this is better because:

- When in `sync` operation, the summary now distinguishes between failed releases and failed to delete releases, which is more informative.
- When in `destroy` operation, the summary of failed releases no longer includes information that are only relevant to `sync` operation, like `CHART` name and version, which is not even required for the `helm delete` command.

Previous:

```console
$ helmfile destroy
DELETED RELEASES:
NAME    NAMESPACE   DURATION
raw-1                     0s


FAILED RELEASES:
NAME    NAMESPACE   CHART                                                                          VERSION   DURATION
raw-2               https://github.com/dysnix/charts/releases/download/raw-v0.3.2/raw-v0.3.2.tgz                   0s
```

After:

```console
$ helmfile destroy
DELETED RELEASES:
NAME    NAMESPACE   DURATION
raw-1                     0s


FAILED TO DELETE RELEASES:
NAME    NAMESPACE   DURATION
raw-2                     0s
```
