### PR TITLE
Introducing Helmfile Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/helmfile/helmfile)](https://goreportcard.com/report/github.com/helmfile/helmfile)
 [![Slack Community #helmfile](https://slack.sweetops.com/badge.svg)](https://slack.sweetops.com)
 [![Documentation](https://readthedocs.org/projects/helmfile/badge/?version=latest&style=flat)](https://helmfile.readthedocs.io/en/latest/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Helmfile%20Guru-006BFF)](https://gurubase.io/g/helmfile)
 
 Deploy Kubernetes Helm Charts
 <br />


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Helmfile Guru](https://gurubase.io/g/helmfile) to Gurubase. Helmfile Guru uses the data from this repo and data from the [docs](https://helmfile.readthedocs.io/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Helmfile Guru", which highlights that Helmfile now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Helmfile Guru in Gurubase, just let me know that's totally fine.