### PR TITLE
fix(maputil): prevent nil value overwrite

### DIFF
--- a/pkg/maputil/maputil.go
+++ b/pkg/maputil/maputil.go
@@ -231,6 +231,9 @@ func MergeMaps(a, b map[string]interface{}) map[string]interface{} {
 		out[k] = v
 	}
 	for k, v := range b {
+		if v == nil {
+			continue
+		}
 		if v, ok := v.(map[string]interface{}); ok {
 			if bv, ok := out[k]; ok {
 				if bv, ok := bv.(map[string]interface{}); ok {

--- a/pkg/maputil/maputil_test.go
+++ b/pkg/maputil/maputil_test.go
@@ -215,6 +215,10 @@ func TestMapUtil_MergeMaps(t *testing.T) {
 			"app1": 3,
 		},
 	}
+	map5 := map[string]interface{}{
+		"logLevel":     "error",
+		"replicaCount": nil,
+	}
 
 	testMap := MergeMaps(map2, map4)
 	equal := reflect.DeepEqual(testMap, map4)
@@ -246,5 +250,18 @@ func TestMapUtil_MergeMaps(t *testing.T) {
 	equal = reflect.DeepEqual(testMap, expectedMap)
 	if !equal {
 		t.Errorf("Expected a map with different keys to merge properly with another map. Expected: %v, got %v", expectedMap, testMap)
+	}
+
+	testMap = MergeMaps(map3, map5)
+	expectedMap = map[string]interface{}{
+		"logLevel": "error",
+		"replicaCount": map[string]any{
+			"app1":    3,
+			"awesome": 4,
+		},
+	}
+	equal = reflect.DeepEqual(testMap, expectedMap)
+	if !equal {
+		t.Errorf("Expected a map with empty value not to overwrite another map's value. Expected: %v, got %v", expectedMap, testMap)
 	}
 }


### PR DESCRIPTION
recently in our project, I faced a hidden issue where empty values from a yaml overwrites the whole key

for example in the base.yaml, we have : 
```yaml
key_1:
  a: "a"
  b:
    b_1: "b_1"
    b_2: "b_2"
key_2:
  xxx: "something"
```
and another yaml to overwrite the base one:
```yaml
key_1:   \# merely a placeholder

key_2:
  xxx: "something else"
```

then the result would be:
```yaml
key_1:
key_2:
  xxx: "something else"
```
The `key_1` field is overwritten by the empty value. I figure it's a better idea not to overwrite with an nil value in this case.