### PR TITLE
feat: refactor label creation in state.go

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2263,22 +2263,21 @@ func markExcludedReleases(releases []ReleaseSpec, selectors []string, commonLabe
 		filters = append(filters, f)
 	}
 	for _, r := range releases {
-		// Do not add any label without any filter, see #276
-		if len(filters) > 0 {
-			if r.Labels == nil {
-				r.Labels = map[string]string{}
-			}
-			// Let the release name, namespace, and chart be used as a tag
-			r.Labels["name"] = r.Name
-			r.Labels["namespace"] = r.Namespace
-			// Strip off just the last portion for the name stable/newrelic would give newrelic
-			chartSplit := strings.Split(r.Chart, "/")
-			r.Labels["chart"] = chartSplit[len(chartSplit)-1]
-			// Merge CommonLabels into release labels
-			for k, v := range commonLabels {
-				r.Labels[k] = v
-			}
+		orginReleaseLabel := r.Labels
+		if r.Labels == nil {
+			r.Labels = map[string]string{}
 		}
+		// Let the release name, namespace, and chart be used as a tag
+		r.Labels["name"] = r.Name
+		r.Labels["namespace"] = r.Namespace
+		// Strip off just the last portion for the name stable/newrelic would give newrelic
+		chartSplit := strings.Split(r.Chart, "/")
+		r.Labels["chart"] = chartSplit[len(chartSplit)-1]
+		// Merge CommonLabels into release labels
+		for k, v := range commonLabels {
+			r.Labels[k] = v
+		}
+
 		var filterMatch bool
 		for _, f := range filters {
 			if r.Labels == nil {
@@ -2294,6 +2293,8 @@ func markExcludedReleases(releases []ReleaseSpec, selectors []string, commonLabe
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse condition in release %s: %w", r.Name, err)
 		}
+		// reset the labels to the original
+		r.Labels = orginReleaseLabel
 		res := Release{
 			ReleaseSpec: r,
 			Filtered:    (len(filters) > 0 && !filterMatch) || (!conditionMatch),


### PR DESCRIPTION
This pull request makes changes to the `markExcludedReleases` function in `pkg/state/state.go` to ensure that the original labels of releases are preserved and restored after processing.

Key changes include:

### Label Management:

* Introduced a new variable `orginReleaseLabel` to store the original labels of each release before any modifications. (`pkg/state/state.go`, [pkg/state/state.goL2266-R2266](diffhunk://#diff-7e4e87a1e777423a3d9a915e00fb78a9c4fc2f4c476863f60b67e89b9c635697L2266-R2266))
* Added code to reset the release labels to their original state after processing each release. (`pkg/state/state.go`, [pkg/state/state.goR2296-R2297](diffhunk://#diff-7e4e87a1e777423a3d9a915e00fb78a9c4fc2f4c476863f60b67e89b9c635697R2296-R2297))

### Code Cleanup:

* Removed an unnecessary closing brace to improve code readability. (`pkg/state/state.go`, [pkg/state/state.goL2281-R2280](diffhunk://#diff-7e4e87a1e777423a3d9a915e00fb78a9c4fc2f4c476863f60b67e89b9c635697L2281-R2280))