### PR TITLE
fix: this url doesn't work anymore

### DIFF
--- a/test/advanced/helmfile.yaml
+++ b/test/advanced/helmfile.yaml
@@ -1,6 +1,6 @@
 repositories:
 - name: incubator
-  url: https://kubernetes-charts-incubator.storage.googleapis.com
+  url: https://charts.helm.sh/incubator
 
 releases:
 - name: kustomapp


### PR DESCRIPTION
It fixes the error when trying the helmfile.
Error: repo "https://kubernetes-charts-incubator.storage.googleapis.com" is no longer available; try "https://charts.helm.sh/incubator" instead