### PR TITLE
fix: update acme chart URL in input.yaml

### DIFF
--- a/test/e2e/template/helmfile/testdata/snapshot/issue_498_template_go_getter_with_selector/input.yaml
+++ b/test/e2e/template/helmfile/testdata/snapshot/issue_498_template_go_getter_with_selector/input.yaml
@@ -4,7 +4,7 @@ repositories:
 - name: istio
   url: https://istio-release.storage.googleapis.com/charts
 releases:
-- chart: git::https://github.com/joshuasimon-taulia/acme.git@charts/acme?ref=master
+- chart: git::https://github.com/jenkins-x/acme.git@charts/acme?ref=main
   name: acme-jx
   labels:
     values.jenkins-x.io: lock


### PR DESCRIPTION
This pull request includes a change to the `input.yaml` file to update the URL of a chart repository.

* [`test/e2e/template/helmfile/testdata/snapshot/issue_498_template_go_getter_with_selector/input.yaml`](diffhunk://#diff-9d4beeb294b3e6678fef6dc5f84a5d776404b2e83c02a811ec68908df6e11406L7-R7): Changed the chart URL from `https://github.com/joshuasimon-taulia/acme.git@charts/acme?ref=master` to `https://github.com/jenkins-x/acme.git@charts/acme?ref=main`.



https://github.com/jenkins-x/acme.git@charts/acme?ref=main had gone.