### PR TITLE
docs: Add Gurubase badge to README-zh_CN

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -16,6 +16,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/helmfile/helmfile)](https://goreportcard.com/report/github.com/helmfile/helmfile)
 [![Slack Community #helmfile](https://slack.sweetops.com/badge.svg)](https://slack.sweetops.com)
 [![Documentation](https://readthedocs.org/projects/helmfile/badge/?version=latest&style=flat)](https://helmfile.readthedocs.io/en/latest/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Helmfile%20Guru-006BFF)](https://gurubase.io/g/helmfile)
 
 声明式Helm Chart管理工具
 <br />


### PR DESCRIPTION
This pull request includes a small change to the `README-zh_CN.md` file. The change adds a new badge for Gurubase to the list of badges.

* [`README-zh_CN.md`](diffhunk://#diff-099beda0196f3588b806c1d7ace4d054b6a1caf09bfede3b0c1a9ac7cfb74473R19): Added a new badge for Gurubase to the list of badges.