### PR TITLE
build: update Helm version to v3.16.3 in CI and Dockerfiles

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,20 +71,20 @@ jobs:
             plugin-diff-version: 3.9.11
             extra-helmfile-flags: ''
             v1mode: ''
-          - helm-version: v3.16.2
+          - helm-version: v3.16.3
             kustomize-version: v5.2.1
             plugin-secrets-version: 3.15.0
             plugin-diff-version: 3.8.1
             extra-helmfile-flags: ''
             v1mode: ''
-          - helm-version: v3.16.2
+          - helm-version: v3.16.3
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.0
             plugin-diff-version: 3.9.11
             extra-helmfile-flags: ''
             v1mode: ''
           # Helmfile v1
-          - helm-version: v3.16.2
+          - helm-version: v3.16.3
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.0
             plugin-diff-version: 3.9.11
@@ -92,7 +92,7 @@ jobs:
             v1mode: 'true'
           # In case you need to test some optional helmfile features,
           # enable it via extra-helmfile-flags below.
-          - helm-version: v3.16.2
+          - helm-version: v3.16.3
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.0
             plugin-diff-version: 3.9.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.16.2"
+ARG HELM_VERSION="v3.16.3"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -38,8 +38,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb"  ;; \
-    "linux/arm64")  HELM_SHA256="1888301aeb7d08a03b6d9f4d2b73dcd09b89c41577e80e3455c113629fc657a4"  ;; \
+    "linux/amd64")  HELM_SHA256="495d75b404a96fb664f1ca3f8cb01db2210aacc62dbfa1bbab30916abbb20a57"  ;; \
+    "linux/arm64")  HELM_SHA256="3a39f690173086e6eea17674751eb3c8b970c02697e49cecd4093eaa3cf89dcd"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -35,7 +35,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.16.2"
+ARG HELM_VERSION="v3.16.3"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -43,8 +43,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb"  ;; \
-    "linux/arm64")  HELM_SHA256="1888301aeb7d08a03b6d9f4d2b73dcd09b89c41577e80e3455c113629fc657a4"  ;; \
+    "linux/amd64")  HELM_SHA256="495d75b404a96fb664f1ca3f8cb01db2210aacc62dbfa1bbab30916abbb20a57"  ;; \
+    "linux/arm64")  HELM_SHA256="3a39f690173086e6eea17674751eb3c8b970c02697e49cecd4093eaa3cf89dcd"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -35,7 +35,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.16.2"
+ARG HELM_VERSION="v3.16.3"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -43,8 +43,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb"  ;; \
-    "linux/arm64")  HELM_SHA256="1888301aeb7d08a03b6d9f4d2b73dcd09b89c41577e80e3455c113629fc657a4"  ;; \
+    "linux/amd64")  HELM_SHA256="495d75b404a96fb664f1ca3f8cb01db2210aacc62dbfa1bbab30916abbb20a57"  ;; \
+    "linux/arm64")  HELM_SHA256="3a39f690173086e6eea17674751eb3c8b970c02697e49cecd4093eaa3cf89dcd"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	HelmRequiredVersion           = "v3.15.4"
-	HelmRecommendedVersion        = "v3.16.2"
+	HelmRecommendedVersion        = "v3.16.3"
 	HelmDiffRecommendedVersion    = "v3.9.11"
 	HelmSecretsRecommendedVersion = "v4.6.0"
 	HelmGitRecommendedVersion     = "v0.15.1"


### PR DESCRIPTION
This pull request includes several changes to update the Helm version from v3.16.2 to v3.16.3 across various files. The most important changes include updates to the version number and corresponding SHA256 checksums in configuration files and Dockerfiles.

Version updates:

* Updated Helm version from v3.16.2 to v3.16.3 in `.github/workflows/ci.yaml`.
* Updated Helm version from v3.16.2 to v3.16.3 in `Dockerfile`, including changes to the SHA256 checksums for `linux/amd64` and `linux/arm64`.
* Updated Helm version from v3.16.2 to v3.16.3 in `Dockerfile.debian-stable-slim`, including changes to the SHA256 checksums for `linux/amd64` and `linux/arm64`.
* Updated Helm version from v3.16.2 to v3.16.3 in `Dockerfile.ubuntu`, including changes to the SHA256 checksums for `linux/amd64` and `linux/arm64`.
* Updated `HelmRecommendedVersion` from v3.16.2 to v3.16.3 in `pkg/app/init.go`.