### PR TITLE
update example chart URL in remote-secrets doc

### DIFF
--- a/docs/remote-secrets.md
+++ b/docs/remote-secrets.md
@@ -17,8 +17,8 @@ To fetch single key from remote secret storage you can use `fetchSecretValue` te
 
 repositories:
   - name: stable
-    url: https://kubernetes-charts.storage.googleapis.com
-
+    url: https://charts.helm.sh/stable
+---
 environments:
   default:
     values:


### PR DESCRIPTION
- Address changes to the URL of the google chart
- Address warning that helmfile generates about splitting environments and releases

Related to #1808 