### PR TITLE
chore(doc): fix the indent of the selector usage sample yaml

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1347,7 +1347,7 @@ helmfiles:
   - name=prometheus
   - tier=frontend
 - path: apps/b-helmfile.yaml # no selector, so all releases are used
-selectors: []
+  selectors: []
 - path: apps/c-helmfile.yaml # parent selector to be used or cli selector for the initial helmfile
   selectorsInherited: true
 ```


### PR DESCRIPTION
This is a simple fix to the indention.