### PR TITLE
feat(apply): add ignore-release-not-found option

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -72,6 +72,7 @@ func NewApplyCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 	f.BoolVar(&applyOptions.SkipSchemaValidation, "skip-schema-validation", false, `pass --skip-schema-validation to "helm template" or "helm upgrade --install"`)
 	f.StringVar(&applyOptions.Cascade, "cascade", "", "pass cascade to helm exec, default: background")
 	f.StringArrayVar(&applyOptions.SuppressOutputLineRegex, "suppress-output-line-regex", nil, "a list of regex patterns to suppress output lines from the diff output")
+	f.BoolVar(&applyOptions.IgnoreReleaseNotFound, "ignore-release-not-found", false, "Treat release not found as a successful uninstall")
 
 	return cmd
 }

--- a/pkg/config/apply.go
+++ b/pkg/config/apply.go
@@ -70,6 +70,8 @@ type ApplyOptions struct {
 	SyncArgs string
 	// HideNotes is the hide notes flag
 	HideNotes bool
+	// Ignore release not found
+	IgnoreReleaseNotFound bool
 }
 
 // NewApply creates a new Apply
@@ -257,6 +259,12 @@ func (a *ApplyImpl) SyncArgs() string {
 	return a.ApplyOptions.SyncArgs
 }
 
+// Hide Notes returns the HideNotes.
 func (a *ApplyImpl) HideNotes() bool {
 	return a.ApplyOptions.HideNotes
+}
+
+// IgnoreDeprecationWarnings returns the IgnoreDeprecationWarnings.
+func (a *ApplyImpl) IgnoreReleaseNotFound() bool {
+	return a.ApplyOptions.IgnoreReleaseNotFound
 }


### PR DESCRIPTION
fix: https://github.com/helmfile/helmfile/issues/1803

This pull request introduces a new option to handle cases where a release is not found during the application process. The changes add a new flag to the command and update the relevant structures and methods to support this functionality.

Key changes include:

### New Flag Addition:
* [`cmd/apply.go`](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR75): Added a new boolean flag `ignore-release-not-found` to the `NewApplyCmd` function to treat the release not found as a successful uninstall.

### Struct Updates:
* [`pkg/config/apply.go`](diffhunk://#diff-9c1981b259ffcd33444e1fbb03afb3ee368563ed6e10b852a1165199e8005a05R73-R74): Added a new boolean field `IgnoreReleaseNotFound` to the `ApplyOptions` struct to store the state of the new flag.

### Method Updates:
* [`pkg/config/apply.go`](diffhunk://#diff-9c1981b259ffcd33444e1fbb03afb3ee368563ed6e10b852a1165199e8005a05R262-R270): Added a new method `IgnoreReleaseNotFound` to the `ApplyImpl` struct to return the value of the new `IgnoreReleaseNotFound` field.