### PR TITLE
feat(state): add support for setString in ReleaseSpec and HelmState

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -282,6 +282,16 @@ releases:
           domain: {{ requiredEnv "PLATFORM_ID" }}.my-domain.com
           scheme: {{ env "SCHEME" | default "https" }}
     # Use `values` whenever possible!
+    # `setString` translates to helm's `--set-string key=val`
+    setString:
+    # set a single array value in an array, translates to --set-string bar[0]={1,2}
+    - name: bar[0]
+      values:
+      - 1
+      - 2
+    # set a templated value
+    - name: namespace
+      value: {{ .Namespace }}
     # `set` translates to helm's `--set key=val`, that is known to suffer from type issues like https://github.com/roboll/helmfile/issues/608
     set:
     # single value loaded from a local file, translates to --set-file foo.config=path/to/file

--- a/pkg/state/state_exec_tmpl.go
+++ b/pkg/state/state_exec_tmpl.go
@@ -199,6 +199,8 @@ func (st *HelmState) releaseWithInheritedTemplate(r *ReleaseSpec, inheritancePat
 				src.SetValuesTemplate = nil
 			case "set":
 				src.SetValues = nil
+			case "setString":
+				src.SetStringValues = nil
 			case "secrets":
 				src.Secrets = nil
 			default:

--- a/pkg/state/temp_test.go
+++ b/pkg/state/temp_test.go
@@ -38,39 +38,39 @@ func TestGenerateID(t *testing.T) {
 	run(testcase{
 		subject: "baseline",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
-		want:    "foo-values-5db58595d7",
+		want:    "foo-values-5b58697694",
 	})
 
 	run(testcase{
 		subject: "different bytes content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    []byte(`{"k":"v"}`),
-		want:    "foo-values-78d88d86dd",
+		want:    "foo-values-58bff47d77",
 	})
 
 	run(testcase{
 		subject: "different map content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    map[string]any{"k": "v"},
-		want:    "foo-values-f9c8967cd",
+		want:    "foo-values-5fb8948f75",
 	})
 
 	run(testcase{
 		subject: "different chart",
 		release: ReleaseSpec{Name: "foo", Chart: "stable/envoy"},
-		want:    "foo-values-cdfb97444",
+		want:    "foo-values-784b76684f",
 	})
 
 	run(testcase{
 		subject: "different name",
 		release: ReleaseSpec{Name: "bar", Chart: "incubator/raw"},
-		want:    "bar-values-749bc4c6d4",
+		want:    "bar-values-f48df5f49",
 	})
 
 	run(testcase{
 		subject: "specific ns",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw", Namespace: "myns"},
-		want:    "myns-foo-values-7b74fbd6d6",
+		want:    "myns-foo-values-6b68696b8c",
 	})
 
 	for id, n := range ids {


### PR DESCRIPTION
This pull request introduces new functionality for handling `set-string` values in Helm releases and includes corresponding tests. The most important changes are as follows:

### New Functionality for `set-string` Values:

* **Addition of `SetStringValues` field**: A new field `SetStringValues` is added to the `ReleaseSpec` struct to support `set-string` values in Helm releases. (`pkg/state/state.go`)

* **Handling `set-string` flags**: Implemented the `setStringFlags` function to generate the `--set-string` flags for Helm, ensuring proper rendering of values and secrets. (`pkg/state/state.go`)

* **Incorporation in namespace and values flags**: Modified the `namespaceAndValuesFlags` function to include `set-string` flags if `SetStringValues` are present. (`pkg/state/state.go`)

### Testing Enhancements:

* **New test function**: Added `testSetStringValuesTemplate` function to validate the handling of `set-string` values in Helm releases. (`pkg/app/app_test.go`)

* **Integration in test suite**: Included `TestSetStringValuesTemplate` in the test suite to run the new test function with different YAML parsers. (`pkg/app/app_test.go`)

### Miscellaneous:

* **Template inheritance adjustment**: Updated `releaseWithInheritedTemplate` function to handle inheritance of `set-string` values correctly. (`pkg/state/state_exec_tmpl.go`)