### PR TITLE
test(state): add TestHelmState_setStringFlags for setStringFlags method

### DIFF
--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -4203,3 +4203,63 @@ func TestAppendVerifyFlags(t *testing.T) {
 		})
 	}
 }
+
+// TestHelmState_setStringFlags tests the setStringFlags method
+func TestHelmState_setStringFlags(t *testing.T) {
+	tests := []struct {
+		name            string
+		setStringValues []SetValue
+		want            []string
+		wantErr         bool
+	}{
+		{
+			name: "single value",
+			setStringValues: []SetValue{
+				{
+					Name:  "key",
+					Value: "value",
+				},
+			},
+			want:    []string{"--set-string", "key=value"},
+			wantErr: false,
+		},
+		{
+			name: "multiple values",
+			setStringValues: []SetValue{
+				{
+					Name:   "key",
+					Values: []string{"value1", "value2"},
+				},
+			},
+			want:    []string{"--set-string", "key={value1,value2}"},
+			wantErr: false,
+		},
+		{
+			name: "rendered value error",
+			setStringValues: []SetValue{
+				{
+					Name:  "key",
+					Value: "ref+echo://value",
+				},
+			},
+			want:    []string{"--set-string", "key=value"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &HelmState{
+				valsRuntime: valsRuntime,
+			}
+			got, err := st.setStringFlags(tt.setStringValues)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("setStringFlags() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("setStringFlags() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request includes a new test function to the `pkg/state/state_test.go` file. The new function, `TestHelmState_setStringFlags`, tests the `setStringFlags` method of the `HelmState` struct.

New test function:

* [`pkg/state/state_test.go`](diffhunk://#diff-e276c65aad47f6c58e4c8e8dd0192233e623108558fd69805f89743620b9e425R4206-R4265): Added `TestHelmState_setStringFlags` to test various scenarios for the `setStringFlags` method, including single value, multiple values, and rendered value error cases.