### PR TITLE
build: update Helm version to v3.16.4 in CI and Dockerfiles

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,20 +71,20 @@ jobs:
             plugin-diff-version: 3.9.12
             extra-helmfile-flags: ''
             v1mode: ''
-          - helm-version: v3.16.3
+          - helm-version: v3.16.4
             kustomize-version: v5.2.1
             plugin-secrets-version: 3.15.0
             plugin-diff-version: 3.8.1
             extra-helmfile-flags: ''
             v1mode: ''
-          - helm-version: v3.16.3
+          - helm-version: v3.16.4
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.0
             plugin-diff-version: 3.9.12
             extra-helmfile-flags: ''
             v1mode: ''
           # Helmfile v1
-          - helm-version: v3.16.3
+          - helm-version: v3.16.4
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.0
             plugin-diff-version: 3.9.12
@@ -92,7 +92,7 @@ jobs:
             v1mode: 'true'
           # In case you need to test some optional helmfile features,
           # enable it via extra-helmfile-flags below.
-          - helm-version: v3.16.3
+          - helm-version: v3.16.4
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.0
             plugin-diff-version: 3.9.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.16.3"
+ARG HELM_VERSION="v3.16.4"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -38,8 +38,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="f5355c79190951eed23c5432a3b920e071f4c00a64f75e077de0dd4cb7b294ea"  ;; \
-    "linux/arm64")  HELM_SHA256="5bd34ed774df6914b323ff84a0a156ea6ff2ba1eaf0113962fa773f3f9def798"  ;; \
+    "linux/amd64")  HELM_SHA256="fc307327959aa38ed8f9f7e66d45492bb022a66c3e5da6063958254b9767d179"  ;; \
+    "linux/arm64")  HELM_SHA256="d3f8f15b3d9ec8c8678fbf3280c3e5902efabe5912e2f9fcf29107efbc8ead69"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -35,7 +35,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.16.3"
+ARG HELM_VERSION="v3.16.4"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -43,8 +43,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="f5355c79190951eed23c5432a3b920e071f4c00a64f75e077de0dd4cb7b294ea"  ;; \
-    "linux/arm64")  HELM_SHA256="5bd34ed774df6914b323ff84a0a156ea6ff2ba1eaf0113962fa773f3f9def798"  ;; \
+    "linux/amd64")  HELM_SHA256="fc307327959aa38ed8f9f7e66d45492bb022a66c3e5da6063958254b9767d179"  ;; \
+    "linux/arm64")  HELM_SHA256="d3f8f15b3d9ec8c8678fbf3280c3e5902efabe5912e2f9fcf29107efbc8ead69"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -35,7 +35,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.16.3"
+ARG HELM_VERSION="v3.16.4"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -43,8 +43,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="f5355c79190951eed23c5432a3b920e071f4c00a64f75e077de0dd4cb7b294ea"  ;; \
-    "linux/arm64")  HELM_SHA256="5bd34ed774df6914b323ff84a0a156ea6ff2ba1eaf0113962fa773f3f9def798"  ;; \
+    "linux/amd64")  HELM_SHA256="fc307327959aa38ed8f9f7e66d45492bb022a66c3e5da6063958254b9767d179"  ;; \
+    "linux/arm64")  HELM_SHA256="d3f8f15b3d9ec8c8678fbf3280c3e5902efabe5912e2f9fcf29107efbc8ead69"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	HelmRequiredVersion           = "v3.15.4"
-	HelmRecommendedVersion        = "v3.16.3"
+	HelmRecommendedVersion        = "v3.16.4"
 	HelmDiffRecommendedVersion    = "v3.9.12"
 	HelmSecretsRecommendedVersion = "v4.6.0"
 	HelmGitRecommendedVersion     = "v0.15.1"


### PR DESCRIPTION
This pull request includes updates to the Helm version across multiple files to ensure consistency and compatibility with the latest features and security patches. The most important changes include updating the Helm version in various configuration and Docker files, as well as updating the recommended Helm version in the application initialization file.

Version updates:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL74-R95): Updated Helm version from `v3.16.3` to `v3.16.4`.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L33-R42): Updated Helm version from `v3.16.3` to `v3.16.4` and updated corresponding SHA256 checksums.
* [`Dockerfile.debian-stable-slim`](diffhunk://#diff-ba602f969c43d8bdc4cbe0c2243476dfcc51f818d28f079418302e94cf7e791aL38-R47): Updated Helm version from `v3.16.3` to `v3.16.4` and updated corresponding SHA256 checksums.
* [`Dockerfile.ubuntu`](diffhunk://#diff-b4c6189f9184e61338a887d10410ec33e466f2fdba640cb632fab869dcb8b289L38-R47): Updated Helm version from `v3.16.3` to `v3.16.4` and updated corresponding SHA256 checksums.
* [`pkg/app/init.go`](diffhunk://#diff-a8d88c94aa5b407b495d262c095333250dae969e2cdde4db3d3783394e742e9bL21-R21): Updated the recommended Helm version from `v3.16.3` to `v3.16.4`.