### PR TITLE
feat: execute templates against postRendererHooks

### DIFF
--- a/pkg/app/desired_state_file_loader.go
+++ b/pkg/app/desired_state_file_loader.go
@@ -249,6 +249,14 @@ func (ld *desiredStateLoader) load(env, overrodeEnv *environment.Environment, ba
 			finalState.RenderedValues = currentState.RenderedValues
 		}
 
+		if len(finalState.HelmDefaults.PostRendererArgs) > 0 {
+			for i := range finalState.Releases {
+				if len(finalState.Releases[i].PostRendererArgs) == 0 {
+					finalState.Releases[i].PostRendererArgs = finalState.HelmDefaults.PostRendererArgs
+				}
+			}
+			finalState.HelmDefaults.PostRendererArgs = nil
+		}
 		env = &finalState.Env
 
 		ld.logger.Debugf("merged environment: %v", env)

--- a/pkg/state/release.go
+++ b/pkg/state/release.go
@@ -90,6 +90,18 @@ func (r ReleaseSpec) ExecuteTemplateExpressions(renderer *tmpl.FileRenderer) (*R
 		result.Labels[key] = s.String()
 	}
 
+	{
+		postRendererArgs := []string{}
+		for _, ts := range result.PostRendererArgs {
+			postRendererArg, err := renderer.RenderTemplateContentToString([]byte(ts))
+			if err != nil {
+				return nil, fmt.Errorf("failed executing template expressions in release \"%s\".postRendererArgs = \"%s\": %v", r.Name, ts, err)
+			}
+			postRendererArgs = append(postRendererArgs, postRendererArg)
+		}
+		result.PostRendererArgs = postRendererArgs
+	}
+
 	if len(result.ValuesTemplate) > 0 {
 		for i, t := range result.ValuesTemplate {
 			switch ts := t.(type) {

--- a/pkg/state/state_exec_tmpl_test.go
+++ b/pkg/state/state_exec_tmpl_test.go
@@ -123,6 +123,29 @@ func TestHelmState_executeTemplates(t *testing.T) {
 				Values:    []any{map[string]any{"key": "app-val0"}},
 			},
 		},
+		{
+			name: "Has template expressions in post renderer args",
+			input: ReleaseSpec{
+				Chart: "test-chart",
+				PostRendererArgs: []string{
+					"--release",
+					"{{ .Release.Name }}",
+					"--chart",
+					"{{ .Release.Chart }}",
+				},
+				Name: "test-release",
+			},
+			want: ReleaseSpec{
+				Chart: "test-chart",
+				Name:  "test-release",
+				PostRendererArgs: []string{
+					"--release",
+					"test-chart-dev",
+					"--chart",
+					"test-chart",
+				},
+			},
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
This commit is supposed to add template support to post renderer args. Also, to make it possible to template arguments that are added to helm defaults, during the load, I'm removing default post renderer args from the state and putting them to each release, unless custom args are defined for the release.

Why do I need it? 

I'm trying to implement some kind of audit log to the helmfile. The idea is pretty simple, I'm adding a configmap that contains an information that can be used to identify a person that has sync the release via helmfile. In the first implementation, I was using subcharts with some `.Release.Set` fields, added via templates, so I could just add a release like that

```yaml
templates:
  apply-log:
    dependencies:
      - chart: ./charts/apply-log
        version: '0.1.0'
        alias: apply-log
    set:
      - name: apply-log.author
        value: '{{ env "USER" }}'

releases:
  - name: test
    inherit:
      - template: apply-log 
```

But from time to time, it's violating chart's values schemas, and also it needs to be enabled per-release, that I consider error-prone. 

So I had an idea to use postRendererHooks for that, but I couldn't find a way to access a Release Name from the hook, and that's why I came up with this PR.

Example: 
```bash
#!/bin/bash

WORKDIR=$(mktemp -d)
cat <&0 > "${WORKDIR}/result.yaml"

echo "---" >> "${WORKDIR}/result.yaml"

kubectl create configmap --dry-run=client "${1}-apply-log" -o yaml --from-literal author="${USER}" >> "${WORKDIR}/result.yaml"

cat "${WORKDIR}/result.yaml"
```
This script is supposed to take the first argument and use it for the resource name. 

I have `helmDefaults` set like this:

```yaml
helmDefaults:
  postRenderer: ./scripts/post_render_apply_log.sh
  postRendererArgs:
    - "{{ `{{ .Release.Name }}` }}"
 releases:
  - name: namespaces
    chart: ./charts/namespaces
    namespace: kube-public
    createNamespace: false
    inherit:
      - template: default-env-values

```

And then the result is 

```
❯ hf diff -l name=namespaces

Comparing release=namespaces, chart=charts/namespaces, namespace=kube-public
kube-public, namespaces-apply-log, ConfigMap (v1) has been added:
-
+ apiVersion: v1
+ data:
+   author: allanger
+ kind: ConfigMap
+ metadata:
+   creationTimestamp: null
+   name: namespaces-apply-log
```

Why am I merging `.HelmDefaults.PostRendererArgs` to the `.Release.PostRendererArgs`. To avoid adding the args entry to each release, I need to merge all the args before templating, so I can access the release Data in the Args that are defined globally.

