### PR TITLE
build: update helm-diff to v3.9.13 in Dockerfiles and init.go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN set -x && \
     [ "$(age --version)" = "${AGE_VERSION}" ] && \
     [ "$(age-keygen --version)" = "${AGE_VERSION}" ]
 
-RUN helm plugin install https://github.com/databus23/helm-diff --version v3.9.12 && \
+RUN helm plugin install https://github.com/databus23/helm-diff --version v3.9.13 && \
     helm plugin install https://github.com/jkroepke/helm-secrets --version v4.6.0 && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.16.2 && \
     helm plugin install https://github.com/aslafy-z/helm-git.git --version v0.16.0 && \

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -99,7 +99,7 @@ RUN set -x && \
     [ "$(age --version)" = "${AGE_VERSION}" ] && \
     [ "$(age-keygen --version)" = "${AGE_VERSION}" ]
 
-RUN helm plugin install https://github.com/databus23/helm-diff --version v3.9.12 && \
+RUN helm plugin install https://github.com/databus23/helm-diff --version v3.9.13 && \
     helm plugin install https://github.com/jkroepke/helm-secrets --version v4.6.0 && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.16.2 && \
     helm plugin install https://github.com/aslafy-z/helm-git.git --version v0.16.0 && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -99,7 +99,7 @@ RUN set -x && \
     [ "$(age --version)" = "${AGE_VERSION}" ] && \
     [ "$(age-keygen --version)" = "${AGE_VERSION}" ]
 
-RUN helm plugin install https://github.com/databus23/helm-diff --version v3.9.12 && \
+RUN helm plugin install https://github.com/databus23/helm-diff --version v3.9.13 && \
     helm plugin install https://github.com/jkroepke/helm-secrets --version v4.6.0 && \
     helm plugin install https://github.com/hypnoglow/helm-s3.git --version v0.16.2 && \
     helm plugin install https://github.com/aslafy-z/helm-git.git --version v0.16.0 && \

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -19,7 +19,7 @@ import (
 const (
 	HelmRequiredVersion           = "v3.15.4"
 	HelmRecommendedVersion        = "v3.16.4"
-	HelmDiffRecommendedVersion    = "v3.9.12"
+	HelmDiffRecommendedVersion    = "v3.9.13"
 	HelmSecretsRecommendedVersion = "v4.6.0"
 	HelmGitRecommendedVersion     = "v0.15.1"
 	HelmS3RecommendedVersion      = "v0.16.0"


### PR DESCRIPTION
This pull request includes updates to the `helm-diff` plugin version across multiple Dockerfiles and the initialization file. The primary goal is to upgrade the `helm-diff` plugin from version `v3.9.12` to `v3.9.13`.

Version updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L97-R97): Updated `helm-diff` plugin version from `v3.9.12` to `v3.9.13`.
* [`Dockerfile.debian-stable-slim`](diffhunk://#diff-ba602f969c43d8bdc4cbe0c2243476dfcc51f818d28f079418302e94cf7e791aL102-R102): Updated `helm-diff` plugin version from `v3.9.12` to `v3.9.13`.
* [`Dockerfile.ubuntu`](diffhunk://#diff-b4c6189f9184e61338a887d10410ec33e466f2fdba640cb632fab869dcb8b289L102-R102): Updated `helm-diff` plugin version from `v3.9.12` to `v3.9.13`.
* [`pkg/app/init.go`](diffhunk://#diff-a8d88c94aa5b407b495d262c095333250dae969e2cdde4db3d3783394e742e9bL22-R22): Updated `HelmDiffRecommendedVersion` constant from `v3.9.12` to `v3.9.13`.