### PR TITLE
feat: add --take-ownership flag to apply and sync commands

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -62,6 +62,7 @@ func NewApplyCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 	f.BoolVar(&applyOptions.ShowSecrets, "show-secrets", false, "do not redact secret values in the diff output. should be used for debug purpose only")
 	f.BoolVar(&applyOptions.NoHooks, "no-hooks", false, "do not diff changes made by hooks.")
 	f.BoolVar(&applyOptions.HideNotes, "hide-notes", false, "add --hide-notes flag to helm")
+	f.BoolVar(&applyOptions.TakeOwnership, "take-ownership", false, "add --take-ownership flag to helm")
 	f.BoolVar(&applyOptions.SuppressDiff, "suppress-diff", false, "suppress diff in the output. Usable in new installs")
 	f.BoolVar(&applyOptions.Wait, "wait", false, `Override helmDefaults.wait setting "helm upgrade --install --wait"`)
 	f.BoolVar(&applyOptions.WaitForJobs, "wait-for-jobs", false, `Override helmDefaults.waitForJobs setting "helm upgrade --install --wait-for-jobs"`)

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -42,6 +42,7 @@ func NewSyncCmd(globalCfg *config.GlobalImpl) *cobra.Command {
 	f.BoolVar(&syncOptions.IncludeNeeds, "include-needs", false, `automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when --selector/-l flag is not provided`)
 	f.BoolVar(&syncOptions.IncludeTransitiveNeeds, "include-transitive-needs", false, `like --include-needs, but also includes transitive needs (needs of needs). Does nothing when --selector/-l flag is not provided. Overrides exclusions of other selectors and conditions.`)
 	f.BoolVar(&syncOptions.HideNotes, "hide-notes", false, "add --hide-notes flag to helm")
+	f.BoolVar(&syncOptions.TakeOwnership, "take-ownership", false, `add --take-ownership flag to helm`)
 	f.BoolVar(&syncOptions.Wait, "wait", false, `Override helmDefaults.wait setting "helm upgrade --install --wait"`)
 	f.BoolVar(&syncOptions.WaitForJobs, "wait-for-jobs", false, `Override helmDefaults.waitForJobs setting "helm upgrade --install --wait-for-jobs"`)
 	f.BoolVar(&syncOptions.ReuseValues, "reuse-values", false, `Override helmDefaults.reuseValues "helm upgrade --install --reuse-values"`)

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -1550,6 +1550,7 @@ Do you really want to apply?
 					SkipSchemaValidation: c.SkipSchemaValidation(),
 					SyncArgs:             c.SyncArgs(),
 					HideNotes:            c.HideNotes(),
+					TakeOwnership:        c.TakeOwnership(),
 				}
 				return subst.SyncReleases(&affectedReleases, helm, c.Values(), c.Concurrency(), syncOpts)
 			}))
@@ -1945,6 +1946,7 @@ Do you really want to sync?
 					PostRendererArgs: c.PostRendererArgs(),
 					SyncArgs:         c.SyncArgs(),
 					HideNotes:        c.HideNotes(),
+					TakeOwnership:    c.TakeOwnership(),
 				}
 				return subst.SyncReleases(&affectedReleases, helm, c.Values(), c.Concurrency(), opts)
 			}))

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2248,6 +2248,7 @@ type applyConfig struct {
 	suppressOutputLineRegex []string
 	showOnly                []string
 	hideNotes               bool
+	takeOwnership           bool
 
 	// template-only options
 	includeCRDs, skipTests       bool
@@ -2438,6 +2439,10 @@ func (a applyConfig) ShowOnly() []string {
 
 func (a applyConfig) HideNotes() bool {
 	return a.hideNotes
+}
+
+func (a applyConfig) TakeOwnership() bool {
+	return a.takeOwnership
 }
 
 type depsConfig struct {

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -54,6 +54,7 @@ type ApplyConfigProvider interface {
 	SkipSchemaValidation() bool
 	Cascade() string
 	HideNotes() bool
+	TakeOwnership() bool
 	SuppressOutputLineRegex() []string
 
 	Values() []string
@@ -103,6 +104,7 @@ type SyncConfigProvider interface {
 	PostRenderer() string
 	PostRendererArgs() []string
 	HideNotes() bool
+	TakeOwnership() bool
 	Cascade() string
 
 	Values() []string

--- a/pkg/config/apply.go
+++ b/pkg/config/apply.go
@@ -70,6 +70,9 @@ type ApplyOptions struct {
 	SyncArgs string
 	// HideNotes is the hide notes flag
 	HideNotes bool
+
+	// TakeOwnership is true if the ownership should be taken
+	TakeOwnership bool
 }
 
 // NewApply creates a new Apply
@@ -257,6 +260,12 @@ func (a *ApplyImpl) SyncArgs() string {
 	return a.ApplyOptions.SyncArgs
 }
 
+// HideNotes returns the HideNotes.
 func (a *ApplyImpl) HideNotes() bool {
 	return a.ApplyOptions.HideNotes
+}
+
+// TakeOwnership returns the TakeOwnership.
+func (a *ApplyImpl) TakeOwnership() bool {
+	return a.ApplyOptions.TakeOwnership
 }

--- a/pkg/config/sync.go
+++ b/pkg/config/sync.go
@@ -38,6 +38,8 @@ type SyncOptions struct {
 	SyncArgs string
 	// HideNotes is the hide notes flag
 	HideNotes bool
+	// TakeOwnership is the take ownership flag
+	TakeOwnership bool
 }
 
 // NewSyncOptions creates a new Apply
@@ -149,6 +151,12 @@ func (t *SyncImpl) SyncArgs() string {
 	return t.SyncOptions.SyncArgs
 }
 
+// HideNotes returns the hide notes
 func (t *SyncImpl) HideNotes() bool {
 	return t.SyncOptions.HideNotes
+}
+
+// TakeOwnership returns the take ownership
+func (t *SyncImpl) TakeOwnership() bool {
+	return t.SyncOptions.TakeOwnership
 }

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -148,6 +148,19 @@ func (st *HelmState) appendHideNotesFlags(flags []string, helm helmexec.Interfac
 	return flags
 }
 
+// append take-ownership flags to helm flags
+func (st *HelmState) appendTakeOwnershipFlags(flags []string, helm helmexec.Interface, ops *SyncOpts) []string {
+	// see https://github.com/helm/helm/releases/tag/v3.17.0
+	if !helm.IsVersionAtLeast("3.17.0") {
+		return flags
+	}
+	switch {
+	case ops.HideNotes:
+		flags = append(flags, "--take-ownership")
+	}
+	return flags
+}
+
 // append show-only flags to helm flags
 func (st *HelmState) appendShowOnlyFlags(flags []string, showOnly []string) []string {
 	showOnlyFlags := []string{}

--- a/pkg/state/helmx_test.go
+++ b/pkg/state/helmx_test.go
@@ -321,3 +321,48 @@ func TestAppendHideNotesFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestAppendTakeOwnershipFlags(t *testing.T) {
+	type args struct {
+		flags    []string
+		helm     helmexec.Interface
+		helmSpec HelmSpec
+		opt      *SyncOpts
+		expected []string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "no take-ownership when helm less than 3.17.0",
+			args: args{
+				flags: []string{},
+				helm:  testutil.NewVersionHelmExec("3.16.0"),
+				opt: &SyncOpts{
+					HideNotes: true,
+				},
+				expected: []string{},
+			},
+		},
+		{
+			name: "hide-notes from cmd flag",
+			args: args{
+				flags: []string{},
+				helm:  testutil.NewVersionHelmExec("3.17.0"),
+				opt: &SyncOpts{
+					HideNotes: true,
+				},
+				expected: []string{"--take-ownership"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &HelmState{}
+			st.HelmDefaults = tt.args.helmSpec
+			got := st.appendTakeOwnershipFlags(tt.args.flags, tt.args.helm, tt.args.opt)
+			require.Equalf(t, tt.args.expected, got, "appendTakeOwnershipFlags() = %v, want %v", got, tt.args.expected)
+		})
+	}
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -789,6 +789,7 @@ type SyncOpts struct {
 	PostRendererArgs     []string
 	SyncArgs             string
 	HideNotes            bool
+	TakeOwnership        bool
 }
 
 type SyncOpt interface{ Apply(*SyncOpts) }
@@ -2774,6 +2775,9 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 
 	// append hide-notes flag
 	flags = st.appendHideNotesFlags(flags, helm, opt)
+
+	// append take-ownership flag
+	flags = st.appendTakeOwnershipFlags(flags, helm, opt)
 
 	flags = st.appendExtraSyncFlags(flags, opt)
 


### PR DESCRIPTION
This pull request introduces a new `--take-ownership` flag to the Helm commands in the codebase. The changes add support for this flag in various parts of the application, including command definitions, configuration structures, and test cases.

### Addition of `--take-ownership` flag:

* `cmd/apply.go` and `cmd/sync.go`: Added `TakeOwnership` flag to the `applyOptions` and `syncOptions` respectively. [[1]](diffhunk://#diff-a08f2011636c2b27ac4df1809b3bf95ee8aa9a6de2050807d33ddfb65fb69f6fR65) [[2]](diffhunk://#diff-6f5f9ca9ac82cbfb03857438b7f2b2373c6ddf3db19f1f68e7074242baebaadcR45)

### Configuration updates:

* `pkg/config/apply.go` and `pkg/config/sync.go`: Updated `ApplyOptions` and `SyncOptions` structs to include the `TakeOwnership` field. Added corresponding getter methods. [[1]](diffhunk://#diff-9c1981b259ffcd33444e1fbb03afb3ee368563ed6e10b852a1165199e8005a05R73-R75) [[2]](diffhunk://#diff-9c1981b259ffcd33444e1fbb03afb3ee368563ed6e10b852a1165199e8005a05R263-R271) [[3]](diffhunk://#diff-44d82704651db22ff5ebfa1b636e76edf8e97a075c3cba2ea1714be914d6af74R41-R42) [[4]](diffhunk://#diff-44d82704651db22ff5ebfa1b636e76edf8e97a075c3cba2ea1714be914d6af74R154-R162)

### Application logic changes:

* [`pkg/app/app.go`](diffhunk://#diff-63facfa8b028c9f397524787fac074737e5534ae2591640c1a029549ec3d7450R1553): Incorporated `TakeOwnership` flag into the sync and apply processes. [[1]](diffhunk://#diff-63facfa8b028c9f397524787fac074737e5534ae2591640c1a029549ec3d7450R1553) [[2]](diffhunk://#diff-63facfa8b028c9f397524787fac074737e5534ae2591640c1a029549ec3d7450R1949)

### Interface and implementation adjustments:

* [`pkg/app/config.go`](diffhunk://#diff-e418c68aeab93ac15c26ccfd87279212111505eaa53c3b044c8d5bf13315a879R57): Updated `ApplyConfigProvider` and `SyncConfigProvider` interfaces to include the `TakeOwnership` method. [[1]](diffhunk://#diff-e418c68aeab93ac15c26ccfd87279212111505eaa53c3b044c8d5bf13315a879R57) [[2]](diffhunk://#diff-e418c68aeab93ac15c26ccfd87279212111505eaa53c3b044c8d5bf13315a879R107)
* `pkg/state/helmx.go` and `pkg/state/state.go`: Added logic to append the `--take-ownership` flag to Helm commands based on the provided options. [[1]](diffhunk://#diff-0daf4882942a9b5bde520c6aff471ed273a0bf861363a0d7c99c091c35232412R151-R163) [[2]](diffhunk://#diff-7e4e87a1e777423a3d9a915e00fb78a9c4fc2f4c476863f60b67e89b9c635697R2779-R2781)

### Testing updates:

* `pkg/app/app_test.go` and `pkg/state/helmx_test.go`: Added test cases to verify the correct handling of the `TakeOwnership` flag. [[1]](diffhunk://#diff-c7d8cc80ef42a7d06d8053179322063692c2714db211e9393be0114fd9744c7aR2251) [[2]](diffhunk://#diff-c7d8cc80ef42a7d06d8053179322063692c2714db211e9393be0114fd9744c7aR2444-R2447) [[3]](diffhunk://#diff-47cac6e4a9938f93a9f0865372d84a02c6a273522fa679a4a6e020205743b914R324-R368)