### PR TITLE
fix: ensure development versions of charts can be used across helmfile commands

### DIFF
--- a/pkg/app/app_template_test.go
+++ b/pkg/app/app_template_test.go
@@ -236,7 +236,7 @@ releases:
 			},
 			selectors: []string{"name=test2"},
 			templated: []exectest.Release{
-				{Name: "test2", Flags: []string{}},
+				{Name: "test2"},
 			},
 		})
 	})
@@ -249,8 +249,8 @@ releases:
 			},
 			selectors: []string{"name=test3"},
 			templated: []exectest.Release{
-				{Name: "test2", Flags: []string{}},
-				{Name: "test3", Flags: []string{}},
+				{Name: "test2"},
+				{Name: "test3"},
 			},
 		})
 	})
@@ -264,8 +264,8 @@ releases:
 			},
 			selectors: []string{"name=test3"},
 			templated: []exectest.Release{
-				{Name: "test2", Flags: []string{}},
-				{Name: "test3", Flags: []string{}},
+				{Name: "test2"},
+				{Name: "test3"},
 			},
 		})
 	})
@@ -279,7 +279,7 @@ releases:
 			},
 			selectors: []string{"name=test2"},
 			templated: []exectest.Release{
-				{Name: "test2", Flags: []string{}},
+				{Name: "test2"},
 			},
 		})
 	})
@@ -293,8 +293,8 @@ releases:
 			},
 			selectors: []string{"name=test3"},
 			templated: []exectest.Release{
-				{Name: "test2", Flags: []string{}},
-				{Name: "test3", Flags: []string{}},
+				{Name: "test2"},
+				{Name: "test3"},
 			},
 		})
 	})

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -519,8 +519,8 @@ func (helm *execer) ChartPull(chart string, path string, flags ...string) error 
 	if helmVersionConstraint.Check(helm.version) {
 		// in the 3.7.0 version, the chart pull has been replaced with helm pull
 		// https://github.com/helm/helm/releases/tag/v3.7.0
-		ociChartURL, ociChartTag := resolveOciChart(chart)
-		helmArgs = []string{"pull", ociChartURL, "--version", ociChartTag, "--destination", path, "--untar"}
+		ociChartURL, _ := resolveOciChart(chart)
+		helmArgs = []string{"pull", ociChartURL, "--destination", path, "--untar"}
 		helmArgs = append(helmArgs, flags...)
 	} else {
 		helmArgs = []string{"chart", "pull", chart}

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -826,20 +826,20 @@ exec: helm --kubeconfig config --kube-context dev chart pull chart
 			helmVersion: "v3.10.0",
 			chartName:   "repo/helm-charts:0.14.0",
 			chartPath:   "path1",
-			chartFlags:  []string{"--untardir", "/tmp/dir"},
+			chartFlags:  []string{"--untardir", "/tmp/dir", "--version", "0.14.0"},
 			listResult: `Pulling repo/helm-charts:0.14.0
-exec: helm --kubeconfig config --kube-context dev pull oci://repo/helm-charts --version 0.14.0 --destination path1 --untar --untardir /tmp/dir
+exec: helm --kubeconfig config --kube-context dev pull oci://repo/helm-charts --destination path1 --untar --untardir /tmp/dir --version 0.14.0
 `,
 		},
 		{
 			name:        "more then v3.7.0 with rc",
 			helmBin:     "helm",
 			helmVersion: "v3.14.0-rc.1+g69dcc92",
-			chartName:   "repo/helm-charts:0.14.0",
+			chartName:   "repo/helm-charts",
 			chartPath:   "path1",
-			chartFlags:  []string{"--untardir", "/tmp/dir"},
-			listResult: `Pulling repo/helm-charts:0.14.0
-exec: helm --kubeconfig config --kube-context dev pull oci://repo/helm-charts --version 0.14.0 --destination path1 --untar --untardir /tmp/dir
+			chartFlags:  []string{"--untardir", "/tmp/dir", "--devel"},
+			listResult: `Pulling repo/helm-charts
+exec: helm --kubeconfig config --kube-context dev pull oci://repo/helm-charts --destination path1 --untar --untardir /tmp/dir --devel
 `,
 		},
 	}

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -3216,6 +3216,8 @@ func TestFullFilePath(t *testing.T) {
 }
 
 func TestGetOCIQualifiedChartName(t *testing.T) {
+	devel := true
+
 	tests := []struct {
 		state    HelmState
 		expected []struct {
@@ -3301,6 +3303,27 @@ func TestGetOCIQualifiedChartName(t *testing.T) {
 				chartVersion       string
 			}{
 				{"registry/chart-path/chart-name:0.1.2", "chart-name", "0.1.2"},
+			},
+		},
+		{
+			state: HelmState{
+				ReleaseSetSpec: ReleaseSetSpec{
+					Repositories: []RepositorySpec{},
+					Releases: []ReleaseSpec{
+						{
+							Chart: "oci://registry/chart-path/chart-name",
+							Devel: &devel,
+						},
+					},
+				},
+			},
+			helmVersion: "3.13.3",
+			expected: []struct {
+				qualifiedChartName string
+				chartName          string
+				chartVersion       string
+			}{
+				{"registry/chart-path/chart-name", "chart-name", ""},
 			},
 		},
 	}


### PR DESCRIPTION
closes #1864

This pull request includes refactorings to ensure the `--devel` flag is correctly passed into the required `helm` and `helm diff` commands.

- [`pkg/helmexec/exec.go`](https://github.com/helmfile/helmfile/pull/1865/files#diff-cc23d827ce15a3ce002578cc0b18d846fd3614d59ac080c703bdd17881466795R522): No longer set the version from the chart name and allow it to be passed through as part of the additional flags. This ensures `--version` and `--devel` are never included together. If you read the helm CLI docs, `--version` disables the behaviour of `--devel`.