### PR TITLE
Ensure 'helm repo add' is also not pollute on helmfile template

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -240,6 +240,10 @@ func (a *App) Template(c TemplateConfigProvider) error {
 		// Live output should never be enabled for the "template" subcommand to avoid breaking `helmfile template | kubectl apply -f -`
 		run.helm.SetEnableLiveOutput(false)
 
+		// Reset helm extra args to not pollute BuildDeps() and AddRepo() on subsequent helmfiles
+		// https://github.com/helmfile/helmfile/issues/1749
+		run.helm.SetExtraArgs()
+
 		prepErr := run.withPreparedCharts("template", state.ChartPrepareOptions{
 			SkipRepos:              c.SkipRefresh() || c.SkipDeps(),
 			SkipRefresh:            c.SkipRefresh(),

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1449,10 +1449,6 @@ func (st *HelmState) runHelmDepBuilds(helm helmexec.Interface, concurrency int, 
 	//
 	//    See https://github.com/roboll/helmfile/issues/1521
 
-	// Reset helm extra args to not pollute BuildDeps() on subsequent helmfiles
-	// https://github.com/helmfile/helmfile/issues/1749
-	helm.SetExtraArgs()
-
 	for _, r := range builds {
 		buildDepsFlags := getBuildDepsFlags(r)
 		if err := helm.BuildDeps(r.releaseName, r.chartPath, buildDepsFlags...); err != nil {

--- a/test/integration/test-cases/issue-1749/input/helmfile.d/helmfile1.yaml.gotmpl
+++ b/test/integration/test-cases/issue-1749/input/helmfile.d/helmfile1.yaml.gotmpl
@@ -1,3 +1,7 @@
+repositories:
+- name: bitnami
+  url: https://charts.bitnami.com/bitnami
+
 releases:
   - name: test1
     chart: ../../../../charts/raw

--- a/test/integration/test-cases/issue-1749/input/helmfile.d/helmfile2.yaml.gotmpl
+++ b/test/integration/test-cases/issue-1749/input/helmfile.d/helmfile2.yaml.gotmpl
@@ -1,3 +1,7 @@
+repositories:
+- name: prometheus-community
+  url: https://prometheus-community.github.io/helm-charts
+
 releases:
   - name: test2
     chart: ../../../../charts/raw


### PR DESCRIPTION
When having multiple helmfiles in one helmfile.d folder and multiple of them having repositories defined, the errors mention in #1749 still existed.

Fixes #1749 (again)