### PR TITLE
refactor(state): optimize HelmState flags handling

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -2824,22 +2824,24 @@ func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseS
 	flags = st.appendChartVersionFlags(flags, release)
 	flags = st.appendHelmXFlags(flags, release)
 
-	postRenderer := ""
 	var postRendererArgs []string
-	kubeVersion := ""
 	var showOnly []string
+	postRenderer := ""
+	kubeVersion := ""
+	skipSchemaValidation := false
 	if opt != nil {
 		postRenderer = opt.PostRenderer
 		postRendererArgs = opt.PostRendererArgs
 		kubeVersion = opt.KubeVersion
 		showOnly = opt.ShowOnly
+		skipSchemaValidation = opt.SkipSchemaValidation
 	}
 	flags = st.appendPostRenderFlags(flags, release, postRenderer)
 	flags = st.appendPostRenderArgsFlags(flags, release, postRendererArgs)
 	flags = st.appendApiVersionsFlags(flags, release, kubeVersion)
 	flags = st.appendChartDownloadFlags(flags, release)
 	flags = st.appendShowOnlyFlags(flags, showOnly)
-	flags = st.appendSkipSchemaValidationFlags(flags, release, opt.SkipSchemaValidation)
+	flags = st.appendSkipSchemaValidationFlags(flags, release, skipSchemaValidation)
 
 	common, files, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {


### PR DESCRIPTION
This pull request includes changes to the `pkg/state/state.go` file to improve the handling of Helm template flags. The most important changes involve the refactoring of variable initialization and the addition of a new flag for schema validation.

Improvements to Helm template flags handling:

* [`pkg/state/state.go`](diffhunk://#diff-7e4e87a1e777423a3d9a915e00fb78a9c4fc2f4c476863f60b67e89b9c635697L2827-R2844): Refactored the initialization of `postRenderer`, `kubeVersion`, and `skipSchemaValidation` variables to ensure they are properly set when `opt` is not nil. This change also includes the addition of the `skipSchemaValidation` flag.