### PR TITLE
build: update golang version to 1.24 and golangci-lint to v1.64.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           cache: false
       - uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.64.5
 
   tests:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
 
 RUN apk add --no-cache make git
 WORKDIR /workspace/helmfile

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
 
 RUN apk add --no-cache make git
 WORKDIR /workspace/helmfile

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
 
 RUN apk add --no-cache make git
 WORKDIR /workspace/helmfile

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/helmfile/helmfile
 
-go 1.23.1
+go 1.24
 
 require (
 	dario.cat/mergo v1.0.1

--- a/pkg/tmpl/context_funcs.go
+++ b/pkg/tmpl/context_funcs.go
@@ -391,12 +391,10 @@ func RequiredEnv(name string) (string, error) {
 
 func Required(warn string, val any) (any, error) {
 	if val == nil {
-		// nolint:govet,staticcheck
-		return nil, fmt.Errorf(warn)
+		return nil, fmt.Errorf("%s", warn)
 	} else if _, ok := val.(string); ok {
 		if val == "" {
-			// nolint:govet,staticcheck
-			return nil, fmt.Errorf(warn)
+			return nil, fmt.Errorf("%s", warn)
 		}
 	}
 


### PR DESCRIPTION
This pull request includes updates to the CI workflow and Go module version.

Changes to CI workflow:

* Updated the `golangci-lint-action` version from `v1.61.0` to `v1.64.5` in `.github/workflows/ci.yaml`.

Changes to Go module:

* Updated the Go version from `1.23.1` to `1.24` in `go.mod`.