### PR TITLE
docs(fix): correct typo in 'tier=fronted' to 'tier=frontend'

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -764,7 +764,7 @@ For additional context, take a look at [paths examples](paths.md).
 
 A selector can be used to only target a subset of releases when running Helmfile. This is useful for large helmfiles with releases that are logically grouped together.
 
-Labels are simple key value pairs that are an optional field of the release spec. When selecting by label, the search can be inverted. `tier!=backend` would match all releases that do NOT have the `tier: backend` label. `tier=fronted` would only match releases with the `tier: frontend` label.
+Labels are simple key value pairs that are an optional field of the release spec. When selecting by label, the search can be inverted. `tier!=backend` would match all releases that do NOT have the `tier: backend` label. `tier=frontend` would only match releases with the `tier: frontend` label.
 
 Multiple labels can be specified using `,` as a separator. A release must match all selectors in order to be selected for the final helm command.
 


### PR DESCRIPTION
This pull request includes a minor change to the `docs/index.md` file. The change corrects a typo in the example of label selection by ensuring the label `tier=frontend` is correctly specified.

Documentation update:

* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L767-R767): Corrected the label example from `tier=fronted` to `tier=frontend`.