### PR TITLE
fix: Check needs with context and namespace

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -488,7 +488,20 @@ func (st *HelmState) reformat(spec *ReleaseSpec) []string {
 	var needs []string
 	releaseInstalledInfo := make(map[string]bool)
 	for _, r := range st.OrginReleases {
-		releaseInstalledInfo[fmt.Sprintf("%s/%s/%s", r.KubeContext, r.Namespace, r.Name)] = r.Desired()
+		var kubecontext, namespace string
+
+		if st.OverrideKubeContext != "" {
+			kubecontext = st.OverrideKubeContext
+		} 	else {
+			kubecontext = r.KubeContext
+		}
+		if st.OverrideNamespace != "" {
+			namespace = st.OverrideNamespace
+		} 	else {
+			namespace = r.Namespace
+		}
+
+		releaseInstalledInfo[fmt.Sprintf("%s/%s/%s", kubecontext, namespace, r.Name)] = r.Desired()
 	}
 
 	// Since the representation differs between needs and id,

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -488,7 +488,7 @@ func (st *HelmState) reformat(spec *ReleaseSpec) []string {
 	var needs []string
 	releaseInstalledInfo := make(map[string]bool)
 	for _, r := range st.OrginReleases {
-		releaseInstalledInfo[r.Name] = r.Desired()
+		releaseInstalledInfo[fmt.Sprintf("%s/%s/%s", r.KubeContext, r.Namespace, r.Name)] = r.Desired()
 	}
 
 	// Since the representation differs between needs and id,
@@ -501,9 +501,6 @@ func (st *HelmState) reformat(spec *ReleaseSpec) []string {
 		components := strings.Split(n, "/")
 
 		name = components[len(components)-1]
-		if spec.Desired() && !releaseInstalledInfo[name] {
-			st.logger.Warnf("WARNING: %s", fmt.Sprintf("release %s needs %s, but %s is not installed due to installed: false. Either mark %s as installed or remove %s from %s's needs", spec.Name, name, name, name, name, spec.Name))
-		}
 
 		if len(components) > 1 {
 			ns = components[len(components)-2]
@@ -517,6 +514,10 @@ func (st *HelmState) reformat(spec *ReleaseSpec) []string {
 			kubecontext = strings.Join(components[:len(components)-2], "/")
 		} else {
 			kubecontext = spec.KubeContext
+		}
+
+		if spec.Desired() && !releaseInstalledInfo[fmt.Sprintf("%s/%s/%s", kubecontext, ns, name)] {
+			st.logger.Warnf("WARNING: %s", fmt.Sprintf("release %s needs %s, but %s is not installed due to installed: false. Either mark %s as installed or remove %s from %s's needs", spec.Name, name, name, name, name, spec.Name))
 		}
 
 		var componentsAfterOverride []string


### PR DESCRIPTION
Fixes: #1985

Hello!

I'm not that proficient in Go so please do let me know if I should rework it somehow.

The second commit is ensure we have override information for the kubecontext and namespace in releases stored in `st.OrginReleases`, as the apply and diff tests with namespace override didn't have that information and failed.

I expected that information to be set already, and what I've done feels like a workaround.
Is this expected, or is this a bug somewhere else?