### PR TITLE
build: update Helm to v3.17.3 and update related Dockerfiles

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,19 +69,19 @@ jobs:
             plugin-secrets-version: 4.6.3
             plugin-diff-version: 3.11.0
             extra-helmfile-flags: ''
-          - helm-version: v3.17.2
+          - helm-version: v3.17.3
             kustomize-version: v5.2.1
             plugin-secrets-version: 3.15.0
             plugin-diff-version: 3.10.0
             extra-helmfile-flags: ''
-          - helm-version: v3.17.2
+          - helm-version: v3.17.3
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.3
             plugin-diff-version: 3.11.0
             extra-helmfile-flags: ''
           # In case you need to test some optional helmfile features,
           # enable it via extra-helmfile-flags below.
-          - helm-version: v3.17.2
+          - helm-version: v3.17.3
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.3
             plugin-diff-version: 3.11.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.17.2"
+ARG HELM_VERSION="v3.17.3"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -38,8 +38,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="90c28792a1eb5fb0b50028e39ebf826531ebfcf73f599050dbd79bab2f277241"  ;; \
-    "linux/arm64")  HELM_SHA256="d78d76ec7625a94991e887ac049d93f44bd70e4876200b945f813c9e1ed1df7c"  ;; \
+    "linux/amd64")  HELM_SHA256="ee88b3c851ae6466a3de507f7be73fe94d54cbf2987cbaa3d1a3832ea331f2cd"  ;; \
+    "linux/arm64")  HELM_SHA256="7944e3defd386c76fd92d9e6fec5c2d65a323f6fadc19bfb5e704e3eee10348e"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -35,7 +35,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.17.2"
+ARG HELM_VERSION="v3.17.3"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -43,8 +43,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="90c28792a1eb5fb0b50028e39ebf826531ebfcf73f599050dbd79bab2f277241"  ;; \
-    "linux/arm64")  HELM_SHA256="d78d76ec7625a94991e887ac049d93f44bd70e4876200b945f813c9e1ed1df7c"  ;; \
+    "linux/amd64")  HELM_SHA256="ee88b3c851ae6466a3de507f7be73fe94d54cbf2987cbaa3d1a3832ea331f2cd"  ;; \
+    "linux/arm64")  HELM_SHA256="7944e3defd386c76fd92d9e6fec5c2d65a323f6fadc19bfb5e704e3eee10348e"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -35,7 +35,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.17.2"
+ARG HELM_VERSION="v3.17.3"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -43,8 +43,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="90c28792a1eb5fb0b50028e39ebf826531ebfcf73f599050dbd79bab2f277241"  ;; \
-    "linux/arm64")  HELM_SHA256="d78d76ec7625a94991e887ac049d93f44bd70e4876200b945f813c9e1ed1df7c"  ;; \
+    "linux/amd64")  HELM_SHA256="ee88b3c851ae6466a3de507f7be73fe94d54cbf2987cbaa3d1a3832ea331f2cd"  ;; \
+    "linux/arm64")  HELM_SHA256="7944e3defd386c76fd92d9e6fec5c2d65a323f6fadc19bfb5e704e3eee10348e"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	HelmRequiredVersion           = "v3.16.4"
-	HelmRecommendedVersion        = "v3.17.2"
+	HelmRecommendedVersion        = "v3.17.3"
 	HelmDiffRecommendedVersion    = "v3.11.0"
 	HelmSecretsRecommendedVersion = "v4.6.3"
 	HelmGitRecommendedVersion     = "v1.3.0"


### PR DESCRIPTION
This pull request updates the Helm version across various files to ensure consistency and compatibility with the latest version. The most important changes include updating the Helm version in configuration files, Dockerfiles, and Go module dependencies.

Updates to Helm version:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL72-R84): Updated `helm-version` from `v3.17.2` to `v3.17.3`.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L33-R42): Updated `HELM_VERSION` from `v3.17.2` to `v3.17.3` and corresponding SHA256 checksums.
* [`Dockerfile.debian-stable-slim`](diffhunk://#diff-ba602f969c43d8bdc4cbe0c2243476dfcc51f818d28f079418302e94cf7e791aL38-R47): Updated `HELM_VERSION` from `v3.17.2` to `v3.17.3` and corresponding SHA256 checksums.
* [`Dockerfile.ubuntu`](diffhunk://#diff-b4c6189f9184e61338a887d10410ec33e466f2fdba640cb632fab869dcb8b289L38-R47): Updated `HELM_VERSION` from `v3.17.2` to `v3.17.3` and corresponding SHA256 checksums.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L32-R32): Updated Helm dependency from `v3.17.2` to `v3.17.3`.
* [`pkg/app/init.go`](diffhunk://#diff-a8d88c94aa5b407b495d262c095333250dae969e2cdde4db3d3783394e742e9bL21-R21): Updated `HelmRecommendedVersion` from `v3.17.2` to `v3.17.3`.