### PR TITLE
feat: add helmfile archive configuration in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,14 @@ builds:
       - amd64
       - arm64
       - "386"
-
+archives:
+  - id: helmfile
+    ids:
+      - helmfile
+    builds_info:
+      group: root
+      owner: root
+      mode: 0644
 changelog:
   use: github
   sort: asc


### PR DESCRIPTION
This pull request includes changes to the `.goreleaser.yml` file to add an `archives` section, which configures the build archives for the `helmfile` project.

Configuration updates:

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L23-R30): Added an `archives` section with details for the `helmfile` project, including `id`, `ids`, `builds_info`, `group`, `owner`, and `mode`.