### PR TITLE
Do not add latest tag on pre-releases

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -61,7 +61,7 @@ jobs:
             type=raw,value=canary,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=ref,event=pr
             type=semver,pattern={{raw}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.') && !contains(github.ref, '-') }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
This pull request refines the condition for setting the `latest` tag to ensure it only applies to tags that start with 'v', contain a period, and do not contain a hyphen. This change avoids setting the `latest` tag on pre-release images like v1.0.0-rc.12.

P.S. Unfortunately, GitHub Actions does not support regex matching in expressions, so the condition is somewhat simplified.
