### PR TITLE
docs: add more complex examples section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Iterate on the `helmfile.yaml` by referencing:
 
 ## More complex examples
 
-See: https://github.com/helmfile/multi-env-helmfile
+See: [multi-env-helmfile](https://github.com/helmfile/multi-env-helmfile)
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ Iterate on the `helmfile.yaml` by referencing:
 * [CLI reference](https://helmfile.readthedocs.io/en/latest/#cli-reference)
 * [Helmfile Best Practices Guide](https://helmfile.readthedocs.io/en/latest/writing-helmfile/)
 
+## More complex examples
+
+See: https://github.com/helmfile/multi-env-helmfile
+
 ## Docs
 
 Please read [complete documentation](https://helmfile.readthedocs.io/)


### PR DESCRIPTION
This pull request updates the `README.md` file to include a new section for more complex examples, providing a link to a GitHub repository for multi-environment Helmfile configurations.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108-R111): Added a "More complex examples" section with a link to the `https://github.com/helmfile/multi-env-helmfile` repository.