### PR TITLE
build: update golangci-lint to v2.1.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           cache: false
       - uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.0.2
+          version: v2.1.6
 
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the version of the `golangci-lint-action` used in the CI workflow configuration.

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL23-R23): Updated the `golangci-lint-action` version from `v2.0.2` to `v2.1.6` to ensure the latest linting features and fixes are applied.