### PR TITLE
feat(tmpl): enhance ToYaml test with multiple scenarios

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -574,6 +574,7 @@ Helmfile uses some OS environment variables to override default behaviour:
 * `HELMFILE_CACHE_HOME` - specify directory to store cached files for remote operations
 * `HELMFILE_FILE_PATH` - specify the path to the helmfile.yaml file
 * `HELMFILE_INTERACTIVE` - enable interactive mode, expecting `true` lower case. The same as `--interactive` CLI flag
+* `HELMFILE_ENABLE_GOCCY_GOYAML_JSON_STYLE`: - enable JSON style for *goccy/go-yaml* instead of *gopkg.in/yaml.v2*.  It's `false` by default in Helmfile. it will add quotes to string values.
 
 ## CLI Reference
 

--- a/pkg/envvar/const.go
+++ b/pkg/envvar/const.go
@@ -15,5 +15,5 @@ const (
 	GoccyGoYaml                = "HELMFILE_GOCCY_GOYAML"
 	CacheHome                  = "HELMFILE_CACHE_HOME"
 	Interactive                = "HELMFILE_INTERACTIVE"
-	EanbleGoccyGoYamlJsonStyle = "HELMFILE_ENABLE_GOCCY_GOYAML_JSON_STYLE"
+	EnableGoccyGoYamlJSONStyle = "HELMFILE_ENABLE_GOCCY_GOYAML_JSON_STYLE"
 )

--- a/pkg/envvar/const.go
+++ b/pkg/envvar/const.go
@@ -6,13 +6,14 @@ const (
 	// use helm status to check if a release exists before installing it
 	UseHelmStatusToCheckReleaseExistence = "HELMFILE_USE_HELM_STATUS_TO_CHECK_RELEASE_EXISTENCE"
 
-	DisableRunnerUniqueID = "HELMFILE_DISABLE_RUNNER_UNIQUE_ID"
-	Experimental          = "HELMFILE_EXPERIMENTAL" // environment variable for experimental features, expecting "true" lower case
-	Environment           = "HELMFILE_ENVIRONMENT"
-	FilePath              = "HELMFILE_FILE_PATH"
-	TempDir               = "HELMFILE_TEMPDIR"
-	UpgradeNoticeDisabled = "HELMFILE_UPGRADE_NOTICE_DISABLED"
-	GoccyGoYaml           = "HELMFILE_GOCCY_GOYAML"
-	CacheHome             = "HELMFILE_CACHE_HOME"
-	Interactive           = "HELMFILE_INTERACTIVE"
+	DisableRunnerUniqueID      = "HELMFILE_DISABLE_RUNNER_UNIQUE_ID"
+	Experimental               = "HELMFILE_EXPERIMENTAL" // environment variable for experimental features, expecting "true" lower case
+	Environment                = "HELMFILE_ENVIRONMENT"
+	FilePath                   = "HELMFILE_FILE_PATH"
+	TempDir                    = "HELMFILE_TEMPDIR"
+	UpgradeNoticeDisabled      = "HELMFILE_UPGRADE_NOTICE_DISABLED"
+	GoccyGoYaml                = "HELMFILE_GOCCY_GOYAML"
+	CacheHome                  = "HELMFILE_CACHE_HOME"
+	Interactive                = "HELMFILE_INTERACTIVE"
+	EanbleGoccyGoYamlJsonStyle = "HELMFILE_ENABLE_GOCCY_GOYAML_JSON_STYLE"
 )

--- a/pkg/tmpl/context_funcs_test.go
+++ b/pkg/tmpl/context_funcs_test.go
@@ -248,10 +248,10 @@ func TestToYaml(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.enableJsonStyle {
-				_ = os.Setenv(envvar.EanbleGoccyGoYamlJsonStyle, "true")
+				_ = os.Setenv(envvar.EnableGoccyGoYamlJSONStyle, "true")
 			}
 			defer func() {
-				_ = os.Unsetenv(envvar.EanbleGoccyGoYamlJsonStyle)
+				_ = os.Unsetenv(envvar.EnableGoccyGoYamlJSONStyle)
 			}()
 			actual, err := ToYaml(tt.input)
 			if tt.wantErr {

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -3,6 +3,8 @@ package yaml
 import (
 	"bytes"
 	"io"
+	"strconv"
+	"strings"
 
 	"github.com/goccy/go-yaml"
 	v2 "gopkg.in/yaml.v2"
@@ -71,6 +73,15 @@ func Marshal(v any) ([]byte, error) {
 			yaml.Indent(2),
 			yaml.UseSingleQuote(true),
 			yaml.UseLiteralStyleIfMultiline(true),
+			yaml.CustomMarshaler(
+				func(v string) ([]byte, error) {
+					if strings.HasPrefix(v, "0") {
+						// check v is 0xxxx style number.
+						return []byte(strconv.Quote(v)), nil
+					}
+					return []byte(v), nil
+				},
+			),
 		)
 		err := yamlEncoder.Encode(v)
 		defer func() {

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -74,7 +74,7 @@ func Marshal(v any) ([]byte, error) {
 			yaml.UseLiteralStyleIfMultiline(true),
 		}
 		// enable JSON style if the envvar is set
-		if os.Getenv(envvar.EanbleGoccyGoYamlJsonStyle) == "true" {
+		if os.Getenv(envvar.EnableGoccyGoYamlJSONStyle) == "true" {
 			yamlEncoderOpts = append(yamlEncoderOpts, yaml.JSON(), yaml.Flow(false))
 		}
 


### PR DESCRIPTION
This pull request introduces a new feature to enable JSON-style YAML encoding via an environment variable, along with corresponding updates to tests and dependencies. The most significant changes include adding support for the new environment variable, modifying the YAML encoder to respect this setting, and expanding test coverage to validate various YAML encoding scenarios.

### Feature Addition: JSON-Style YAML Encoding
* [`pkg/envvar/const.go`](diffhunk://#diff-b0fadbbd41be976802e402a74ed5ef301ea6f668f479b3e89a095228c3c55209R18): Added a new environment variable `HELMFILE_ENABLE_GOCCY_GOYAML_JSON_STYLE` to toggle JSON-style YAML encoding.
* [`pkg/yaml/yaml.go`](diffhunk://#diff-f3e5704a72bb1c4506fdac012b4894bb5fce8445612ed745a08eb50857db141cL69-R83): Updated the `Marshal` function to conditionally enable JSON-style encoding based on the new environment variable. This includes adding options for JSON-style formatting and disabling flow style.

### Test Enhancements
* [`pkg/tmpl/context_funcs_test.go`](diffhunk://#diff-a1b34d413282a574d32127359dd18ddf6bebb81fd5029bcf1ba9059dc9a6df05L189-R264): Refactored the `TestToYaml` function into a table-driven test structure, adding multiple test cases to cover various YAML encoding scenarios, including JSON-style encoding when the new environment variable is set.

### Dependency Updates
* `pkg/tmpl/context_funcs_test.go` and `pkg/yaml/yaml.go`: Imported the `envvar` package to access the new `HELMFILE_ENABLE_GOCCY_GOYAML_JSON_STYLE` constant. [[1]](diffhunk://#diff-a1b34d413282a574d32127359dd18ddf6bebb81fd5029bcf1ba9059dc9a6df05R7-R14) [[2]](diffhunk://#diff-f3e5704a72bb1c4506fdac012b4894bb5fce8445612ed745a08eb50857db141cR6-R11)