### PR TITLE
feat(yaml): add JSON style encoding option to NewEncoder

### DIFF
--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -20,7 +20,12 @@ type Encoder interface {
 // NewEncoder creates and returns a function that is used to encode a Go object to a YAML document
 func NewEncoder(w io.Writer) Encoder {
 	if runtime.GoccyGoYaml {
-		return yaml.NewEncoder(w)
+		yamlEncoderOpts := []yaml.EncodeOption{}
+		// enable JSON style if the envvar is set
+		if os.Getenv(envvar.EnableGoccyGoYamlJSONStyle) == "true" {
+			yamlEncoderOpts = append(yamlEncoderOpts, yaml.JSON(), yaml.Flow(false))
+		}
+		return yaml.NewEncoder(w, yamlEncoderOpts...)
 	}
 
 	return v2.NewEncoder(w)


### PR DESCRIPTION
This pull request introduces a change to the `NewEncoder` function in `pkg/yaml/yaml.go` to support conditional encoding options based on an environment variable. Specifically, it enables JSON-style encoding for YAML when the environment variable `EnableGoccyGoYamlJSONStyle` is set to `true`.

Key change:

* [`pkg/yaml/yaml.go`](diffhunk://#diff-f3e5704a72bb1c4506fdac012b4894bb5fce8445612ed745a08eb50857db141cL23-R28): Updated the `NewEncoder` function to include conditional logic that checks the `EnableGoccyGoYamlJSONStyle` environment variable. If set to `true`, JSON-style encoding is enabled by adding `yaml.JSON()` and `yaml.Flow(false)` options to the encoder.