### PR TITLE
feat: add chart version to template values

### DIFF
--- a/pkg/state/state_exec_tmpl.go
+++ b/pkg/state/state_exec_tmpl.go
@@ -28,11 +28,12 @@ func (st *HelmState) createReleaseTemplateData(release *ReleaseSpec, vals map[st
 		Chart:       st.OverrideChart,
 		Values:      vals,
 		Release: releaseTemplateDataRelease{
-			Name:        release.Name,
-			Chart:       release.Chart,
-			Namespace:   release.Namespace,
-			Labels:      release.Labels,
-			KubeContext: release.KubeContext,
+			Name:         release.Name,
+			Chart:        release.Chart,
+			ChartVersion: release.Version,
+			Namespace:    release.Namespace,
+			Labels:       release.Labels,
+			KubeContext:  release.KubeContext,
 		},
 	}
 	tmplData.StateValues = &tmplData.Values

--- a/pkg/state/state_exec_tmpl_test.go
+++ b/pkg/state/state_exec_tmpl_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-test/deep"
 
 	"github.com/helmfile/helmfile/pkg/environment"
+	"github.com/helmfile/helmfile/pkg/event"
 	"github.com/helmfile/helmfile/pkg/filesystem"
 )
 
@@ -144,6 +145,41 @@ func TestHelmState_executeTemplates(t *testing.T) {
 					"--chart",
 					"test-chart",
 				},
+			},
+		},
+		{
+			name: "Has template expressions in hook args",
+			input: ReleaseSpec{
+				Name:    "test-name",
+				Chart:   "test-chart",
+				Version: "{{ .Release.Name }}-0.1.0",
+				Hooks: []event.Hook{{
+					Name:    "test-hook",
+					Command: "helm",
+					Args: []string{
+						"show",
+						"crds",
+						"{{ .Release.Chart }}",
+						"--version",
+						"{{ .Release.ChartVersion }}",
+					},
+				}},
+			},
+			want: ReleaseSpec{
+				Name:    "test-name",
+				Chart:   "test-chart",
+				Version: "test-name-0.1.0",
+				Hooks: []event.Hook{{
+					Name:    "test-hook",
+					Command: "helm",
+					Args: []string{
+						"show",
+						"crds",
+						"test-chart",
+						"--version",
+						"0.1.0",
+					},
+				}},
 			},
 		},
 	}

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -16,11 +16,11 @@ type EnvironmentTemplateData struct {
 	// Namespace is accessible as `.Namespace` from any non-values template executed by the renderer
 	Namespace string
 	// Values is accessible as `.Values` and it contains default state values overrode by environment values and override values.
-	Values      map[string]any
-	StateValues *map[string]any
+	Values      map[string]interface{}
+	StateValues *map[string]interface{}
 }
 
-func NewEnvironmentTemplateData(environment environment.Environment, namespace string, values map[string]any) *EnvironmentTemplateData {
+func NewEnvironmentTemplateData(environment environment.Environment, namespace string, values map[string]interface{}) *EnvironmentTemplateData {
 	d := EnvironmentTemplateData{environment, namespace, values, nil}
 	d.StateValues = &d.Values
 	return &d
@@ -35,8 +35,8 @@ type releaseTemplateData struct {
 	// It contains a subset of ReleaseSpec that is known to be useful to dynamically render values.
 	Release releaseTemplateDataRelease
 	// Values is accessible as `.Values` and it contains default state values overrode by environment values and override values.
-	Values      map[string]any
-	StateValues *map[string]any
+	Values      map[string]interface{}
+	StateValues *map[string]interface{}
 	// KubeContext is HelmState.OverrideKubeContext.
 	// You should better use Release.KubeContext as it might work as you'd expect even if HelmState.OverrideKubeContext is not set.
 	// See releaseTemplateDataRelease.KubeContext for more information.
@@ -63,6 +63,9 @@ type releaseTemplateDataRelease struct {
 
 	// Chart is ReleaseSpec.Chart
 	Chart string
+
+	// ChartVersion is ReleaseSpec.Version, renamed to disambiguate from the templated version field
+	ChartVersion string
 
 	// KubeContext is ReleaseSpec.KubeContext
 	KubeContext string


### PR DESCRIPTION
This exposes `ReleaseSpec.Version` as a templatable value with `.Release.ChartVersion`

for context, see https://github.com/helmfile/helmfile/discussions/2056