### PR TITLE
build: update Helm to v3.18.2 and adjust related configurations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
           # See https://github.com/helmfile/helmfile/pull/286#issuecomment-1250161182 for more context.
           - helm-version: v3.17.3
             kustomize-version: v5.2.1
-            plugin-secrets-version: 4.5.1
+            plugin-secrets-version: 4.6.5
             plugin-diff-version: 3.11.0
             extra-helmfile-flags: ''
           - helm-version: v3.17.3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
           # See https://github.com/helmfile/helmfile/pull/286#issuecomment-1250161182 for more context.
           - helm-version: v3.17.3
             kustomize-version: v5.2.1
-            plugin-secrets-version: 4.6.5
+            plugin-secrets-version: 4.5.1
             plugin-diff-version: 3.11.0
             extra-helmfile-flags: ''
           - helm-version: v3.17.3
@@ -69,19 +69,19 @@ jobs:
             plugin-secrets-version: 4.6.5
             plugin-diff-version: 3.12.1
             extra-helmfile-flags: ''
-          - helm-version: v3.18.1
+          - helm-version: v3.18.2
             kustomize-version: v5.2.1
             plugin-secrets-version: 4.6.5
             plugin-diff-version: 3.11.0
             extra-helmfile-flags: ''
-          - helm-version: v3.18.1
+          - helm-version: v3.18.2
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.5
             plugin-diff-version: 3.12.1
             extra-helmfile-flags: ''
           # In case you need to test some optional helmfile features,
           # enable it via extra-helmfile-flags below.
-          - helm-version: v3.18.1
+          - helm-version: v3.18.2
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.5
             plugin-diff-version: 3.12.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.18.1"
+ARG HELM_VERSION="v3.18.2"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -38,8 +38,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="b1c7e8e261fd30f34c617282813ecafc63628fcd59a255a9fc51b1fe43394c05"  ;; \
-    "linux/arm64")  HELM_SHA256="5ddc8fbd4b17857754a95be799543ceafa5aa9532b05f738ee590a76bb049988"  ;; \
+    "linux/amd64")  HELM_SHA256="c5deada86fe609deefdf40e9cbbe3da2f8cf3f6a4551a0ebe7886dc8fcf98bce"  ;; \
+    "linux/arm64")  HELM_SHA256="03181a494a0916b370a100a5b2536104963b095be53fb23d1e29b2afb1c7de8d"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -35,7 +35,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.18.1"
+ARG HELM_VERSION="v3.18.2"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -43,8 +43,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="b1c7e8e261fd30f34c617282813ecafc63628fcd59a255a9fc51b1fe43394c05"  ;; \
-    "linux/arm64")  HELM_SHA256="5ddc8fbd4b17857754a95be799543ceafa5aa9532b05f738ee590a76bb049988"  ;; \
+    "linux/amd64")  HELM_SHA256="c5deada86fe609deefdf40e9cbbe3da2f8cf3f6a4551a0ebe7886dc8fcf98bce"  ;; \
+    "linux/arm64")  HELM_SHA256="03181a494a0916b370a100a5b2536104963b095be53fb23d1e29b2afb1c7de8d"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -35,7 +35,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.18.1"
+ARG HELM_VERSION="v3.18.2"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -43,8 +43,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="b1c7e8e261fd30f34c617282813ecafc63628fcd59a255a9fc51b1fe43394c05"  ;; \
-    "linux/arm64")  HELM_SHA256="5ddc8fbd4b17857754a95be799543ceafa5aa9532b05f738ee590a76bb049988"  ;; \
+    "linux/amd64")  HELM_SHA256="c5deada86fe609deefdf40e9cbbe3da2f8cf3f6a4551a0ebe7886dc8fcf98bce"  ;; \
+    "linux/arm64")  HELM_SHA256="03181a494a0916b370a100a5b2536104963b095be53fb23d1e29b2afb1c7de8d"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	HelmRequiredVersion           = "v3.17.3"
-	HelmRecommendedVersion        = "v3.18.1"
+	HelmRecommendedVersion        = "v3.18.2"
 	HelmDiffRecommendedVersion    = "v3.12.1"
 	HelmSecretsRecommendedVersion = "v4.6.5"
 	HelmGitRecommendedVersion     = "v1.3.0"


### PR DESCRIPTION
This pull request updates the Helm version across multiple files to `v3.18.2` and adjusts related SHA256 checksums for the new version. It also includes a minor downgrade of the `plugin-secrets` version in the CI configuration. These changes ensure compatibility with the latest Helm release while maintaining consistency across Dockerfiles, CI workflows, and Go module dependencies.

### Helm Version Updates:

* Updated Helm version to `v3.18.2` in `Dockerfile`, `Dockerfile.debian-stable-slim`, and `Dockerfile.ubuntu`, along with corresponding SHA256 checksum values for `linux/amd64` and `linux/arm64` platforms. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L33-R42) [[2]](diffhunk://#diff-ba602f969c43d8bdc4cbe0c2243476dfcc51f818d28f079418302e94cf7e791aL38-R47) [[3]](diffhunk://#diff-b4c6189f9184e61338a887d10410ec33e466f2fdba640cb632fab869dcb8b289L38-R47)
* Updated Helm version to `v3.18.2` in `go.mod` and `pkg/app/init.go` to align Go module dependencies and application constants with the new version. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L32-R32) [[2]](diffhunk://#diff-a8d88c94aa5b407b495d262c095333250dae969e2cdde4db3d3783394e742e9bL21-R21)

### CI Workflow Adjustments:

* Downgraded `plugin-secrets-version` from `4.6.5` to `4.5.1` in the CI configuration.
* Updated Helm version references in the CI workflow to `v3.18.2`.