### PR TITLE
fix: `TestToYaml` not working with 32-bit architectures

### DIFF
--- a/pkg/tmpl/context_funcs_test.go
+++ b/pkg/tmpl/context_funcs_test.go
@@ -201,7 +201,7 @@ func TestToYaml(t *testing.T) {
 		},
 		{
 			name:  "test unmarshalling issue 2024 with int64",
-			input: map[string]any{"thisShouldBeString": 1234567890123456789},
+			input: map[string]any{"thisShouldBeString": int64(1234567890123456789)},
 			expected: `thisShouldBeString: 1234567890123456789
 `,
 		},


### PR DESCRIPTION
I've opened a [MR to updated the alpine package](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/85529) and noticed that the release 1.1.0 introduced a test which does not compile on 32-bit architectures. This should fix the problem (tested it with `podman run --arch i386 ...` and `go test $(go list ./... | grep -v /e2e)`). It would be nice if this fix would be released in the near future, but considering past events I have no doubt ^^ (but don't get me wrong, do not rush, if it takes time, it takes time).

Completely off topic, what is your policy on updating the minimum supported `helm` version? Before 1.0.0 the minimum supported version has regularly been updated. That was fine for a pre-stable release, but I guess now this could be considered a breaking change. What is your opinion regarding that (if this is a bigger topic I would create an issue so that other people would also notice it)?