### PR TITLE
docs: update status section with May 2025 release information

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Deploy Kubernetes Helm Charts
 May 2025 Update
 
 * Helmfile v1.0 and v1.1 has been released. We recommend upgrading directly to v1.1 if you are still using v0.x.
-* If you haven't already upgraded, please go over this v1 proposal [here](docs/proposals/towards-1.0.md) to see a small list of breaking changes.
+* If you haven't already upgraded, please go over this v1 proposal [here](https://github.com/helmfile/helmfile/blob/main/docs/proposals/towards-1.0.md) to see a small list of breaking changes.
 
 ## About
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,13 +24,10 @@ Deploy Kubernetes Helm Charts
 
 ## Status
 
-March 2022 Update - The helmfile project has been moved to [helmfile/helmfile](https://github.com/helmfile/helmfile) from the former home `roboll/helmfile`. Please see [roboll/helmfile#1824](https://github.com/roboll/helmfile/issues/1824) for more information.
+May 2025 Update
 
-Even though Helmfile is used in production environments [across multiple organizations](users.md), it is still in its early stage of development, hence versioned 0.x.
-
-Helmfile complies to Semantic Versioning 2.0.0 in which v0.x means that there could be backward-incompatible changes for every release.
-
-Note that we will try our best to document any backward incompatibility. And in reality, helmfile had no breaking change for a year or so.
+* Helmfile v1.0 and v1.1 has been released. We recommend upgrading directly to v1.1 if you are still using v0.x.
+* If you haven't already upgraded, please go over this v1 proposal [here](docs/proposals/towards-1.0.md) to see a small list of breaking changes.
 
 ## About
 


### PR DESCRIPTION
This pull request updates the `Deploy Kubernetes Helm Charts` section in the `docs/index.md` file to reflect the latest status of the Helmfile project. The changes focus on updating the project's versioning information and providing guidance on upgrading.

### Documentation updates:
* Removed outdated information about Helmfile being in its early development stage and versioned as 0.x.
* Added details about the release of Helmfile v1.0 and v1.1, recommending users to upgrade to v1.1 and review the v1 proposal for breaking changes.