### PR TITLE
fix: update Helm version to v3.17.4 in CI and init.go

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,12 +54,12 @@ jobs:
           # Helm maintains the latest minor version only and therefore each Helmfile version supports 2 Helm minor versions.
           # That's why we cover only 2 Helm minor versions in this matrix.
           # See https://github.com/helmfile/helmfile/pull/286#issuecomment-1250161182 for more context.
-          - helm-version: v3.17.3
+          - helm-version: v3.17.4
             kustomize-version: v5.2.1
             plugin-secrets-version: 4.6.5
             plugin-diff-version: 3.11.0
             extra-helmfile-flags: ''
-          - helm-version: v3.17.3
+          - helm-version: v3.17.4
             kustomize-version: v5.4.3
             # We assume that the helm-secrets plugin is supposed to
             # work with the two most recent helm minor versions.

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	HelmRequiredVersion           = "v3.17.3"
+	HelmRequiredVersion           = "v3.17.4"
 	HelmDiffRecommendedVersion    = "v3.12.3"
 	HelmRecommendedVersion        = "v3.18.4"
 	HelmSecretsRecommendedVersion = "v4.6.5"


### PR DESCRIPTION
This pull request includes updates to the Helm version used in the project to ensure compatibility with the latest minor release. The changes primarily focus on updating version references in configuration and initialization files.

### Helm version updates:
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL57-R62): Updated the Helm version in the CI workflow matrix from `v3.17.3` to `v3.17.4` to align with the latest minor release.
* [`pkg/app/init.go`](diffhunk://#diff-a8d88c94aa5b407b495d262c095333250dae969e2cdde4db3d3783394e742e9bL20-R20): Updated the `HelmRequiredVersion` constant from `v3.17.3` to `v3.17.4` to reflect the new required version.