### PR TITLE
feat: Ensure repo update is only run once (#1310)

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1468,7 +1468,7 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 	}
 
 	if len(builds) > 0 {
-		if err := st.runHelmDepBuilds(helm, concurrency, builds); err != nil {
+		if err := st.runHelmDepBuilds(helm, concurrency, builds, opts); err != nil {
 			return nil, []error{err}
 		}
 	}
@@ -1477,7 +1477,7 @@ func (st *HelmState) PrepareCharts(helm helmexec.Interface, dir string, concurre
 }
 
 // nolint: unparam
-func (st *HelmState) runHelmDepBuilds(helm helmexec.Interface, concurrency int, builds []*chartPrepareResult) error {
+func (st *HelmState) runHelmDepBuilds(helm helmexec.Interface, concurrency int, builds []*chartPrepareResult, opts ChartPrepareOptions) error {
 	// NOTES:
 	// 1. `helm dep build` fails when it was run concurrency on the same chart.
 	//    To avoid that, we run `helm dep build` only once per each local chart.
@@ -1488,7 +1488,20 @@ func (st *HelmState) runHelmDepBuilds(helm helmexec.Interface, concurrency int, 
 	//
 	//    See https://github.com/roboll/helmfile/issues/1521
 
+	// Perform an update of repos once before running `helm dep build` so that we
+	// can safely pass --skip-refresh to the command to avoid doing a repo update
+	// for every iteration of the loop where charts have external dependencies.
+	if len(builds) > 0 && !opts.SkipRefresh {
+		if err := helm.UpdateRepo(); err != nil {
+			return fmt.Errorf("updating repo: %w", err)
+		}
+	}
+
 	for _, r := range builds {
+		// Never update the local repository cache here, since we've already
+		// updated it before entering the loop
+		r.skipRefresh = true
+
 		buildDepsFlags := getBuildDepsFlags(r)
 		if err := helm.BuildDeps(r.releaseName, r.chartPath, buildDepsFlags...); err != nil {
 			if r.chartFetchedByGoGetter {


### PR DESCRIPTION
By default `helm dep build` will fetch repo updates before building the chart (see https://github.com/helmfile/helmfile/issues/1310). For helmfile this means for every chart with remote dependencies, another repo update is performed. This isn't necessary as the cache only needs to be refreshed once.

By performing a `helm repo update` before running any `helm dep`, it is safe to pass `--skip-refresh` to all `helm dep build` commands as the cache will be up-to-date.

A few notes to be aware of for this change:
* If there are **no remote dependencies** then this will lead to an extra refresh that could be unnecessary. However, a single repo update is usually quite fast and can still be skipped with a manual `--skip-refresh`.
* There are no tests for this new behaviour yet
* I think even this single update might be unnecessary as any initial `helm repo add --force-update` that is normally performed anyway and should already refresh all repos. However, I wasn't confident enough to simply force this flag at all times and considered this the safer option.

I would appreciate some guidance how to best test this new behaviour. The extensive test suite is awesome, but it's hard to get started with adding a new test. I've found `app_test.go:TestApply` and `app_apply_test.go:TestApply_2` but I'm not sure if that's the right place to add.

As noted, I'm also not sure if this repo update is necessary at all given how `helm repo add` behaves (and seems to always be invoked unless skipped with the same flags that'd skip this call anyway). This could also be a risk if in the future `helm repo add` is changed to only update the repo list if changes were made.