### PR TITLE
refactor(state): extract getMissingFileHandler method for clarity

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -28,6 +28,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
+      - name: check disk usage
+        run: df -h
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -3210,7 +3210,7 @@ func (st *HelmState) ExpandedHelmfiles() ([]SubHelmfileSpec, error) {
 		}
 		if len(matches) == 0 {
 			err := fmt.Errorf("no matches for path: %s", hf.Path)
-			if *st.MissingFileHandler == "Error" {
+			if *st.getMissingFileHandler() == "Error" {
 				return nil, err
 			}
 			st.logger.Warnf("no matches for path: %s", hf.Path)
@@ -3291,6 +3291,19 @@ func (st *HelmState) getReleaseMissingFileHandler(release *ReleaseSpec) *string 
 	switch {
 	case release.MissingFileHandler != nil:
 		return release.MissingFileHandler
+	case st.MissingFileHandler != nil:
+		return st.MissingFileHandler
+	default:
+		return &defaultMissingFileHandler
+	}
+}
+
+// getMissingFileHandler returns the first non-nil MissingFileHandler in the following order:
+// - st.MissingFileHandler
+// - "Error"
+func (st *HelmState) getMissingFileHandler() *string {
+	defaultMissingFileHandler := "Error"
+	switch {
 	case st.MissingFileHandler != nil:
 		return st.MissingFileHandler
 	default:


### PR DESCRIPTION
This pull request introduces a new helper method to improve how the missing file handler is determined in the `HelmState` logic. The main change is the addition of the `getMissingFileHandler` method, which centralizes and simplifies the logic for selecting the appropriate missing file handler value.

**Refactoring and logic improvement:**

* Added the `getMissingFileHandler` method to `HelmState`, which returns the first non-nil `MissingFileHandler` or defaults to `"Error"` if none is set.
* Updated the `ExpandedHelmfiles` method to use `getMissingFileHandler` instead of directly accessing `MissingFileHandler`, ensuring consistent behavior and reducing code duplication.



https://github.com/helmfile/helmfile/issues/2119#issuecomment-3185182387