### PR TITLE
build: update helm to v3.18.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,19 +69,19 @@ jobs:
             plugin-secrets-version: 4.6.5
             plugin-diff-version: 3.12.5
             extra-helmfile-flags: ''
-          - helm-version: v3.18.5
+          - helm-version: v3.18.6
             kustomize-version: v5.2.1
             plugin-secrets-version: 4.6.5
             plugin-diff-version: 3.11.0
             extra-helmfile-flags: ''
-          - helm-version: v3.18.5
+          - helm-version: v3.18.6
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.5
             plugin-diff-version: 3.12.5
             extra-helmfile-flags: ''
           # In case you need to test some optional helmfile features,
           # enable it via extra-helmfile-flags below.
-          - helm-version: v3.18.5
+          - helm-version: v3.18.6
             kustomize-version: v5.4.3
             plugin-secrets-version: 4.6.5
             plugin-diff-version: 3.12.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.18.5"
+ARG HELM_VERSION="v3.18.6"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -38,8 +38,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="9879bf9c471cdecbbee5ee17cf1de1849b0ffd12871ea01f17ede6861d7134f5"  ;; \
-    "linux/arm64")  HELM_SHA256="d25d2c1b1c5a9844755ab5c66e6df4d6b31c25e6d92dd2ce66c137a63ddf9f2c"  ;; \
+    "linux/amd64")  HELM_SHA256="3f43c0aa57243852dd542493a0f54f1396c0bc8ec7296bbb2c01e802010819ce"  ;; \
+    "linux/arm64")  HELM_SHA256="5b8e00b6709caab466cbbb0bc29ee09059b8dc9417991dd04b497530e49b1737"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -35,7 +35,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.18.5"
+ARG HELM_VERSION="v3.18.6"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -43,8 +43,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="9879bf9c471cdecbbee5ee17cf1de1849b0ffd12871ea01f17ede6861d7134f5"  ;; \
-    "linux/arm64")  HELM_SHA256="d25d2c1b1c5a9844755ab5c66e6df4d6b31c25e6d92dd2ce66c137a63ddf9f2c"  ;; \
+    "linux/amd64")  HELM_SHA256="3f43c0aa57243852dd542493a0f54f1396c0bc8ec7296bbb2c01e802010819ce"  ;; \
+    "linux/arm64")  HELM_SHA256="5b8e00b6709caab466cbbb0bc29ee09059b8dc9417991dd04b497530e49b1737"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -35,7 +35,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v3.18.5"
+ARG HELM_VERSION="v3.18.6"
 ENV HELM_VERSION="${HELM_VERSION}"
 ARG HELM_LOCATION="https://get.helm.sh"
 ARG HELM_FILENAME="helm-${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz"
@@ -43,8 +43,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="9879bf9c471cdecbbee5ee17cf1de1849b0ffd12871ea01f17ede6861d7134f5"  ;; \
-    "linux/arm64")  HELM_SHA256="d25d2c1b1c5a9844755ab5c66e6df4d6b31c25e6d92dd2ce66c137a63ddf9f2c"  ;; \
+    "linux/amd64")  HELM_SHA256="3f43c0aa57243852dd542493a0f54f1396c0bc8ec7296bbb2c01e802010819ce"  ;; \
+    "linux/arm64")  HELM_SHA256="5b8e00b6709caab466cbbb0bc29ee09059b8dc9417991dd04b497530e49b1737"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sync v0.16.0
 	golang.org/x/term v0.34.0
-	helm.sh/helm/v3 v3.18.5
+	helm.sh/helm/v3 v3.18.6
 	k8s.io/apimachinery v0.33.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2301,8 +2301,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-helm.sh/helm/v3 v3.18.5 h1:Cc3Z5vd6kDrZq9wO9KxKLNEickiTho6/H/dBNRVSos4=
-helm.sh/helm/v3 v3.18.5/go.mod h1:L/dXDR2r539oPlFP1PJqKAC1CUgqHJDLkxKpDGrWnyg=
+helm.sh/helm/v3 v3.18.6 h1:S/2CqcYnNfLckkHLI0VgQbxgcDaU3N4A/46E3n9wSNY=
+helm.sh/helm/v3 v3.18.6/go.mod h1:L/dXDR2r539oPlFP1PJqKAC1CUgqHJDLkxKpDGrWnyg=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -19,7 +19,7 @@ import (
 const (
 	HelmRequiredVersion           = "v3.17.4"
 	HelmDiffRecommendedVersion    = "v3.12.5"
-	HelmRecommendedVersion        = "v3.18.5"
+	HelmRecommendedVersion        = "v3.18.6"
 	HelmSecretsRecommendedVersion = "v4.6.5"
 	HelmGitRecommendedVersion     = "v1.3.0"
 	HelmS3RecommendedVersion      = "v0.16.3"


### PR DESCRIPTION
This pull request upgrades the recommended and used version of Helm from v3.18.5 to v3.18.6 across the codebase, including Dockerfiles, CI workflows, and Go dependencies. This ensures consistency and brings in the latest fixes and improvements from Helm.

**Helm version upgrade:**

* Updated the Helm version from `v3.18.5` to `v3.18.6` in the following places:
  * `Dockerfile`, `Dockerfile.ubuntu`, and `Dockerfile.debian-stable-slim`, including the corresponding SHA256 checksums for both `amd64` and `arm64` architectures. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L33-R42) [[2]](diffhunk://#diff-b4c6189f9184e61338a887d10410ec33e466f2fdba640cb632fab869dcb8b289L38-R47) [[3]](diffhunk://#diff-ba602f969c43d8bdc4cbe0c2243476dfcc51f818d28f079418302e94cf7e791aL38-R47)
  * `.github/workflows/ci.yaml` to ensure CI uses the updated Helm version.
  * `go.mod` to update the Helm Go module dependency.
  * `pkg/app/init.go` to set `HelmRecommendedVersion` to `v3.18.6`.