### PR TITLE
fix pflag error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,7 +76,7 @@ func NewRootCmd(globalConfig *config.GlobalOptions) (*cobra.Command, error) {
 	// Set the global options for the root command.
 	setGlobalOptionsForRootCmd(flags, globalConfig)
 
-	flags.ParseErrorsWhitelist.UnknownFlags = true
+	flags.ParseErrorsAllowlist.UnknownFlags = true
 
 	globalImpl := config.NewGlobalImpl(globalConfig)
 


### PR DESCRIPTION
fixing this error, which was caught in CI:

```
run golangci-lint
  Running [/home/runner/golangci-lint-2.1.6-linux-amd64/golangci-lint config path] in [/home/runner/work/helmfile/helmfile] ...
  Running [/home/runner/golangci-lint-2.1.6-linux-amd64/golangci-lint config verify] in [/home/runner/work/helmfile/helmfile] ...
  Running [/home/runner/golangci-lint-2.1.6-linux-amd64/golangci-lint run] in [/home/runner/work/helmfile/helmfile] ...
  Error: cmd/root.go:79:2: SA1019: flags.ParseErrorsWhitelist is deprecated: use [FlagSet.ParseErrorsAllowlist] instead. This field will be removed in a future release. (staticcheck)
  	flags.ParseErrorsWhitelist.UnknownFlags = true
  	^
  1 issues:
  * staticcheck: 1
  
  Error: issues found
  Ran golangci-lint in 162900ms
```