### PR TITLE
ci: update minikube and kubernetes versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,7 +108,10 @@ jobs:
           KUSTOMIZE_VERSION: ${{ matrix.kustomize-version }}
         run: make -C .github/workflows helm vault sops kustomize
       - name: Start minikube
-        uses: medyagh/setup-minikube@latest
+        uses: medyagh/setup-minikube@v0.0.20
+        with:
+          kubernetes-version: v1.33.1 
+          minikube-version: v1.36.0
       - name: Execute integration tests
         run: make integration
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,10 +108,9 @@ jobs:
           KUSTOMIZE_VERSION: ${{ matrix.kustomize-version }}
         run: make -C .github/workflows helm vault sops kustomize
       - name: Start minikube
-        uses: medyagh/setup-minikube@v0.0.20
+        uses: medyagh/setup-minikube@latest
         with:
           kubernetes-version: v1.33.1 
-          minikube-version: v1.36.0
       - name: Execute integration tests
         run: make integration
         env:


### PR DESCRIPTION
This pull request makes a small update to the CI workflow configuration by pinning the versions of Minikube and Kubernetes used in the integration tests. This helps ensure more consistent and reproducible test environments.

* CI workflow update:
  * [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL111-R114): Changed the `setup-minikube` action to use version `v0.0.20` and added explicit `kubernetes-version` (`v1.33.1`) and `minikube-version` (`v1.36.0`) parameters.