### PR TITLE
cleanup disk in release ci

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -35,7 +35,6 @@ jobs:
             rm -rf /usr/share/dotnet
             rm -rf /opt/ghc
             rm -rf "/usr/local/share/boost"
-            rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -32,13 +32,15 @@ jobs:
         run: df -h
       - name: cleanup disk
         run: |
-            rm -rf /usr/share/dotnet
-            rm -rf /opt/ghc
-            rm -rf /usr/local/share/boost
-            rm -fr /usr/local/lib/android
-            rm -fr /opt/hostedtoolcache/CodeQL
-            docker image prune --all --force
-            docker builder prune -a
+            sudo rm -rf /usr/share/dotnet
+            sudo rm -rf /opt/ghc
+            sudo rm -rf /usr/local/share/boost
+            sudo rm -fr /usr/local/lib/android
+            sudo rm -fr /opt/hostedtoolcache/CodeQL
+            sudo docker image prune --all --force
+            sudo docker builder prune -a
+      - name: check disk usage
+        run: df -h
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -34,7 +34,11 @@ jobs:
         run: |
             rm -rf /usr/share/dotnet
             rm -rf /opt/ghc
-            rm -rf "/usr/local/share/boost"
+            rm -rf /usr/local/share/boost
+            rm -fr /usr/local/lib/android
+            rm -fr /opt/hostedtoolcache/CodeQL
+            docker image prune --all --force
+            docker builder prune -a
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -30,6 +30,12 @@ jobs:
           go-version-file: go.mod
       - name: check disk usage
         run: df -h
+      - name: cleanup disk
+        run: |
+            rm -rf /usr/share/dotnet
+            rm -rf /opt/ghc
+            rm -rf "/usr/local/share/boost"
+            rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest


### PR DESCRIPTION
This pull request adds a disk cleanup step to the release workflow to help free up space before running the release process.

* Workflow improvement:
  * [`.github/workflows/releaser.yaml`](diffhunk://#diff-723fcb434a7bf0f56b6f4505b087ee476e1c11b0d4698eb9180a5928b1c7142cR33-R38): Added a new "cleanup disk" step that removes unused directories (`/usr/share/dotnet`, `/opt/ghc`, `/usr/local/share/boost`, and `$AGENT_TOOLSDIRECTORY`) to reduce disk usage prior to the release step.