### PR TITLE
Bump Alpine to 3.22 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN make static-${TARGETOS}-${TARGETARCH}
 
 # -----------------------------------------------------------------------------
 
-FROM alpine:3.19
+FROM alpine:3.22
 
 LABEL org.opencontainers.image.source=https://github.com/helmfile/helmfile
 


### PR DESCRIPTION
Simply bumps Dockerfile to use newer Alpine version 3.22