### PR TITLE
fix(helmexec): enhance Helm version detection to support both v3 and v4 formats

### DIFF
--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -761,7 +761,9 @@ func (helm *execer) write(w io.Writer, out []byte) {
 }
 
 func (helm *execer) IsHelm3() bool {
-	return helm.version.Major() == 3
+	// Return true for Helm 3 and later (including Helm 4+)
+	// This function really means "is not Helm 2"
+	return helm.version.Major() >= 3
 }
 
 func (helm *execer) GetVersion() Version {

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -1128,6 +1128,15 @@ func Test_IsHelm3(t *testing.T) {
 	if !helm.IsHelm3() {
 		t.Error("helmexec.IsHelm3() - Failed to detect Helm 3")
 	}
+
+	helm4Runner := mockRunner{output: []byte("v4.0.0+ge29ce2a\n")}
+	helm, err = New("helm", HelmExecOptions{}, NewLogger(os.Stdout, "info"), "", "dev", &helm4Runner)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !helm.IsHelm3() {
+		t.Error("helmexec.IsHelm3() - Failed to detect Helm 4 (should return true for Helm 3+)")
+	}
 }
 
 func Test_GetPluginVersion(t *testing.T) {


### PR DESCRIPTION
Updated the Execute method in mockRunner to handle Helm version commands for both v3 (with --client) and v4 (without --client). The GetHelmVersion function now attempts to retrieve the version using the v4 format first, falling back to v3 if necessary, ensuring backward compatibility.

Changes:
- Modified command string checks in Execute method to support both Helm versions.
- Adjusted GetHelmVersion to prioritize v4 format for version retrieval.

This improves compatibility with different Helm versions and enhances the overall robustness of the version detection logic.