### PR TITLE
disable AWS GO SDK logging

### DIFF
--- a/pkg/plugins/vals.go
+++ b/pkg/plugins/vals.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"io"
+	"os"
 	"sync"
 
 	"github.com/helmfile/vals"
@@ -18,6 +19,12 @@ var once sync.Once
 func ValsInstance() (*vals.Runtime, error) {
 	var err error
 	once.Do(func() {
+		// vals' AWS helper enables SDK request logging by default unless AWS_SDK_GO_LOG_LEVEL is set.
+		// Force it off unless the user explicitly opted in to avoid leaking sensitive headers.
+		if _, exists := os.LookupEnv("AWS_SDK_GO_LOG_LEVEL"); !exists {
+			_ = os.Setenv("AWS_SDK_GO_LOG_LEVEL", "off")
+		}
+
 		// Set LogOutput to io.Discard to suppress debug logs from AWS SDK and other providers
 		// This prevents sensitive information (tokens, auth headers) from being logged to stdout
 		// See issue #2270


### PR DESCRIPTION
https://github.com/helmfile/helmfile/issues/2270 is still occurring for me with helmfile 1.2.1

❯ helmfile version

▓▓▓ helmfile

  Version            v1.2.1
  Git Commit         "brew"
  Build Date         23 Nov 25 16:32 +07 (15 hours ago)
  Commit Date        23 Nov 25 16:32 +07 (15 hours ago)
  Dirty Build        no
  Go version         1.25.4
  Compiler           gc
  Platform           darwin/arm64
❯
❯ helmfile diff -l cluster=staging
SDK 2025/11/24 07:54:06 DEBUG Request
PUT /latest/api/token HTTP/1.1
Host: 169.254.169.254

As I said this started happening with helmfile 1.1.6 and this PR would be a workaround.

https://github.com/helmfile/vals/releases/tag/v0.42.1

Vals 0.42.1 migrated to the new Go SDK version. I believe by default the AWS Go SDK logs as INFO.