### PR TITLE
Fix chartify assertion failure when rendered chart output is empty (Issue #1757)

### DIFF
--- a/pkg/state/issue_1757_test.go
+++ b/pkg/state/issue_1757_test.go
@@ -1,0 +1,204 @@
+package state
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/helmfile/vals"
+	"github.com/helmfile/helmfile/pkg/filesystem"
+	"github.com/helmfile/helmfile/pkg/helmexec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue1757(t *testing.T) {
+	// Create a temporary directory for the test
+	tmpDir, err := os.MkdirTemp("", "issue1757")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create the chart directory structure
+	chartDir := filepath.Join(tmpDir, "chart")
+	err = os.MkdirAll(filepath.Join(chartDir, "templates"), 0755)
+	require.NoError(t, err)
+
+	// Write Chart.yaml
+	err = os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte(`apiVersion: v2
+type: application
+name: test
+version: 0.1.0
+`), 0644)
+	require.NoError(t, err)
+
+	// Write values.yaml (enabled: false to produce empty output)
+	err = os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte(`enabled: false
+`), 0644)
+	require.NoError(t, err)
+
+	// Write templates/configmap.yaml
+	err = os.WriteFile(filepath.Join(chartDir, "templates/configmap.yaml"), []byte(`{{- if .Values.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+{{- end }}
+`), 0644)
+	require.NoError(t, err)
+
+	// Setup HelmState
+	logger := helmexec.NewLogger(os.Stdout, "debug")
+	fs := filesystem.DefaultFileSystem()
+	valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
+	require.NoError(t, err)
+	
+	st := &HelmState{
+		basePath: tmpDir,
+		logger:   logger,
+		fs:       fs,
+		ReleaseSetSpec: ReleaseSetSpec{
+			DefaultHelmBinary: "helm",
+		},
+		RenderedValues: map[string]any{},
+		valsRuntime:    valsRuntime,
+	}
+
+	// Define the release with transformers
+	release := &ReleaseSpec{
+		Name:      "test",
+		Chart:     filepath.Join(tmpDir, "chart"),
+		Namespace: "default",
+		Transformers: []any{
+			map[string]any{
+				"apiVersion": "builtin",
+				"kind":       "LabelTransformer",
+				"metadata": map[string]any{
+					"name": "unused",
+				},
+				"labels": map[string]any{
+					"foo": "bar",
+				},
+				"fieldSpecs": []any{
+					map[string]any{
+						"path":   "spec/groups/rules/labels",
+						"create": true,
+					},
+				},
+			},
+		},
+	}
+
+	// We need a helm executor
+	runner := helmexec.ShellRunner{
+		Logger: logger,
+		Ctx:    context.Background(),
+	}
+	helm, err := helmexec.New("helm", helmexec.HelmExecOptions{}, logger, "", "", runner)
+	require.NoError(t, err)
+
+	// Call PrepareCharts which triggers the chartification process
+	opts := ChartPrepareOptions{
+		OutputDir: tmpDir,
+	}
+	
+	// We need to add the release to the state
+	st.Releases = []ReleaseSpec{*release}
+
+	_, errs := st.PrepareCharts(helm, tmpDir, 1, "template", opts)
+	
+	require.Empty(t, errs, "PrepareCharts should not return errors")
+}
+
+func TestIssue1757_JSONPatches(t *testing.T) {
+	// Create a temporary directory for the test
+	tmpDir, err := os.MkdirTemp("", "issue1757_json")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create the chart directory structure
+	chartDir := filepath.Join(tmpDir, "chart")
+	err = os.MkdirAll(filepath.Join(chartDir, "templates"), 0755)
+	require.NoError(t, err)
+
+	// Write Chart.yaml
+	err = os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte(`apiVersion: v2
+type: application
+name: test
+version: 0.1.0
+`), 0644)
+	require.NoError(t, err)
+
+	// Write values.yaml (enabled: false to produce empty output)
+	err = os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte(`enabled: false
+`), 0644)
+	require.NoError(t, err)
+
+	// Write templates/configmap.yaml
+	err = os.WriteFile(filepath.Join(chartDir, "templates/configmap.yaml"), []byte(`{{- if .Values.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test
+{{- end }}
+`), 0644)
+	require.NoError(t, err)
+
+	// Setup HelmState
+	logger := helmexec.NewLogger(os.Stdout, "debug")
+	fs := filesystem.DefaultFileSystem()
+	valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
+	require.NoError(t, err)
+	
+	st := &HelmState{
+		basePath: tmpDir,
+		logger:   logger,
+		fs:       fs,
+		ReleaseSetSpec: ReleaseSetSpec{
+			DefaultHelmBinary: "helm",
+		},
+		RenderedValues: map[string]any{},
+		valsRuntime:    valsRuntime,
+	}
+
+	// Define the release with jsonPatches
+	release := &ReleaseSpec{
+		Name:      "test",
+		Chart:     filepath.Join(tmpDir, "chart"),
+		Namespace: "default",
+		JSONPatches: []any{
+			map[string]any{
+				"target": map[string]any{
+					"kind": "ConfigMap",
+					"name": "test",
+				},
+				"patch": []any{
+					map[string]any{
+						"op":    "add",
+						"path":  "/metadata/labels/foo",
+						"value": "bar",
+					},
+				},
+			},
+		},
+	}
+
+	// We need a helm executor
+	runner := helmexec.ShellRunner{
+		Logger: logger,
+		Ctx:    context.Background(),
+	}
+	helm, err := helmexec.New("helm", helmexec.HelmExecOptions{}, logger, "", "", runner)
+	require.NoError(t, err)
+
+	// Call PrepareCharts which triggers the chartification process
+	opts := ChartPrepareOptions{
+		OutputDir: tmpDir,
+	}
+	
+	// We need to add the release to the state
+	st.Releases = []ReleaseSpec{*release}
+
+	_, errs := st.PrepareCharts(helm, tmpDir, 1, "template", opts)
+	
+	require.Empty(t, errs, "PrepareCharts should not return errors with JSONPatches")
+}


### PR DESCRIPTION

Helmfile fails with an assertion error when using `transformers`, `jsonPatches`, or `strategicMergePatches` on a Helm chart that renders no resources. The error occurs because the `chartify` library expects output files to exist, but when `helm template` produces no output (e.g., when a chart is conditionally disabled), the chartify process fails with:

```
assertion failed: unexpected dir entry "" it must be the abs path to the output directory
```

## Root Cause
The issue happens in the `processChartification` function in `pkg/state/state.go`. When a chart renders no resources but has chartification operations configured, chartify attempts to process an empty output directory, triggering an assertion failure.

## Solution
Added error handling to detect the specific chartify assertion error and treat it as a no-op operation. When this error occurs:

1. Log a debug message indicating empty output was received
2. Return the original chart path without modification  
3. Continue processing without error

## Changes Made

### 1. Fixed `pkg/state/state.go`
- Added error handling after `c.Chartify()` call
- Detects the specific assertion error message
- Returns early with the original chart path when detected

```go
out, err := c.Chartify(release.Name, chartPath, chartify.WithChartifyOpts(chartifyOpts))
if err != nil {
    // Work around chartify failing when the rendered chart output is empty but
    // jsonPatches / strategicMergePatches / transformers are configured.
    // See https://github.com/helmfile/helmfile/issues/1757
    if strings.Contains(err.Error(), `unexpected dir entry "" it must be the abs path to the output directory`) {
        st.logger.Debugf("Chartify returned empty output for release %s, treating as no-op chartification", release.Name)
        return chartPath, false, nil
    }
    return "", false, err
}
```

### 2. Added Comprehensive Tests in `pkg/state/issue_1757_test.go`
- `TestIssue1757`: Tests with `transformers` configuration
- `TestIssue1757_JSONPatches`: Tests with `jsonPatches` configuration  
- Both tests create charts that render no resources but have chartification operations
- Verifies that `PrepareCharts` completes successfully without errors

## Test Coverage
The tests cover scenarios where:
- A Helm chart has `enabled: false` in values, producing empty template output
- Chartification operations (`transformers` or `jsonPatches`) are configured
- The chartify assertion error would have occurred
- Helmfile now handles the situation gracefully

## Backward Compatibility
This change is fully backward compatible:
- Normal chartification operations continue to work as before
- Only the specific assertion error case is handled differently
- No changes to existing behavior for charts with non-empty output

## Verification
Run the following to verify the fix:

```bash
go test -v ./pkg/state -run TestIssue1757
```

Both test cases should pass, confirming that the issue is resolved for both transformers and JSONPatches scenarios.

## Related Issues
- Fixes #1757: Chartify assertion failure on empty output with transformers/patches
