### PR TITLE
feat: Add option for SkipCRDs to HelmDefaults

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -761,7 +761,7 @@ func (st *HelmState) prepareSyncReleases(helm helmexec.Interface, additionalValu
 					}
 				}
 
-				if st.HelmDefault.SkipCRDs || opts.SkipCRDs {
+				if st.HelmDefaults.SkipCRDs || opts.SkipCRDs {
 					flags = append(flags, "--skip-crds")
 				}
 


### PR DESCRIPTION
This adds a helmDefault option for SkipCRDs which passes the --skip-crds flag to `helm upgrade --install`.

Apparently a lot of the plumbing for this already exists in the form of ApplyOptions/SyncOptions which can be set via the CLI for `helmfile sync` or `helmfile apply` via the `--skip-crds` flag.

All I'm doing is wiring up the HelmDefaults so that it can be used to set that underlying `helm` flag as well.

Referencing:
https://github.com/helmfile/helmfile/discussions/929
https://github.com/helmfile/helmfile/issues/713