### PR TITLE
fix: pass --kube-context to helm template when using jsonPatches

### DIFF
--- a/pkg/app/app_template_test.go
+++ b/pkg/app/app_template_test.go
@@ -188,9 +188,10 @@ releases:
 				skipNeeds: true,
 			},
 			selectors: []string{"app=test"},
+			// Issue #2309: --kube-context is now added to template flags
 			templated: []exectest.Release{
-				{Name: "external-secrets", Flags: []string{"--namespace", "default"}},
-				{Name: "my-release", Flags: []string{"--namespace", "default"}},
+				{Name: "external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
+				{Name: "my-release", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 			},
 		})
 	})
@@ -203,12 +204,13 @@ releases:
 			},
 			error:     ``,
 			selectors: []string{"app=test"},
+			// Issue #2309: --kube-context is now added to template flags
 			templated: []exectest.Release{
 				// TODO: Turned out we can't differentiate needs vs transitive needs in this case :thinking:
-				{Name: "logging", Flags: []string{"--namespace", "kube-system"}},
-				{Name: "kubernetes-external-secrets", Flags: []string{"--namespace", "kube-system"}},
-				{Name: "external-secrets", Flags: []string{"--namespace", "default"}},
-				{Name: "my-release", Flags: []string{"--namespace", "default"}},
+				{Name: "logging", Flags: []string{"--kube-context", "default", "--namespace", "kube-system"}},
+				{Name: "kubernetes-external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "kube-system"}},
+				{Name: "external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
+				{Name: "my-release", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 			},
 		})
 	})
@@ -221,11 +223,12 @@ releases:
 			},
 			error:     ``,
 			selectors: []string{"app=test"},
+			// Issue #2309: --kube-context is now added to template flags
 			templated: []exectest.Release{
-				{Name: "logging", Flags: []string{"--namespace", "kube-system"}},
-				{Name: "kubernetes-external-secrets", Flags: []string{"--namespace", "kube-system"}},
-				{Name: "external-secrets", Flags: []string{"--namespace", "default"}},
-				{Name: "my-release", Flags: []string{"--namespace", "default"}},
+				{Name: "logging", Flags: []string{"--kube-context", "default", "--namespace", "kube-system"}},
+				{Name: "kubernetes-external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "kube-system"}},
+				{Name: "external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
+				{Name: "my-release", Flags: []string{"--kube-context", "default", "--namespace", "default"}},
 			},
 		})
 	})
@@ -237,8 +240,9 @@ releases:
 				includeNeeds: true,
 			},
 			selectors: []string{"name=test2"},
+			// Issue #2309: --kube-context is now added to template flags
 			templated: []exectest.Release{
-				{Name: "test2"},
+				{Name: "test2", Flags: []string{"--kube-context", "default"}},
 			},
 		})
 	})
@@ -250,9 +254,10 @@ releases:
 				includeNeeds: true,
 			},
 			selectors: []string{"name=test3"},
+			// Issue #2309: --kube-context is now added to template flags
 			templated: []exectest.Release{
-				{Name: "test2"},
-				{Name: "test3"},
+				{Name: "test2", Flags: []string{"--kube-context", "default"}},
+				{Name: "test3", Flags: []string{"--kube-context", "default"}},
 			},
 		})
 	})
@@ -265,9 +270,10 @@ releases:
 				includeTransitiveNeeds: true,
 			},
 			selectors: []string{"name=test3"},
+			// Issue #2309: --kube-context is now added to template flags
 			templated: []exectest.Release{
-				{Name: "test2"},
-				{Name: "test3"},
+				{Name: "test2", Flags: []string{"--kube-context", "default"}},
+				{Name: "test3", Flags: []string{"--kube-context", "default"}},
 			},
 		})
 	})
@@ -280,8 +286,9 @@ releases:
 				includeTransitiveNeeds: true,
 			},
 			selectors: []string{"name=test2"},
+			// Issue #2309: --kube-context is now added to template flags
 			templated: []exectest.Release{
-				{Name: "test2"},
+				{Name: "test2", Flags: []string{"--kube-context", "default"}},
 			},
 		})
 	})
@@ -294,9 +301,10 @@ releases:
 				includeTransitiveNeeds: true,
 			},
 			selectors: []string{"name=test3"},
+			// Issue #2309: --kube-context is now added to template flags
 			templated: []exectest.Release{
-				{Name: "test2"},
-				{Name: "test3"},
+				{Name: "test2", Flags: []string{"--kube-context", "default"}},
+				{Name: "test3", Flags: []string{"--kube-context", "default"}},
 			},
 		})
 	})
@@ -308,9 +316,10 @@ releases:
 				noHooks:   true,
 			},
 			selectors: []string{"app=test"},
+			// Issue #2309: --kube-context is now added to template flags
 			templated: []exectest.Release{
-				{Name: "external-secrets", Flags: []string{"--namespace", "default", "--no-hooks"}},
-				{Name: "my-release", Flags: []string{"--namespace", "default", "--no-hooks"}},
+				{Name: "external-secrets", Flags: []string{"--kube-context", "default", "--namespace", "default", "--no-hooks"}},
+				{Name: "my-release", Flags: []string{"--kube-context", "default", "--namespace", "default", "--no-hooks"}},
 			},
 		})
 	})
@@ -329,8 +338,9 @@ releases:
 				showOnly: []string{"templates/resources.yaml"},
 			},
 			selectors: []string{"name=logging"},
+			// Issue #2309: --kube-context is now added to template flags
 			templated: []exectest.Release{
-				{Name: "logging", Flags: []string{"--show-only", "templates/resources.yaml", "--namespace", "kube-system"}},
+				{Name: "logging", Flags: []string{"--show-only", "templates/resources.yaml", "--kube-context", "default", "--namespace", "kube-system"}},
 			},
 		})
 	})

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2754,9 +2754,10 @@ releases:
 	}
 
 	var helm = &mockHelmExec{}
+	// Issue #2309: --kube-context is now added to template flags
 	var wantReleases = []mockTemplates{
-		{name: "myrelease1", chart: "stable/mychart1", flags: []string{"--namespace", "testNamespace", "--set", "foo=a", "--set", "bar=b", "--output-dir", "output/subdir/helmfile-[a-z0-9]{8}-myrelease1"}},
-		{name: "myrelease2", chart: "stable/mychart2", flags: []string{"--namespace", "testNamespace", "--set", "foo=a", "--set", "bar=b", "--output-dir", "output/subdir/helmfile-[a-z0-9]{8}-myrelease2"}},
+		{name: "myrelease1", chart: "stable/mychart1", flags: []string{"--kube-context", "default", "--namespace", "testNamespace", "--set", "foo=a", "--set", "bar=b", "--output-dir", "output/subdir/helmfile-[a-z0-9]{8}-myrelease1"}},
+		{name: "myrelease2", chart: "stable/mychart2", flags: []string{"--kube-context", "default", "--namespace", "testNamespace", "--set", "foo=a", "--set", "bar=b", "--output-dir", "output/subdir/helmfile-[a-z0-9]{8}-myrelease2"}},
 	}
 
 	var wantRepos = []mockRepo{
@@ -2806,7 +2807,8 @@ releases:
 			t.Errorf("chart = [%v], want %v", helm.templated[i].chart, wantReleases[i].chart)
 		}
 		for j := range wantReleases[i].flags {
-			if j == 7 {
+			// Issue #2309: regex index changed from 7 to 9 due to added --kube-context flag
+			if j == 9 {
 				matched, _ := regexp.Match(wantReleases[i].flags[j], []byte(helm.templated[i].flags[j]))
 				if !matched {
 					t.Errorf("HelmState.TemplateReleases() = [%v], want %v", helm.templated[i].flags[j], wantReleases[i].flags[j])
@@ -2834,8 +2836,9 @@ releases:
 	}
 
 	var helm = &mockHelmExec{}
+	// Issue #2309: --kube-context is now added to template flags
 	var wantReleases = []mockTemplates{
-		{name: "myrelease1", chart: "stable/mychart1", flags: []string{"--api-versions", "helmfile.test/v1", "--api-versions", "helmfile.test/v2", "--kube-version", "v1.21", "--namespace", "testNamespace", "--output-dir", "output/subdir/helmfile-[a-z0-9]{8}-myrelease1"}},
+		{name: "myrelease1", chart: "stable/mychart1", flags: []string{"--api-versions", "helmfile.test/v1", "--api-versions", "helmfile.test/v2", "--kube-version", "v1.21", "--kube-context", "default", "--namespace", "testNamespace", "--output-dir", "output/subdir/helmfile-[a-z0-9]{8}-myrelease1"}},
 	}
 
 	var buffer bytes.Buffer
@@ -2874,7 +2877,8 @@ releases:
 			t.Errorf("chart = [%v], want %v", helm.templated[i].chart, wantReleases[i].chart)
 		}
 		for j := range wantReleases[i].flags {
-			if j == 9 {
+			// Issue #2309: regex index changed from 9 to 11 due to added --kube-context flag
+			if j == 11 {
 				matched, _ := regexp.Match(wantReleases[i].flags[j], []byte(helm.templated[i].flags[j]))
 				if !matched {
 					t.Errorf("HelmState.TemplateReleases() = [%v], want %v", helm.templated[i].flags[j], wantReleases[i].flags[j])

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1511,11 +1511,36 @@ func (st *HelmState) processChartification(chartification *Chartify, release *Re
 	// The lookup() function can be used with or without patches, so we enable cluster access
 	// for all cluster-requiring operations (diff, apply, sync, etc.) but not for offline
 	// commands (template, lint, build, etc.)
+	// Issue #2309: Also pass --kube-context to chartify's internal helm template call
+	// Issue #2355: In Helm 4, --validate and --dry-run are mutually exclusive flags.
+	// When --validate is set, we skip adding --dry-run=server since --validate already
+	// provides server-side validation.
 	if requiresCluster {
-		if chartifyOpts.TemplateArgs == "" {
-			chartifyOpts.TemplateArgs = "--dry-run=server"
-		} else if !strings.Contains(chartifyOpts.TemplateArgs, "--dry-run") {
-			chartifyOpts.TemplateArgs += " --dry-run=server"
+		// Get the effective kube-context for this release
+		kubeContext := st.getKubeContext(release)
+
+		// Build the additional args needed for cluster-requiring commands
+		var additionalArgs []string
+
+		// Add --kube-context if configured (Issue #2309)
+		// Note: kube-context is independent of the validate/dry-run mutual exclusion
+		if kubeContext != "" && !strings.Contains(chartifyOpts.TemplateArgs, "--kube-context") {
+			additionalArgs = append(additionalArgs, "--kube-context", kubeContext)
+		}
+
+		// Add --dry-run=server if not already present (Issue #2271)
+		// Skip if --validate is set to avoid Helm 4 mutual exclusion error (Issue #2355)
+		if !opts.Validate && !strings.Contains(chartifyOpts.TemplateArgs, "--dry-run") {
+			additionalArgs = append(additionalArgs, "--dry-run=server")
+		}
+
+		// Append the additional args to TemplateArgs
+		if len(additionalArgs) > 0 {
+			if chartifyOpts.TemplateArgs == "" {
+				chartifyOpts.TemplateArgs = strings.Join(additionalArgs, " ")
+			} else {
+				chartifyOpts.TemplateArgs += " " + strings.Join(additionalArgs, " ")
+			}
 		}
 	}
 
@@ -3082,14 +3107,26 @@ func (st *HelmState) appendEnableDNSFlags(flags []string, release *ReleaseSpec) 
 	return flags
 }
 
+// getKubeContext returns the effective kube-context for a release.
+// It follows the priority: release.KubeContext > environment.KubeContext > helmDefaults.KubeContext
+// Issue #2309: This is the single source of truth for kube-context resolution
+func (st *HelmState) getKubeContext(release *ReleaseSpec) string {
+	if release.KubeContext != "" {
+		return release.KubeContext
+	}
+	if st.Environments[st.Env.Name].KubeContext != "" {
+		return st.Environments[st.Env.Name].KubeContext
+	}
+	if st.HelmDefaults.KubeContext != "" {
+		return st.HelmDefaults.KubeContext
+	}
+	return ""
+}
+
 func (st *HelmState) kubeConnectionFlags(release *ReleaseSpec) []string {
 	flags := []string{}
-	if release.KubeContext != "" {
-		flags = append(flags, "--kube-context", release.KubeContext)
-	} else if st.Environments[st.Env.Name].KubeContext != "" {
-		flags = append(flags, "--kube-context", st.Environments[st.Env.Name].KubeContext)
-	} else if st.HelmDefaults.KubeContext != "" {
-		flags = append(flags, "--kube-context", st.HelmDefaults.KubeContext)
+	if kubeContext := st.getKubeContext(release); kubeContext != "" {
+		flags = append(flags, "--kube-context", kubeContext)
 	}
 	return flags
 }
@@ -3270,6 +3307,8 @@ func (st *HelmState) flagsForTemplate(helm helmexec.Interface, release *ReleaseS
 	flags = st.appendChartDownloadFlags(flags, release)
 	flags = st.appendShowOnlyFlags(flags, showOnly)
 	flags = st.appendSkipSchemaValidationFlags(flags, release, skipSchemaValidation)
+	// Issue #2309: Add kube-context flags for helm template when using jsonPatches with --dry-run=server
+	flags = st.appendConnectionFlags(flags, release)
 
 	common, files, err := st.namespaceAndValuesFlags(helm, release, workerIndex)
 	if err != nil {

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -119,6 +119,7 @@ ${kubectl} create namespace ${test_ns} || fail "Could not create namespace ${tes
 . ${dir}/test-cases/issue-2291.sh
 . ${dir}/test-cases/oci-parallel-pull.sh
 . ${dir}/test-cases/issue-2297-local-chart-transformers.sh
+. ${dir}/test-cases/issue-2309-kube-context-template.sh
 
 # ALL DONE -----------------------------------------------------------------------------------------------------------
 

--- a/test/integration/test-cases/issue-2309-kube-context-template.sh
+++ b/test/integration/test-cases/issue-2309-kube-context-template.sh
@@ -1,0 +1,32 @@
+# Issue #2309: Test that helm template receives --kube-context when using jsonPatches
+# https://github.com/helmfile/helmfile/issues/2309
+#
+# This test verifies that helmfile correctly passes --kube-context to helm template
+# when helmDefaults.kubeContext is set and jsonPatches are used.
+
+issue_2309_case_input_dir="${cases_dir}/issue-2309-kube-context-template/input"
+issue_2309_case_output_dir="${cases_dir}/issue-2309-kube-context-template/output"
+
+config_file="helmfile.yaml.gotmpl"
+issue_2309_tmp=$(mktemp -d)
+issue_2309_template_output=${issue_2309_tmp}/issue_2309.template.log
+
+test_start "helmfile template with kube-context and jsonPatches (issue #2309)"
+
+info "Running helmfile template with kubeContext and jsonPatches"
+${helmfile} -f ${issue_2309_case_input_dir}/${config_file} template > ${issue_2309_template_output} || fail "\"helmfile template\" shouldn't fail"
+
+info "Checking template output"
+cat ${issue_2309_template_output}
+
+# Verify the output contains the patched ConfigMap
+if grep -q "patched: \"true\"" ${issue_2309_template_output}; then
+    info "Found patched value in output - jsonPatches applied successfully"
+else
+    fail "jsonPatches were not applied - missing 'patched: true' in output"
+fi
+
+# Compare with expected output
+./dyff between -bs ${issue_2309_case_output_dir}/template ${issue_2309_template_output} || fail "\"helmfile template\" output should match expected"
+
+test_pass "helmfile template with kube-context and jsonPatches (issue #2309)"

--- a/test/integration/test-cases/issue-2309-kube-context-template/input/helmfile.yaml.gotmpl
+++ b/test/integration/test-cases/issue-2309-kube-context-template/input/helmfile.yaml.gotmpl
@@ -1,0 +1,30 @@
+# Issue #2309: helm template should receive --kube-context when using jsonPatches
+# https://github.com/helmfile/helmfile/issues/2309
+helmDefaults:
+  kubeContext: test-context
+
+repositories:
+- name: incubator
+  url: https://charts.helm.sh/incubator
+---
+releases:
+- name: test-release
+  chart: incubator/raw
+  namespace: default
+  values:
+  - resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: test-configmap
+      data:
+        key: value
+  jsonPatches:
+    - target:
+        version: v1
+        kind: ConfigMap
+        name: test-configmap
+      patch:
+      - op: add
+        path: /data/patched
+        value: "true"

--- a/test/integration/test-cases/issue-2309-kube-context-template/output/template
+++ b/test/integration/test-cases/issue-2309-kube-context-template/output/template
@@ -1,0 +1,15 @@
+---
+# Source: raw/templates/patched_resources.yaml
+apiVersion: v1
+data:
+  key: value
+  patched: "true"
+kind: ConfigMap
+metadata:
+  labels:
+    app: raw
+    chart: raw-0.2.5
+    heritage: Helm
+    release: test-release
+  name: test-configmap
+


### PR DESCRIPTION
## Summary

Fixes #2309

When using `jsonPatches` or `strategicMergePatches` in helmfile, the `helm template` command was not receiving the `--kube-context` flag. This caused issues when `--dry-run=server` was used (introduced in PR #2271 to support `lookup()` functions), because helm would connect to the wrong cluster context instead of the one specified in `helmDefaults.kubeContext`.

### Example that was failing:

```yaml
helmDefaults:
  kubeContext: minikube

releases:
  - name: test
    chart: ./test
    jsonPatches:
      - target:
          group: apps
          version: v1
          kind: Deployment
          name: test
        patch:
          - op: add
            path: /spec/template/spec/containers/0/args/-
            value: "test"
```

Running `helmfile diff` would fail because the internal `helm template` call (used by chartify for jsonPatches) did not receive `--kube-context=minikube`.

## Root Cause

1. **`flagsForTemplate()` missing connection flags**: The function did NOT call `appendConnectionFlags()`, unlike `flagsForUpgrade()` and `flagsForDiff()` which both include this call.

2. **`processChartification()` missing kube-context**: When `--dry-run=server` is added to `chartifyOpts.TemplateArgs`, the `--kube-context` flag was not included.

## Changes

| File | Change |
|------|--------|
| `pkg/state/state.go` | Added `appendConnectionFlags()` call to `flagsForTemplate()` |
| `pkg/state/state.go` | Added new `getKubeContext()` helper function with priority: release > environment > helmDefaults |
| `pkg/state/state.go` | Modified `processChartification()` to include `--kube-context` in chartify's TemplateArgs |
| `pkg/state/state_test.go` | Added unit tests for `flagsForTemplate()` kube-context handling |
| `pkg/state/state_test.go` | Added unit tests for `getKubeContext()` priority logic |
| `pkg/app/app_test.go` | Updated test expectations for new `--kube-context` flag |
| `pkg/app/app_template_test.go` | Updated test expectations for new `--kube-context` flag |
| `test/integration/test-cases/` | Added integration test for issue #2309 |

## Compatibility with PR #2362 (Issue #2355)

This PR includes a compatibility check for the `--validate` flag to avoid Helm 4's mutual exclusion error between `--validate` and `--dry-run`. When `opts.Validate` is set, we skip adding `--dry-run=server` to prevent the conflict.

## Test Coverage

### Unit Tests Added

1. **`TestHelmState_flagsForTemplate`** - 3 new test cases:
   - Tests kube-context from `helmDefaults.kubeContext`
   - Tests kube-context from `release.kubeContext` (override)
   - Tests kube-context from environment

2. **`TestHelmState_getKubeContext`** - 5 test cases:
   - No kube-context set (returns empty)
   - Only helmDefaults.kubeContext set
   - Release kubeContext overrides helmDefaults
   - Environment kubeContext used when release not set
   - Release kubeContext takes priority over environment

### Integration Test Added

- `test/integration/test-cases/issue-2309-kube-context-template.sh`
- Tests `helmfile template` with `kubeContext` and `jsonPatches`
- Verifies that jsonPatches are applied correctly with kube-context

## How to Test

```bash
# Run unit tests
go test ./pkg/state/... -v -run "TestHelmState_flagsForTemplate|TestHelmState_getKubeContext"

# Run all unit tests
go test ./...

# Run integration tests (requires minikube)
make integration
```

## Checklist

- [x] Unit tests pass
- [x] Added unit tests for new functionality
- [x] Added integration test
- [x] Compatible with PR #2362 (--validate flag handling)
- [x] Follows existing code patterns