### PR TITLE
Bump Helm from v4.1.0 to v4.1.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        helm-version: [v3.18.6, v3.20.0, v4.1.0]
+        helm-version: [v3.18.6, v3.20.0, v4.1.1]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -67,16 +67,16 @@ jobs:
         env:
           HELMFILE_HELM4: ${{ startsWith(matrix.helm-version, 'v4') && '1' || '0' }}
       - name: Archive built binaries
-        if: matrix.helm-version == 'v4.1.0'
+        if: matrix.helm-version == 'v4.1.1'
         run: tar -cvf built-binaries.tar helmfile diff-yamls dyff
       - uses: actions/upload-artifact@v6
-        if: matrix.helm-version == 'v4.1.0'
+        if: matrix.helm-version == 'v4.1.1'
         with:
           name: built-binaries-${{ github.run_id }}
           path: built-binaries.tar
           retention-days: 1
       - name: Display built binaries
-        if: matrix.helm-version == 'v4.1.0'
+        if: matrix.helm-version == 'v4.1.1'
         run: ls -l helmfile diff-yamls dyff
 
   integration_tests:
@@ -116,12 +116,12 @@ jobs:
             plugin-diff-version: 3.14.1
             extra-helmfile-flags: '--enable-live-output'
           # Helmfile now supports both Helm 3.x and Helm 4.x
-          - helm-version: v4.1.0
+          - helm-version: v4.1.1
             kustomize-version: v5.8.0
             plugin-secrets-version: 4.7.4
             plugin-diff-version: 3.14.1
             extra-helmfile-flags: ''
-          - helm-version: v4.1.0
+          - helm-version: v4.1.1
             kustomize-version: v5.8.0
             plugin-secrets-version: 4.7.4
             plugin-diff-version: 3.14.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v4.1.0"
+ARG HELM_VERSION="v4.1.1"
 ENV HELM_VERSION="${HELM_VERSION}"
 ENV HELM_BIN="/usr/local/bin/helm"
 ARG HELM_LOCATION="https://get.helm.sh"
@@ -39,8 +39,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="8e7ae5cb890c56f53713bffec38e41cd8e7e4619ebe56f8b31cd383bfb3dbb83"  ;; \
-    "linux/arm64")  HELM_SHA256="81315e404b6d09b65bee577a679ab269d6d44652ef2e1f66a8f922b51ca93f6b"  ;; \
+    "linux/amd64")  HELM_SHA256="5d4c7623283e6dfb1971957f4b755468ab64917066a8567dd50464af298f4031"  ;; \
+    "linux/arm64")  HELM_SHA256="02a5fb7742469d2d132e24cb7c3f52885894043576588c6788b6813297629edd"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.debian-stable-slim
+++ b/Dockerfile.debian-stable-slim
@@ -38,7 +38,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v4.1.0"
+ARG HELM_VERSION="v4.1.1"
 ENV HELM_VERSION="${HELM_VERSION}"
 ENV HELM_BIN="/usr/local/bin/helm"
 ARG HELM_LOCATION="https://get.helm.sh"
@@ -47,8 +47,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="8e7ae5cb890c56f53713bffec38e41cd8e7e4619ebe56f8b31cd383bfb3dbb83"  ;; \
-    "linux/arm64")  HELM_SHA256="81315e404b6d09b65bee577a679ab269d6d44652ef2e1f66a8f922b51ca93f6b"  ;; \
+    "linux/amd64")  HELM_SHA256="5d4c7623283e6dfb1971957f4b755468ab64917066a8567dd50464af298f4031"  ;; \
+    "linux/arm64")  HELM_SHA256="02a5fb7742469d2d132e24cb7c3f52885894043576588c6788b6813297629edd"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -38,7 +38,7 @@ ENV HELM_CONFIG_HOME="${HELM_CONFIG_HOME}"
 ARG HELM_DATA_HOME="${HOME}/.local/share/helm"
 ENV HELM_DATA_HOME="${HELM_DATA_HOME}"
 
-ARG HELM_VERSION="v4.1.0"
+ARG HELM_VERSION="v4.1.1"
 ENV HELM_VERSION="${HELM_VERSION}"
 ENV HELM_BIN="/usr/local/bin/helm"
 ARG HELM_LOCATION="https://get.helm.sh"
@@ -47,8 +47,8 @@ RUN set -x && \
     curl --retry 5 --retry-connrefused -LO "${HELM_LOCATION}/${HELM_FILENAME}" && \
     echo Verifying ${HELM_FILENAME}... && \
     case ${TARGETPLATFORM} in \
-    "linux/amd64")  HELM_SHA256="8e7ae5cb890c56f53713bffec38e41cd8e7e4619ebe56f8b31cd383bfb3dbb83"  ;; \
-    "linux/arm64")  HELM_SHA256="81315e404b6d09b65bee577a679ab269d6d44652ef2e1f66a8f922b51ca93f6b"  ;; \
+    "linux/amd64")  HELM_SHA256="5d4c7623283e6dfb1971957f4b755468ab64917066a8567dd50464af298f4031"  ;; \
+    "linux/arm64")  HELM_SHA256="02a5fb7742469d2d132e24cb7c3f52885894043576588c6788b6813297629edd"  ;; \
     esac && \
     echo "${HELM_SHA256}  ${HELM_FILENAME}" | sha256sum -c && \
     echo Extracting ${HELM_FILENAME}... && \


### PR DESCRIPTION
## Summary
- Update Helm from v4.1.0 to v4.1.1 in all Dockerfiles
- Update Helm version in CI workflow
- Update SHA256 checksums for both amd64 and arm64 architectures