### PR TITLE
fix: prevent local absolute paths from being treated as remote URLs

### DIFF
--- a/pkg/remote/remote_windows_test.go
+++ b/pkg/remote/remote_windows_test.go
@@ -1,0 +1,69 @@
+//go:build windows
+
+package remote
+
+import (
+	"testing"
+)
+
+func TestIsRemote_Windows(t *testing.T) {
+	testcases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "windows drive letter path",
+			input:    `C:\project\services\values.yaml`,
+			expected: false,
+		},
+		{
+			name:     "windows UNC path",
+			input:    `\\server\share\path\values.yaml`,
+			expected: false,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRemote(tt.input)
+			if result != tt.expected {
+				t.Errorf("IsRemote(%q) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParse_Windows(t *testing.T) {
+	testcases := []struct {
+		name  string
+		input string
+		err   string
+	}{
+		{
+			name:  "windows drive letter path",
+			input: `C:\project\services\values.yaml`,
+			err:   `parse url: local absolute path is not a remote URL: C:\project\services\values.yaml`,
+		},
+		{
+			name:  "windows UNC path",
+			input: `\\server\share\path\values.yaml`,
+			err:   `parse url: local absolute path is not a remote URL: \\server\share\path\values.yaml`,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse(tt.input)
+			if err == nil {
+				t.Fatalf("Parse(%q) expected error, got nil", tt.input)
+			}
+			if _, ok := err.(InvalidURLError); !ok {
+				t.Fatalf("Parse(%q) expected InvalidURLError, got %T: %v", tt.input, err, err)
+			}
+			if err.Error() != tt.err {
+				t.Errorf("Parse(%q) error = %q, want %q", tt.input, err.Error(), tt.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2384 — `readFile` with parent-directory-relative paths (e.g., `readFile "../files/default.conf"`) fails on Windows starting with v1.2.0.

## Root Cause

PR #2261 (commit `aa7b8cb4`) parallelized `helmfile.d` rendering by replacing the process-wide `chdir()` approach with an explicit `basePath` parameter. This changed how values file paths are resolved:

| | Before (v1.1.9) | After (v1.2.0) |
|---|---|---|
| **Working dir** | `chdir` to helmfile dir | No `chdir`; explicit `basePath` |
| **`state.basePath`** | `"."` (relative) | Absolute, e.g. `C:\project\helmfile.d\` |
| **`normalizePath("../files/...")`** | `../files/...` (relative) | `C:\project\files\...` (absolute) |
| **`url.Parse` result** | No scheme → `IsRemote` = false | go-getter adds `file://` scheme on Windows → `IsRemote` = true |
| **Outcome** | File resolved locally | File fetched to cache dir; sibling directories missing → fails |

**Why Windows-only:** On Unix, `net/url.Parse("/absolute/path")` returns an empty scheme, so `IsRemote` correctly returns false. On Windows, go-getter's `url_windows.go` explicitly prepends `file://` when it detects a drive letter (`C:`), causing `IsRemote` to return true.

## Fix

Add `filepath.IsAbs` guards in two places:

1. **`IsRemote()`** — early-return false for absolute paths. This protects callers in `storage.go`, `state.go`, and `remote.go:Fetch`.
2. **`Parse()`** — reject absolute paths with `InvalidURLError` before `url.Parse` can misinterpret them. This protects the additional call path from `helmx.go:goGetterChart`.

`filepath.IsAbs` correctly handles all platform-specific absolute path formats:
- Unix: `/path/to/file`
- Windows drive letters: `C:\path\to\file`
- Windows UNC: `\\server\share\path`

**No risk to legitimate remote URLs:** URLs like `git::https://...`, `s3://...`, and `https://...` all contain `::` or `://` and are routed through different branches in `Parse` before the new guard is reached. They never satisfy `filepath.IsAbs`.

## Changes

| File | Change |
|------|--------|
| `pkg/remote/remote.go` | `filepath.IsAbs` guard in `IsRemote` and `Parse` |
| `pkg/remote/remote_test.go` | `TestIsRemote` (6 cases) + new `TestParse` case for Unix absolute paths |
| `pkg/remote/remote_windows_test.go` | New file (`//go:build windows`) — tests `C:\path` and `\\UNC\path` |

## Test plan

- [x] `go test ./pkg/remote/...` — all pass (new + existing)
- [x] `go test ./pkg/state/...` — no regressions
- [x] Windows CI validates `remote_windows_test.go`