### PR TITLE
feat: add `helmfile unittest` command for helm-unittest integration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,6 +99,7 @@ func NewRootCmd(globalConfig *config.GlobalOptions) (*cobra.Command, error) {
 		NewLintCmd(globalImpl),
 		NewWriteValuesCmd(globalImpl),
 		NewTestCmd(globalImpl),
+		NewUnittestCmd(globalImpl),
 		NewTemplateCmd(globalImpl),
 		NewSyncCmd(globalImpl),
 		NewDiffCmd(globalImpl),

--- a/cmd/unittest.go
+++ b/cmd/unittest.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/helmfile/helmfile/pkg/app"
+	"github.com/helmfile/helmfile/pkg/config"
+)
+
+// NewUnittestCmd returns unittest subcmd
+func NewUnittestCmd(globalCfg *config.GlobalImpl) *cobra.Command {
+	unittestOptions := config.NewUnittestOptions()
+
+	cmd := &cobra.Command{
+		Use:   "unittest",
+		Short: "Unit test charts from state file using helm-unittest plugin",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			unittestImpl := config.NewUnittestImpl(globalCfg, unittestOptions)
+			err := config.NewCLIConfigImpl(unittestImpl.GlobalImpl)
+			if err != nil {
+				return err
+			}
+
+			if err := unittestImpl.ValidateConfig(); err != nil {
+				return err
+			}
+
+			a := app.New(unittestImpl)
+			return toCLIError(unittestImpl.GlobalImpl, a.Unittest(unittestImpl))
+		},
+	}
+
+	f := cmd.Flags()
+	f.IntVar(&unittestOptions.Concurrency, "concurrency", 0, "maximum number of concurrent helm processes to run, 0 is unlimited")
+	f.StringVar(&globalCfg.GlobalOptions.Args, "args", "", "pass args to helm exec")
+	f.StringArrayVar(&unittestOptions.Set, "set", nil, "additional values to be merged into the helm command --set flag")
+	f.StringArrayVar(&unittestOptions.Values, "values", nil, "additional value files to be merged into the helm command --values flag")
+	f.BoolVar(&unittestOptions.FailFast, "fail-fast", false, "fail fast on the first test failure")
+	f.BoolVar(&unittestOptions.Color, "color", false, "enforce colored output even when stdout is not a tty (ignored on Helm 4 due to flag parsing issues)")
+	f.BoolVar(&unittestOptions.DebugPlugin, "debug-plugin", false, "enable verbose output from the helm-unittest plugin")
+	f.BoolVar(&unittestOptions.SkipNeeds, "skip-needs", true, `do not automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when --selector/-l flag is not provided. Defaults to true when --include-needs or --include-transitive-needs is not provided`)
+	f.BoolVar(&unittestOptions.IncludeNeeds, "include-needs", false, `automatically include releases from the target release's "needs" when --selector/-l flag is provided. Does nothing when --selector/-l flag is not provided`)
+	f.BoolVar(&unittestOptions.IncludeTransitiveNeeds, "include-transitive-needs", false, `like --include-needs, but also includes transitive needs (needs of needs). Does nothing when --selector/-l flag is not provided. Overrides exclusions of other selectors and conditions.`)
+
+	return cmd
+}

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -2354,6 +2354,8 @@ type applyConfig struct {
 	suppressDiff             bool
 	noColor                  bool
 	color                    bool
+	failFast                 bool
+	debugPlugin              bool
 	context                  int
 	diffOutput               string
 	concurrency              int
@@ -2474,6 +2476,14 @@ func (a applyConfig) SuppressDiff() bool {
 
 func (a applyConfig) Color() bool {
 	return a.color
+}
+
+func (a applyConfig) FailFast() bool {
+	return a.failFast
+}
+
+func (a applyConfig) DebugPlugin() bool {
+	return a.debugPlugin
 }
 
 func (a applyConfig) NoColor() bool {
@@ -2708,6 +2718,9 @@ func (helm *mockHelmExec) Fetch(chart string, flags ...string) error {
 	return nil
 }
 func (helm *mockHelmExec) Lint(name, chart string, flags ...string) error {
+	return nil
+}
+func (helm *mockHelmExec) Unittest(name, chart string, flags ...string) error {
 	return nil
 }
 func (helm *mockHelmExec) IsHelm3() bool {

--- a/pkg/app/app_unittest_test.go
+++ b/pkg/app/app_unittest_test.go
@@ -1,0 +1,256 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/helmfile/vals"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/helmfile/helmfile/pkg/exectest"
+	ffs "github.com/helmfile/helmfile/pkg/filesystem"
+	"github.com/helmfile/helmfile/pkg/helmexec"
+)
+
+func TestUnittest(t *testing.T) {
+	type fields struct {
+		skipNeeds              bool
+		includeNeeds           bool
+		includeTransitiveNeeds bool
+		failFast               bool
+		color                  bool
+		debugPlugin            bool
+	}
+
+	type testcase struct {
+		fields     fields
+		ns         string
+		error      string
+		selectors  []string
+		unittested []exectest.Release
+	}
+
+	check := func(t *testing.T, tc testcase) {
+		t.Helper()
+
+		wantUnittests := tc.unittested
+
+		var helm = &exectest.Helm{
+			FailOnUnexpectedList: true,
+			FailOnUnexpectedDiff: true,
+			Helm4:                exectest.IsHelm4Enabled(),
+			Helm3:                !exectest.IsHelm4Enabled(),
+			DiffMutex:            &sync.Mutex{},
+			ChartsMutex:          &sync.Mutex{},
+			ReleasesMutex:        &sync.Mutex{},
+		}
+
+		bs := runWithLogCapture(t, "debug", func(t *testing.T, logger *zap.SugaredLogger) {
+			t.Helper()
+
+			valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
+			if err != nil {
+				t.Errorf("unexpected error creating vals runtime: %v", err)
+			}
+
+			files := map[string]string{
+				"/path/to/helmfile.yaml": `
+releases:
+- name: logging
+  chart: incubator/raw
+  namespace: kube-system
+  unitTests:
+  - tests/logging
+
+- name: kubernetes-external-secrets
+  chart: incubator/raw
+  namespace: kube-system
+  needs:
+  - kube-system/logging
+  unitTests:
+  - tests/secrets
+
+- name: external-secrets
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - kube-system/kubernetes-external-secrets
+  unitTests:
+  - tests/external
+
+- name: my-release
+  chart: incubator/raw
+  namespace: default
+  labels:
+    app: test
+  needs:
+  - default/external-secrets
+  unitTests:
+  - tests/myrelease
+
+- name: no-tests
+  chart: incubator/raw
+  namespace: default
+`,
+			}
+
+			app := appWithFs(&App{
+				OverrideHelmBinary:              DefaultHelmBinary,
+				fs:                              ffs.DefaultFileSystem(),
+				OverrideKubeContext:             "default",
+				DisableKubeVersionAutoDetection: true,
+				Env:                             "default",
+				Logger:                          logger,
+				helms: map[helmKey]helmexec.Interface{
+					createHelmKey("helm", "default"): helm,
+				},
+				valsRuntime: valsRuntime,
+			}, files)
+
+			if tc.ns != "" {
+				app.Namespace = tc.ns
+			}
+
+			if tc.selectors != nil {
+				app.Selectors = tc.selectors
+			}
+
+			unittestErr := app.Unittest(applyConfig{
+				concurrency:            1,
+				logger:                 logger,
+				skipNeeds:              tc.fields.skipNeeds,
+				includeNeeds:           tc.fields.includeNeeds,
+				includeTransitiveNeeds: tc.fields.includeTransitiveNeeds,
+				failFast:               tc.fields.failFast,
+				color:                  tc.fields.color,
+				debugPlugin:            tc.fields.debugPlugin,
+			})
+
+			var gotErr string
+			if unittestErr != nil {
+				gotErr = unittestErr.Error()
+			}
+
+			if d := cmp.Diff(tc.error, gotErr); d != "" {
+				t.Fatalf("unexpected error: want (-), got (+): %s", d)
+			}
+
+			require.Equal(t, wantUnittests, helm.Unittested)
+		})
+
+		testNameComponents := strings.Split(t.Name(), "/")
+		testBaseName := strings.ToLower(
+			strings.ReplaceAll(
+				testNameComponents[len(testNameComponents)-1],
+				" ",
+				"_",
+			),
+		)
+		wantLogFileDir := filepath.Join("testdata", "app_unittest_test")
+		snapshotName := testBaseName
+		if exectest.IsHelm4Enabled() {
+			if _, err := os.Stat(filepath.Join(wantLogFileDir, testBaseName+"_helm4")); err == nil {
+				snapshotName = testBaseName + "_helm4"
+			}
+		}
+		wantLogFile := filepath.Join(wantLogFileDir, snapshotName)
+		wantLogData, err := os.ReadFile(wantLogFile)
+		updateLogFile := err != nil
+		wantLog := string(wantLogData)
+		gotLog := bs.String()
+		if updateLogFile {
+			if err := os.MkdirAll(wantLogFileDir, 0755); err != nil {
+				t.Fatalf("unable to create directory %q: %v", wantLogFileDir, err)
+			}
+			if err := os.WriteFile(wantLogFile, bs.Bytes(), 0644); err != nil {
+				t.Fatalf("unable to update unittest log snapshot: %v", err)
+			}
+		}
+
+		assert.Equal(t, wantLog, gotLog)
+	}
+
+	t.Run("unittest all releases with unitTests", func(t *testing.T) {
+		check(t, testcase{
+			unittested: []exectest.Release{
+				{Name: "logging", Flags: []string{"--namespace", "kube-system", "--file", "tests/logging/*_test.yaml"}},
+				{Name: "kubernetes-external-secrets", Flags: []string{"--namespace", "kube-system", "--file", "tests/secrets/*_test.yaml"}},
+				{Name: "external-secrets", Flags: []string{"--namespace", "default", "--file", "tests/external/*_test.yaml"}},
+				{Name: "my-release", Flags: []string{"--namespace", "default", "--file", "tests/myrelease/*_test.yaml"}},
+			},
+		})
+	})
+
+	t.Run("with dedicated flags", func(t *testing.T) {
+		// --color is skipped on Helm 4 due to flag parsing issues
+		expectedFlags := []string{"--namespace", "kube-system", "--failfast"}
+		if !exectest.IsHelm4Enabled() {
+			expectedFlags = append(expectedFlags, "--color")
+		}
+		expectedFlags = append(expectedFlags, "--debugPlugin", "--file", "tests/logging/*_test.yaml")
+
+		check(t, testcase{
+			fields: fields{
+				failFast:    true,
+				color:       true,
+				debugPlugin: true,
+			},
+			selectors: []string{"name=logging"},
+			unittested: []exectest.Release{
+				{Name: "logging", Flags: expectedFlags},
+			},
+		})
+	})
+
+	t.Run("skip-needs", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds: true,
+			},
+			selectors: []string{"app=test"},
+			unittested: []exectest.Release{
+				{Name: "external-secrets", Flags: []string{"--namespace", "default", "--file", "tests/external/*_test.yaml"}},
+				{Name: "my-release", Flags: []string{"--namespace", "default", "--file", "tests/myrelease/*_test.yaml"}},
+			},
+		})
+	})
+
+	t.Run("include-needs", func(t *testing.T) {
+		check(t, testcase{
+			fields: fields{
+				skipNeeds:    false,
+				includeNeeds: true,
+			},
+			selectors: []string{"app=test"},
+			unittested: []exectest.Release{
+				{Name: "logging", Flags: []string{"--namespace", "kube-system", "--file", "tests/logging/*_test.yaml"}},
+				{Name: "kubernetes-external-secrets", Flags: []string{"--namespace", "kube-system", "--file", "tests/secrets/*_test.yaml"}},
+				{Name: "external-secrets", Flags: []string{"--namespace", "default", "--file", "tests/external/*_test.yaml"}},
+				{Name: "my-release", Flags: []string{"--namespace", "default", "--file", "tests/myrelease/*_test.yaml"}},
+			},
+		})
+	})
+
+	t.Run("release without unitTests is skipped", func(t *testing.T) {
+		check(t, testcase{
+			selectors:  []string{"name=no-tests"},
+			unittested: nil,
+		})
+	})
+
+	t.Run("bad selector", func(t *testing.T) {
+		check(t, testcase{
+			selectors:  []string{"app=test_non_existent"},
+			unittested: nil,
+			error:      "err: no releases found that matches specified selector(app=test_non_existent) and environment(default), in any helmfile",
+		})
+	})
+}

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -207,6 +207,23 @@ type LintConfigProvider interface {
 	concurrencyConfig
 }
 
+type UnittestConfigProvider interface {
+	Args() string
+
+	Values() []string
+	Set() []string
+	FailFast() bool
+	Color() bool
+	DebugPlugin() bool
+	SkipDeps() bool
+	SkipRefresh() bool
+	SkipCleanup() bool
+
+	DAGConfig
+
+	concurrencyConfig
+}
+
 type FetchConfigProvider interface {
 	SkipDeps() bool
 	SkipRefresh() bool

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -18,13 +18,14 @@ import (
 )
 
 const (
-	HelmRequiredVersion           = "v3.18.6" // Minimum required version (supports Helm 3.x and 4.x)
-	HelmDiffRecommendedVersion    = "v3.14.1"
-	HelmRecommendedVersion        = "v4.1.0" // Recommended to use latest Helm 4
-	HelmSecretsRecommendedVersion = "v4.7.4" // v4.7.0+ works with both Helm 3 (single plugin) and Helm 4 (split plugin architecture)
-	HelmGitRecommendedVersion     = "v1.3.0"
-	HelmS3RecommendedVersion      = "v0.16.3"
-	HelmInstallCommand            = "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3" // Default to Helm 3 script for compatibility
+	HelmRequiredVersion            = "v3.18.6" // Minimum required version (supports Helm 3.x and 4.x)
+	HelmDiffRecommendedVersion     = "v3.14.1"
+	HelmRecommendedVersion         = "v4.1.0" // Recommended to use latest Helm 4
+	HelmSecretsRecommendedVersion  = "v4.7.4" // v4.7.0+ works with both Helm 3 (single plugin) and Helm 4 (split plugin architecture)
+	HelmGitRecommendedVersion      = "v1.3.0"
+	HelmS3RecommendedVersion       = "v0.16.3"
+	HelmUnittestRecommendedVersion = "v1.0.3"
+	HelmInstallCommand             = "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3" // Default to Helm 3 script for compatibility
 )
 
 var (
@@ -53,6 +54,11 @@ var (
 			name:    "helm-git",
 			version: HelmGitRecommendedVersion,
 			repo:    "https://github.com/aslafy-z/helm-git.git",
+		},
+		{
+			name:    "unittest",
+			version: HelmUnittestRecommendedVersion,
+			repo:    "https://github.com/helm-unittest/helm-unittest",
 		},
 	}
 )

--- a/pkg/app/testdata/app_unittest_test/bad_selector
+++ b/pkg/app/testdata/app_unittest_test/bad_selector
@@ -1,0 +1,6 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+merged environment: &{default  map[] map[] map[]}
+0 release(s) matching app=test_non_existent found in helmfile.yaml
+
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_unittest_test/include-needs
+++ b/pkg/app/testdata/app_unittest_test/include-needs
@@ -1,0 +1,17 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+merged environment: &{default  map[] map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+processing 4 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/logging
+2     default/kube-system/kubernetes-external-secrets
+3     default/default/external-secrets
+4     default/default/my-release
+
+processing releases in group 1/4: default/kube-system/logging
+processing releases in group 2/4: default/kube-system/kubernetes-external-secrets
+processing releases in group 3/4: default/default/external-secrets
+processing releases in group 4/4: default/default/my-release
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_unittest_test/release_without_unittests_is_skipped
+++ b/pkg/app/testdata/app_unittest_test/release_without_unittests_is_skipped
@@ -1,0 +1,11 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+merged environment: &{default  map[] map[] map[]}
+1 release(s) matching name=no-tests found in helmfile.yaml
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default/default/no-tests
+
+processing releases in group 1/1: default/default/no-tests
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_unittest_test/skip-needs
+++ b/pkg/app/testdata/app_unittest_test/skip-needs
@@ -1,0 +1,13 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+merged environment: &{default  map[] map[] map[]}
+2 release(s) matching app=test found in helmfile.yaml
+
+processing 2 groups of releases in this order:
+GROUP RELEASES
+1     default/default/external-secrets
+2     default/default/my-release
+
+processing releases in group 1/2: default/default/external-secrets
+processing releases in group 2/2: default/default/my-release
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_unittest_test/unittest_all_releases_with_unittests
+++ b/pkg/app/testdata/app_unittest_test/unittest_all_releases_with_unittests
@@ -1,0 +1,17 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+merged environment: &{default  map[] map[] map[]}
+5 release(s) found in helmfile.yaml
+
+processing 4 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/logging, default/default/no-tests
+2     default/kube-system/kubernetes-external-secrets
+3     default/default/external-secrets
+4     default/default/my-release
+
+processing releases in group 1/4: default/kube-system/logging, default/default/no-tests
+processing releases in group 2/4: default/kube-system/kubernetes-external-secrets
+processing releases in group 3/4: default/default/external-secrets
+processing releases in group 4/4: default/default/my-release
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_unittest_test/with_dedicated_flags
+++ b/pkg/app/testdata/app_unittest_test/with_dedicated_flags
@@ -1,0 +1,11 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+merged environment: &{default  map[] map[] map[]}
+1 release(s) matching name=logging found in helmfile.yaml
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/logging
+
+processing releases in group 1/1: default/kube-system/logging
+changing working directory back to "/path/to"

--- a/pkg/app/testdata/app_unittest_test/with_dedicated_flags_helm4
+++ b/pkg/app/testdata/app_unittest_test/with_dedicated_flags_helm4
@@ -1,0 +1,13 @@
+processing file "helmfile.yaml" in directory "."
+changing working directory to "/path/to"
+merged environment: &{default  map[] map[] map[]}
+1 release(s) matching name=logging found in helmfile.yaml
+
+processing 1 groups of releases in this order:
+GROUP RELEASES
+1     default/kube-system/logging
+
+processing releases in group 1/1: default/kube-system/logging
+warn: --color flag is not supported with Helm 4 due to flag parsing issues, ignoring
+
+changing working directory back to "/path/to"

--- a/pkg/config/unittest.go
+++ b/pkg/config/unittest.go
@@ -1,0 +1,101 @@
+package config
+
+// UnittestOptions is the options for the unittest command
+type UnittestOptions struct {
+	// Concurrency is the maximum number of concurrent helm processes to run, 0 is unlimited
+	Concurrency int
+	// Set is the set flags to pass to helm unittest
+	Set []string
+	// Values is the values flags to pass to helm unittest
+	Values []string
+	// FailFast causes helm-unittest to quit immediately when a test fails
+	FailFast bool
+	// Color enforces colored output even when stdout is not a tty
+	Color bool
+	// DebugPlugin enables verbose output from the helm-unittest plugin
+	DebugPlugin bool
+	// SkipNeeds is the skip needs flag
+	SkipNeeds bool
+	// IncludeNeeds is the include needs flag
+	IncludeNeeds bool
+	// IncludeTransitiveNeeds is the include transitive needs flag
+	IncludeTransitiveNeeds bool
+}
+
+// NewUnittestOptions creates a new UnittestOptions
+func NewUnittestOptions() *UnittestOptions {
+	return &UnittestOptions{}
+}
+
+// UnittestImpl is impl for UnittestOptions
+type UnittestImpl struct {
+	*GlobalImpl
+	*UnittestOptions
+}
+
+// NewUnittestImpl creates a new UnittestImpl
+func NewUnittestImpl(g *GlobalImpl, u *UnittestOptions) *UnittestImpl {
+	return &UnittestImpl{
+		GlobalImpl:      g,
+		UnittestOptions: u,
+	}
+}
+
+// Concurrency returns the concurrency
+func (u *UnittestImpl) Concurrency() int {
+	return u.UnittestOptions.Concurrency
+}
+
+// Set returns the Set
+func (u *UnittestImpl) Set() []string {
+	return u.UnittestOptions.Set
+}
+
+// Values returns the Values
+func (u *UnittestImpl) Values() []string {
+	return u.UnittestOptions.Values
+}
+
+// FailFast returns the fail fast flag
+func (u *UnittestImpl) FailFast() bool {
+	return u.UnittestOptions.FailFast
+}
+
+// Color returns the color flag
+func (u *UnittestImpl) Color() bool {
+	return u.UnittestOptions.Color
+}
+
+// DebugPlugin returns the debug plugin flag
+func (u *UnittestImpl) DebugPlugin() bool {
+	return u.UnittestOptions.DebugPlugin
+}
+
+// SkipCleanup returns the skip clean up
+func (u *UnittestImpl) SkipCleanup() bool {
+	return false
+}
+
+// IncludeNeeds returns the include needs
+func (u *UnittestImpl) IncludeNeeds() bool {
+	return u.UnittestOptions.IncludeNeeds || u.IncludeTransitiveNeeds()
+}
+
+// IncludeTransitiveNeeds returns the include transitive needs
+func (u *UnittestImpl) IncludeTransitiveNeeds() bool {
+	return u.UnittestOptions.IncludeTransitiveNeeds
+}
+
+// SkipNeeds returns the skip needs
+func (u *UnittestImpl) SkipNeeds() bool {
+	if !u.IncludeNeeds() {
+		return u.UnittestOptions.SkipNeeds
+	}
+
+	return false
+}
+
+// EnforceNeedsAreInstalled returns false for unittest
+func (u *UnittestImpl) EnforceNeedsAreInstalled() bool {
+	return false
+}

--- a/pkg/exectest/helm.go
+++ b/pkg/exectest/helm.go
@@ -37,6 +37,7 @@ type Helm struct {
 	Releases             []Release
 	Deleted              []Release
 	Linted               []Release
+	Unittested           []Release
 	Templated            []Release
 	Lists                map[ListKey]string
 	Diffs                map[DiffKey]error
@@ -208,6 +209,13 @@ func (helm *Helm) TestRelease(context helmexec.HelmContext, name string, flags .
 	return nil
 }
 func (helm *Helm) Fetch(chart string, flags ...string) error {
+	return nil
+}
+func (helm *Helm) Unittest(name, chart string, flags ...string) error {
+	if strings.Contains(name, "error") {
+		return errors.New("error")
+	}
+	helm.Unittested = append(helm.Unittested, Release{Name: name, Flags: flags})
 	return nil
 }
 func (helm *Helm) Lint(name, chart string, flags ...string) error {

--- a/pkg/helmexec/helmexec.go
+++ b/pkg/helmexec/helmexec.go
@@ -28,6 +28,7 @@ type Interface interface {
 	ChartPull(chart string, path string, flags ...string) error
 	ChartExport(chart string, path string) error
 	Lint(name, chart string, flags ...string) error
+	Unittest(name, chart string, flags ...string) error
 	ReleaseStatus(context HelmContext, name string, flags ...string) error
 	DeleteRelease(context HelmContext, name string, flags ...string) error
 	TestRelease(context HelmContext, name string, flags ...string) error

--- a/pkg/state/temp_test.go
+++ b/pkg/state/temp_test.go
@@ -38,39 +38,39 @@ func TestGenerateID(t *testing.T) {
 	run(testcase{
 		subject: "baseline",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
-		want:    "foo-values-66f7fd6f7b",
+		want:    "foo-values-6884949b8b",
 	})
 
 	run(testcase{
 		subject: "different bytes content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    []byte(`{"k":"v"}`),
-		want:    "foo-values-6664979cd7",
+		want:    "foo-values-58f57b794f",
 	})
 
 	run(testcase{
 		subject: "different map content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    map[string]any{"k": "v"},
-		want:    "foo-values-78897dfd49",
+		want:    "foo-values-6b6b884cc9",
 	})
 
 	run(testcase{
 		subject: "different chart",
 		release: ReleaseSpec{Name: "foo", Chart: "stable/envoy"},
-		want:    "foo-values-64b7846cb7",
+		want:    "foo-values-85494c4677",
 	})
 
 	run(testcase{
 		subject: "different name",
 		release: ReleaseSpec{Name: "bar", Chart: "incubator/raw"},
-		want:    "bar-values-576cb7ddc7",
+		want:    "bar-values-9d65c65f",
 	})
 
 	run(testcase{
 		subject: "specific ns",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw", Namespace: "myns"},
-		want:    "myns-foo-values-6c567f54c",
+		want:    "myns-foo-values-84b69bb989",
 	})
 
 	for id, n := range ids {

--- a/pkg/testutil/mocks.go
+++ b/pkg/testutil/mocks.go
@@ -142,6 +142,10 @@ func (helm *noCallHelmExec) Lint(name, chart string, flags ...string) error {
 	helm.doPanic()
 	return nil
 }
+func (helm *noCallHelmExec) Unittest(name, chart string, flags ...string) error {
+	helm.doPanic()
+	return nil
+}
 func (helm *noCallHelmExec) IsHelm3() bool {
 	helm.doPanic()
 	return false

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -129,6 +129,7 @@ ${kubectl} create namespace ${test_ns} || fail "Could not create namespace ${tes
 . ${dir}/test-cases/issue-2309-kube-context-template.sh
 . ${dir}/test-cases/issue-2355.sh
 . ${dir}/test-cases/issue-2103.sh
+. ${dir}/test-cases/unittest.sh
 
 # ALL DONE -----------------------------------------------------------------------------------------------------------
 

--- a/test/integration/test-cases/unittest.sh
+++ b/test/integration/test-cases/unittest.sh
@@ -1,0 +1,25 @@
+unittest_input_dir="${cases_dir}/unittest/input"
+helmfile_real="$(pwd)/${helmfile}"
+HELM_UNITTEST_VERSION="${HELM_UNITTEST_VERSION:-1.0.3}"
+
+# Ensure helm-unittest plugin is installed (matching plugin install pattern from run.sh)
+info "Ensuring helm-unittest plugin v${HELM_UNITTEST_VERSION} is installed"
+${helm} plugin ls | grep "^unittest" || ${helm} plugin install https://github.com/helm-unittest/helm-unittest --version v${HELM_UNITTEST_VERSION} ${PLUGIN_INSTALL_FLAGS} || fail "Could not install helm-unittest plugin"
+
+test_start "helmfile unittest - runs unit tests on releases with unitTests defined"
+cd "${unittest_input_dir}"
+${helmfile_real} unittest || fail "helmfile unittest should succeed"
+cd -
+test_pass "helmfile unittest - runs unit tests on releases with unitTests defined"
+
+test_start "helmfile unittest - with selector targeting release without unitTests"
+cd "${unittest_input_dir}"
+${helmfile_real} -l name=no-tests-app unittest || fail "helmfile unittest should succeed for releases without unitTests (skips them)"
+cd -
+test_pass "helmfile unittest - with selector targeting release without unitTests"
+
+test_start "helmfile unittest - with selector targeting release with unitTests"
+cd "${unittest_input_dir}"
+${helmfile_real} -l name=test-app unittest || fail "helmfile unittest should succeed for releases with unitTests"
+cd -
+test_pass "helmfile unittest - with selector targeting release with unitTests"

--- a/test/integration/test-cases/unittest/input/charts/test-app/Chart.yaml
+++ b/test/integration/test-cases/unittest/input/charts/test-app/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: test-app
+description: A test chart for helmfile unittest integration test
+type: application
+version: 0.1.0

--- a/test/integration/test-cases/unittest/input/charts/test-app/templates/deployment.yaml
+++ b/test/integration/test-cases/unittest/input/charts/test-app/templates/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Release.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+            - containerPort: {{ .Values.service.port }}

--- a/test/integration/test-cases/unittest/input/charts/test-app/templates/service.yaml
+++ b/test/integration/test-cases/unittest/input/charts/test-app/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  selector:
+    app: {{ .Release.Name }}

--- a/test/integration/test-cases/unittest/input/charts/test-app/tests/deployment_test.yaml
+++ b/test/integration/test-cases/unittest/input/charts/test-app/tests/deployment_test.yaml
@@ -1,0 +1,20 @@
+suite: test deployment
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: should create deployment with correct replicas
+    set:
+      replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: should use the correct image
+    set:
+      image.repository: nginx
+      image.tag: "1.21"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "nginx:1.21"

--- a/test/integration/test-cases/unittest/input/charts/test-app/values.yaml
+++ b/test/integration/test-cases/unittest/input/charts/test-app/values.yaml
@@ -1,0 +1,9 @@
+replicaCount: 1
+
+image:
+  repository: nginx
+  tag: latest
+
+service:
+  type: ClusterIP
+  port: 80

--- a/test/integration/test-cases/unittest/input/helmfile.yaml
+++ b/test/integration/test-cases/unittest/input/helmfile.yaml
@@ -1,0 +1,10 @@
+releases:
+  - name: test-app
+    chart: ./charts/test-app
+    values:
+      - ./charts/test-app/values.yaml
+    unitTests:
+      - tests
+
+  - name: no-tests-app
+    chart: ./charts/test-app


### PR DESCRIPTION
## Summary

Adds a new `helmfile unittest` command that integrates the [helm-unittest](https://github.com/helm-unittest/helm-unittest) plugin, allowing users to define unit test paths per release and run them via helmfile.

Closes #2376

---

## What changed

### New release spec field: `unitTests`

```yaml
releases:
  - name: my-app
    chart: ./charts/my-app
    values:
      - values.yaml
    unitTests:
      - tests           # directory → auto-appended with /*_test.yaml
      - custom/*_test.yaml  # explicit glob patterns also supported
```

- Paths are **relative to the chart directory** (matching helm-unittest conventions).
- Directory paths automatically get `/*_test.yaml` appended; explicit `.yaml`/`.yml` file paths are passed as-is.
- Releases **without** `unitTests` are silently skipped.

### New CLI command: `helmfile unittest`

```bash
helmfile unittest                          # run all releases with unitTests
helmfile -l name=my-app unittest           # target specific releases
helmfile unittest --values extra.yaml      # pass additional values
helmfile unittest --set key=value          # override values
helmfile unittest --fail-fast              # stop on first failure
helmfile unittest --color                  # force colored output
helmfile unittest --debug-plugin           # verbose plugin output
helmfile unittest --args "--strict"        # pass arbitrary helm-unittest flags
```

Supports `--concurrency`, `--skip-needs`, `--include-needs`, `--include-transitive-needs` (same as `lint`).

### Dedicated helm-unittest flags

| Flag | Description | helm-unittest equivalent |
|---|---|---|
| `--fail-fast` | Quit immediately on first test failure | `--failfast` |
| `--color` | Enforce colored output even when stdout is not a tty | `--color` |
| `--debug-plugin` | Enable verbose plugin output | `--debugPlugin` |

Any flags not covered by the above can still be passed via `--args`.

### Plugin availability check

At runtime, `helmfile unittest` checks that the `helm-unittest` plugin is installed (same pattern as the `helm-diff` check). If missing, it fails with a clear installation instruction.

---

## Files changed (by layer)

| Layer | Files | What |
|---|---|---|
| **Interface** | `pkg/helmexec/helmexec.go` | Added `Unittest` to `Interface` |
| **Execution** | `pkg/helmexec/exec.go` | `Unittest()` impl with plugin check |
| **State** | `pkg/state/state.go` | `UnitTests` field on `ReleaseSpec`, `UnittestReleases()` method with `--file`, `--failfast`, `--color`, `--debugPlugin` flag construction |
| **App** | `pkg/app/app.go`, `pkg/app/config.go` | `Unittest()` / `unittest()` methods, `UnittestConfigProvider` interface |
| **Config** | `pkg/config/unittest.go` | CLI options struct with `FailFast`, `Color`, `DebugPlugin` fields |
| **CLI** | `cmd/unittest.go`, `cmd/root.go` | Cobra command with dedicated flags |
| **Init** | `pkg/app/init.go` | Plugin entry for auto-init recommendation |
| **Mocks** | `pkg/exectest/helm.go`, `pkg/app/app_test.go`, `pkg/testutil/mocks.go` | All 4 `Interface` implementations updated |
| **Tests** | `pkg/app/app_unittest_test.go`, `pkg/state/temp_test.go` | 5 unit test cases + hash fixups |
| **Integration** | `test/integration/test-cases/unittest.sh`, `test/integration/test-cases/unittest/` | 3 integration test scenarios with chart fixtures |
| **Docs** | `docs/index.md` | CLI reference, release spec field, usage examples |

---

## Design decisions

1. **Follows the `lint` command pattern** — The entire implementation mirrors `LintReleases` / `Lint` / `NewLintCmd` for consistency with the existing codebase.

2. **`--file` flag (not `--tests`)** — helm-unittest uses `--file` / `-f` for specifying test file glob patterns. Directory paths in `unitTests` are automatically suffixed with `/*_test.yaml`. Explicit `.yaml`/`.yml` file paths are passed through unchanged.

3. **Paths relative to chart directory** — This matches helm-unittest's native behavior where `--file` patterns are resolved relative to the chart root.

4. **Plugin check in `execer` layer** — The plugin availability check lives in `helmexec/exec.go` (same as real helm execution), keeping mocks clean and testable.

5. **Dedicated CLI flags + `--args` passthrough** — Common helm-unittest flags (`--fail-fast`, `--color`, `--debug-plugin`) are exposed as first-class CLI flags for discoverability. Less common flags can still be passed via the generic `--args` mechanism.

---

## Testing

### Unit tests (5 cases)
- Unittest all releases with `unitTests` defined
- Skip-needs with selector
- Include-needs with selector
- Release without `unitTests` is skipped
- Bad selector returns error

### Integration tests (3 scenarios)
- Basic `helmfile unittest` on a chart with test files
- Selector targeting a release without `unitTests` (skips gracefully)
- Selector targeting a release with `unitTests` (runs tests)

### Local validation
- `go test ./...` — all 22 packages pass
- `golangci-lint run` — no lint issues
- Built binary and ran `helmfile unittest` against the integration test chart — all tests pass