### PR TITLE
fix: prevent panic in helmfile init on plugin install errors

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/helmfile/helmfile/pkg/config"
+	"github.com/helmfile/helmfile/pkg/errors"
+	"github.com/helmfile/helmfile/pkg/helmexec"
+)
+
+func TestToCLIError(t *testing.T) {
+	g := config.NewGlobalImpl(&config.GlobalOptions{})
+
+	tests := []struct {
+		name            string
+		err             error
+		wantNil         bool
+		wantExitCode    int
+		wantMsgContains string
+	}{
+		{
+			name:    "nil error returns nil",
+			err:     nil,
+			wantNil: true,
+		},
+		{
+			name: "helmexec.ExitError returns correct exit code",
+			err: helmexec.ExitError{
+				Message: "helm command failed",
+				Code:    7,
+			},
+			wantExitCode:    7,
+			wantMsgContains: "helm command failed",
+		},
+		{
+			name:            "wrapped helmexec.ExitError preserves exit code",
+			err:             fmt.Errorf("helm version failed: %w", helmexec.ExitError{Message: "exit status 7", Code: 7}),
+			wantExitCode:    7,
+			wantMsgContains: "exit status 7",
+		},
+		{
+			name:            "unknown error type returns exit code 1 without panic",
+			err:             fmt.Errorf("some unexpected error"),
+			wantExitCode:    1,
+			wantMsgContains: "unexpected error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Should never panic
+			var result error
+			assert.NotPanics(t, func() {
+				result = toCLIError(g, tt.err)
+			})
+
+			if tt.wantNil {
+				assert.NoError(t, result)
+				return
+			}
+
+			assert.Error(t, result)
+			exitErr, ok := result.(*errors.ExitError)
+			assert.True(t, ok, "expected *errors.ExitError, got %T", result)
+			assert.Equal(t, tt.wantExitCode, exitErr.ExitCode())
+			assert.Contains(t, exitErr.Error(), tt.wantMsgContains)
+		})
+	}
+}

--- a/pkg/app/init_test.go
+++ b/pkg/app/init_test.go
@@ -2,14 +2,21 @@ package app
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/helmfile/helmfile/pkg/helmexec"
 )
 
 func TestDownloadfile(t *testing.T) {
@@ -83,4 +90,120 @@ func TestDownloadfile(t *testing.T) {
 			assert.Equal(t, c.wantContent, string(content), "unexpected content in downloaded file")
 		})
 	}
+}
+
+// initMockRunner implements helmexec.Runner for testing with configurable behavior.
+type initMockRunner struct {
+	// executeFunc is called for each Execute call. If nil, returns empty output and no error.
+	executeFunc func(cmd string, args []string, env map[string]string, enableLiveOutput bool) ([]byte, error)
+}
+
+func (m *initMockRunner) Execute(cmd string, args []string, env map[string]string, enableLiveOutput bool) ([]byte, error) {
+	if m.executeFunc != nil {
+		return m.executeFunc(cmd, args, env, enableLiveOutput)
+	}
+	return []byte{}, nil
+}
+
+func (m *initMockRunner) ExecuteStdIn(cmd string, args []string, env map[string]string, stdin io.Reader) ([]byte, error) {
+	return []byte{}, nil
+}
+
+// mockInitConfigProvider implements InitConfigProvider for testing.
+type mockInitConfigProvider struct {
+	force bool
+}
+
+func (m *mockInitConfigProvider) Force() bool {
+	return m.force
+}
+
+func newTestLogger() *zap.SugaredLogger {
+	cfg := zapcore.EncoderConfig{MessageKey: "message"}
+	core := zapcore.NewCore(
+		zapcore.NewConsoleEncoder(cfg),
+		zapcore.AddSync(io.Discard),
+		zapcore.DebugLevel,
+	)
+	return zap.New(core).Sugar()
+}
+
+// createPluginYAML creates a plugin.yaml in a temp plugins directory.
+func createPluginYAML(t *testing.T, pluginsDir, pluginDirName, name, version string) {
+	t.Helper()
+	dir := filepath.Join(pluginsDir, pluginDirName)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	content := fmt.Sprintf("name: %s\nversion: %s\n", name, version)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "plugin.yaml"), []byte(content), 0o644))
+}
+
+// newHelmPluginMockRunner creates a mock runner that returns a valid helm version
+// and fails all "helm plugin" subcommands with the given error.
+func newHelmPluginMockRunner(pluginErr error) *initMockRunner {
+	return &initMockRunner{
+		executeFunc: func(cmd string, args []string, env map[string]string, enableLiveOutput bool) ([]byte, error) {
+			for _, a := range args {
+				if a == "--short" {
+					return []byte("v3.18.6"), nil
+				}
+			}
+			// Fail any "helm plugin ..." subcommand (install, update, etc.)
+			if len(args) > 0 && args[0] == "plugin" {
+				return nil, pluginErr
+			}
+			return []byte{}, nil
+		},
+	}
+}
+
+func TestCheckHelmPlugins_InstallErrorButPluginPresent(t *testing.T) {
+	pluginsDir := t.TempDir()
+	t.Setenv("HELM_PLUGINS", pluginsDir)
+
+	// Do NOT pre-populate plugins — the directory starts empty so
+	// GetPluginVersion returns "not installed" and the install path is triggered.
+	// The mock runner simulates the Windows scenario where "helm plugin install"
+	// places the binary but the post-install script fails: it creates the
+	// plugin.yaml on disk and then returns an error.
+	runner := &initMockRunner{
+		executeFunc: func(cmd string, args []string, env map[string]string, enableLiveOutput bool) ([]byte, error) {
+			for _, a := range args {
+				if a == "--short" {
+					return []byte("v3.18.6"), nil
+				}
+			}
+			if len(args) > 0 && args[0] == "plugin" && len(args) >= 3 && args[1] == "install" {
+				// Find which plugin is being installed by matching the repo URL.
+				repo := args[2]
+				for _, p := range helmPlugins {
+					if p.repo == repo {
+						createPluginYAML(t, pluginsDir, p.name, p.name, strings.TrimPrefix(p.version, "v"))
+						break
+					}
+				}
+				return nil, helmexec.ExitError{Message: "sh: not found", Code: 1}
+			}
+			return []byte{}, nil
+		},
+	}
+
+	h := NewHelmfileInit("helm", &mockInitConfigProvider{force: true}, newTestLogger(), runner)
+	err := h.CheckHelmPlugins()
+	// Should succeed because plugins are present despite install errors
+	assert.NoError(t, err)
+}
+
+func TestCheckHelmPlugins_InstallErrorPluginTrulyMissing(t *testing.T) {
+	pluginsDir := t.TempDir()
+	t.Setenv("HELM_PLUGINS", pluginsDir)
+
+	// Don't create any plugin files — the plugins directory is empty.
+
+	runner := newHelmPluginMockRunner(helmexec.ExitError{Message: "sh: not found", Code: 1})
+
+	h := NewHelmfileInit("helm", &mockInitConfigProvider{force: true}, newTestLogger(), runner)
+	err := h.CheckHelmPlugins()
+	// Should fail because plugin is truly not installed
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "sh: not found")
 }


### PR DESCRIPTION
## Summary

Fixes #1983

On Windows, `helmfile init` panics when installing helm plugins whose install hooks require `sh` (e.g. helm-s3). Two issues cause this:

1. **`toCLIError()` panics on unhandled error types** — It only handles three `app.*` error types; any other error (like `helmexec.ExitError` from a failed `helm plugin install`) triggers `panic` instead of a graceful exit.
2. **`CheckHelmPlugins()` fails immediately on plugin install errors** — On Windows, plugin install hooks can fail (missing `sh`) even though the plugin binary was placed correctly. The function doesn't verify whether the plugin is actually present before returning the error.

## Changes

### `cmd/root.go`
- Add a `helmexec.ExitError` switch case that preserves the exit code from helm command failures
- Replace the `default` panic with a graceful `errors.NewExitError(...)` return (exit code 1), so no error type can crash the process

### `pkg/app/init.go`
- After `AddPlugin()` fails: re-check `GetPluginVersion()` — if the plugin is present, log a warning and continue
- After `UpdatePlugin()` fails: re-check `GetPluginVersion()` — if the plugin meets the required version, log a warning and continue; otherwise propagate the error

### Tests
- `cmd/root_test.go` — `toCLIError` with `helmexec.ExitError` (preserves exit code), unknown error type (no panic, returns code 1), and nil input
- `pkg/app/init_test.go` — `CheckHelmPlugins` with plugin install error but plugin present (succeeds with warning) vs plugin truly missing (returns error)

## Test plan

- [x] `go test ./cmd/... ./pkg/app/... ./pkg/helmexec/...` — all pass
- [x] `go build ./...` — builds successfully
- [ ] Manual: `helmfile init` on Windows with helm-s3 plugin (requires `sh`-less environment to reproduce)