### PR TITLE
fix: support XDG-style multiple paths in HELM_PLUGINS

### DIFF
--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -116,11 +116,19 @@ type PluginMetadata struct {
 func GetPluginVersion(name, pluginsDir string) (*semver.Version, error) {
 	pluginDirs := filepath.SplitList(pluginsDir)
 
+	var firstReadErr error
 	for _, dir := range pluginDirs {
+		if dir == "" {
+			continue
+		}
+
 		entries, err := os.ReadDir(dir)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
+			}
+			if firstReadErr == nil {
+				firstReadErr = err
 			}
 			continue
 		}
@@ -147,6 +155,9 @@ func GetPluginVersion(name, pluginsDir string) (*semver.Version, error) {
 		}
 	}
 
+	if firstReadErr != nil {
+		return nil, firstReadErr
+	}
 	return nil, fmt.Errorf("plugin %s not installed", name)
 }
 

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -1321,13 +1321,14 @@ func Test_GetPluginVersion_XDGPaths(t *testing.T) {
 	v3PluginDirPath := "../../test/plugins/secrets/3.15.0"
 	v4PluginDirPath := "../../test/plugins/secrets/4.7.4"
 
-	xdgPaths := "/nonexistent/path:" + v3PluginDirPath + ":/another/nonexistent"
+	sep := string(os.PathListSeparator)
+	xdgPaths := "nonexistent/path" + sep + v3PluginDirPath + sep + "another/nonexistent"
 
 	pluginVersion, err := GetPluginVersion("secrets", xdgPaths)
 	require.NoError(t, err)
 	assert.Equal(t, v3ExpectedVersion, pluginVersion.String())
 
-	xdgPathsV4 := v4PluginDirPath + ":/nonexistent/path"
+	xdgPathsV4 := v4PluginDirPath + sep + "nonexistent/path"
 	pluginVersion, err = GetPluginVersion("secrets", xdgPathsV4)
 	require.NoError(t, err)
 	assert.Equal(t, v4ExpectedVersion, pluginVersion.String())


### PR DESCRIPTION
## Summary

- Fixes `GetPluginVersion` to properly handle XDG-style multiple directory paths in `HELM_PLUGINS` environment variable (e.g., `HELM_PLUGINS=/path/one:/path/two`)
- Uses `filepath.SplitList` which correctly splits paths by the OS-specific list separator (`:` on Unix, `;` on Windows)
- Adds test coverage for XDG-style path scenarios

## Problem

When `HELM_PLUGINS` contains multiple directories (colon-separated), Helmfile failed to find installed plugins, reporting "plugin secrets not installed" even though the plugin was present in one of the directories.

## Solution

Modified `GetPluginVersion` to iterate through all directories in the path list, searching for the plugin in each one until found.

Fixes #2411