### PR TITLE
fix: skip helm repo update when only OCI repos are configured

### DIFF
--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -132,6 +132,7 @@ ${kubectl} create namespace ${test_ns} || fail "Could not create namespace ${tes
 . ${dir}/test-cases/unittest.sh
 . ${dir}/test-cases/issue-2409-sequential-kubecontext.sh
 . ${dir}/test-cases/issue-2269.sh
+. ${dir}/test-cases/issue-2418.sh
 
 # ALL DONE -----------------------------------------------------------------------------------------------------------
 

--- a/test/integration/test-cases/issue-2418.sh
+++ b/test/integration/test-cases/issue-2418.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Test for issue #2418: Skip helm repo update when only OCI repos are configured
+# When using only OCI repositories combined with a local chart, helmfile should NOT
+# attempt to run `helm repo update` which would fail with "no repositories found".
+
+issue_2418_input_dir="${cases_dir}/issue-2418/input"
+issue_2418_tmp=$(mktemp -d)
+issue_2418_output="${issue_2418_tmp}/template.log"
+
+cleanup_issue_2418() {
+  rm -rf "${issue_2418_tmp}"
+}
+trap cleanup_issue_2418 EXIT
+
+test_start "issue-2418: OCI repos + local chart should skip helm repo update"
+
+# Run helmfile template - this would fail with "no repositories found" before the fix
+# because it would attempt to run `helm repo update` for OCI repos
+info "Running helmfile template with OCI repo + local chart"
+${helmfile} -f "${issue_2418_input_dir}/helmfile.yaml" template > "${issue_2418_output}" 2>&1 || {
+  code=$?
+  cat "${issue_2418_output}"
+  
+  # Check if the failure is due to "no repositories found" error
+  if grep -q "no repositories found" "${issue_2418_output}"; then
+    fail "Issue #2418 regression: helm repo update was called for OCI-only repos"
+  fi
+  
+  fail "helmfile template failed with exit code ${code}"
+}
+
+info "SUCCESS: helmfile template completed without 'no repositories found' error"
+info "Template output:"
+cat "${issue_2418_output}"
+
+trap - EXIT
+test_pass "issue-2418: OCI repos + local chart should skip helm repo update"

--- a/test/integration/test-cases/issue-2418/input/customresources/Chart.yaml
+++ b/test/integration/test-cases/issue-2418/input/customresources/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: customresources
+description: A Helm chart for custom resources
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/test/integration/test-cases/issue-2418/input/customresources/templates/notes.txt
+++ b/test/integration/test-cases/issue-2418/input/customresources/templates/notes.txt
@@ -1,0 +1,1 @@
+{{- /* Empty templates */ -}}

--- a/test/integration/test-cases/issue-2418/input/customresources/values.yaml
+++ b/test/integration/test-cases/issue-2418/input/customresources/values.yaml
@@ -1,0 +1,1 @@
+# Default values for customresources.

--- a/test/integration/test-cases/issue-2418/input/helmfile.yaml
+++ b/test/integration/test-cases/issue-2418/input/helmfile.yaml
@@ -1,0 +1,9 @@
+repositories:
+  - name: karpenter
+    url: public.ecr.aws/karpenter
+    oci: true
+
+releases:
+- name: custom-resources
+  chart: ./customresources
+  namespace: default


### PR DESCRIPTION
## Summary

- Fixes #2418 
- When only OCI repositories are configured, skip `helm repo update` since OCI repos use `helm registry login` instead
- Adds `NeedsRepoUpdate()` helper function to check if any repos require `helm repo update`
- Updates `runHelmDepBuilds` to only call `UpdateRepo()` when non-OCI repos are present

## Problem

When using a local helmfile combined with only OCI repositories, helmfile would attempt to run `helm repo update`. This fails with:
```
Error: no repositories found. You must add one before updating.
```

## Solution

OCI repositories don't need `helm repo update` because they are authenticated via `helm registry login`. The fix checks if there are any non-OCI repositories before attempting to update repos.

## Test Plan

Added tests for:
- `NeedsRepoUpdate()` function with various repo configurations
- `TestRunHelmDepBuilds_HelmDefaultsSkipRefresh` with OCI-only repos (UpdateRepo skipped)
- Mixed OCI + non-OCI repos (UpdateRepo called)