### PR TITLE
feat: add --force-conflicts flag support for Helm 4

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -3459,11 +3459,11 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 	forceConflictsEnabled := (release.ForceConflicts != nil && *release.ForceConflicts) || (release.ForceConflicts == nil && st.HelmDefaults.ForceConflicts)
 
 	if forceConflictsEnabled && !helm.IsHelm4() {
-		return nil, nil, fmt.Errorf("releases[].forceConflicts requires Helm 4 or greater")
+		return nil, nil, fmt.Errorf("forceConflicts requires Helm 4 or greater (set via releases[].forceConflicts or helmDefaults.forceConflicts)")
 	}
 
 	if forceEnabled && forceConflictsEnabled {
-		return nil, nil, fmt.Errorf("force and forceConflicts are mutually exclusive")
+		return nil, nil, fmt.Errorf("force and forceConflicts are mutually exclusive (check both releases[].force/forceConflicts and helmDefaults.force/forceConflicts)")
 	}
 
 	if forceEnabled {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -428,7 +428,22 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 				Name:           "test-charts",
 				Namespace:      "test-namespace",
 			},
-			wantErr: "releases[].forceConflicts requires Helm 4 or greater",
+			wantErr: "forceConflicts requires Helm 4 or greater (set via releases[].forceConflicts or helmDefaults.forceConflicts)",
+		},
+		{
+			name: "force-conflicts-from-default-helm3-error",
+			defaults: HelmSpec{
+				ForceConflicts:  true,
+				CreateNamespace: &disable,
+			},
+			version: semver.MustParse("3.10.0"),
+			release: &ReleaseSpec{
+				Chart:     "test/chart",
+				Version:   "0.1",
+				Name:      "test-charts",
+				Namespace: "test-namespace",
+			},
+			wantErr: "forceConflicts requires Helm 4 or greater (set via releases[].forceConflicts or helmDefaults.forceConflicts)",
 		},
 		{
 			name: "force-and-force-conflicts-mutually-exclusive-helm4",
@@ -444,7 +459,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 				Name:           "test-charts",
 				Namespace:      "test-namespace",
 			},
-			wantErr: "force and forceConflicts are mutually exclusive",
+			wantErr: "force and forceConflicts are mutually exclusive (check both releases[].force/forceConflicts and helmDefaults.force/forceConflicts)",
 		},
 		{
 			name: "recreate-pods",

--- a/pkg/state/temp_test.go
+++ b/pkg/state/temp_test.go
@@ -38,39 +38,39 @@ func TestGenerateID(t *testing.T) {
 	run(testcase{
 		subject: "baseline",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
-		want:    "foo-values-6d799cf798",
+		want:    "foo-values-5bc9c89c6b",
 	})
 
 	run(testcase{
 		subject: "different bytes content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    []byte(`{"k":"v"}`),
-		want:    "foo-values-7f885447bf",
+		want:    "foo-values-7bf9c8bcdf",
 	})
 
 	run(testcase{
 		subject: "different map content",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw"},
 		data:    map[string]any{"k": "v"},
-		want:    "foo-values-86f5d8fb55",
+		want:    "foo-values-65694d8947",
 	})
 
 	run(testcase{
 		subject: "different chart",
 		release: ReleaseSpec{Name: "foo", Chart: "stable/envoy"},
-		want:    "foo-values-5cd5c65db5",
+		want:    "foo-values-856c5f7dd5",
 	})
 
 	run(testcase{
 		subject: "different name",
 		release: ReleaseSpec{Name: "bar", Chart: "incubator/raw"},
-		want:    "bar-values-c59b4f979",
+		want:    "bar-values-fff55fbf5",
 	})
 
 	run(testcase{
 		subject: "specific ns",
 		release: ReleaseSpec{Name: "foo", Chart: "incubator/raw", Namespace: "myns"},
-		want:    "myns-foo-values-56d6cd88cc",
+		want:    "myns-foo-values-6bfbb74765",
 	})
 
 	for id, n := range ids {


### PR DESCRIPTION
## Summary
- Add `forceConflicts` option to `HelmSpec` (helmDefaults) and `ReleaseSpec` for per-release configuration
- `--force-conflicts` flag is only available in Helm 4 and forces server-side apply changes against conflicts
- Added validation to ensure `force` and `forceConflicts` are mutually exclusive
- Added validation to error when `forceConflicts` is used with Helm 3

## Usage
```yaml
helmDefaults:
  forceConflicts: true  # Requires Helm 4

releases:
  - name: my-release
    chart: my/chart
    forceConflicts: true  # Mutually exclusive with force
```

Fixes #2429