### PR TITLE
fix: keep all chart dependencies key / values

### DIFF
--- a/pkg/state/chart_dependencies_rewrite_test.go
+++ b/pkg/state/chart_dependencies_rewrite_test.go
@@ -146,6 +146,41 @@ dependencies:
 				}
 			},
 		},
+		{
+			name: "extra fields",
+			chartYaml: `apiVersion: v2
+name: test-chart
+version: 1.0.0
+dependencies:
+  - name: dep1
+    repository: https://charts.example.com
+    version: 1.0.0
+    condition: dep.install
+    import-values:
+    - child: persistence
+      parent: global.persistence
+    extra-field2: bbb
+extra-field: aaa
+`,
+			expectModified: false,
+			expectError:    false,
+			validate: func(t *testing.T, modifiedChartYaml string) {
+				requiredFields := []string{
+					"condition: dep.install",
+					"import-values:",
+					"child: persistence",
+					"parent: global.persistence",
+					"extra-field2: bbb",
+					"extra-field: aaa",
+				}
+
+				for _, field := range requiredFields {
+					if !strings.Contains(modifiedChartYaml, field) {
+						t.Errorf("field %q should be preserved", field)
+					}
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -304,6 +339,7 @@ dependencies:
   - name: dep1
     repository: file://../relative-chart
     version: 1.0.0
+    condition: test
 `
 
 	chartYamlPath := filepath.Join(tempDir, "Chart.yaml")
@@ -331,9 +367,7 @@ dependencies:
 
 	content := string(modifiedContent)
 
-	// Verify top-level fields are preserved
-	// Note: The implementation preserves top-level chart metadata but may not preserve
-	// extra dependency-level fields (like condition, tags) that are not in the ChartDependency struct
+	// Verify fields are preserved
 	requiredFields := []string{
 		"apiVersion: v2",
 		"name: test-chart",
@@ -341,6 +375,7 @@ dependencies:
 		"description: A test chart",
 		"keywords:",
 		"maintainers:",
+		"condition:",
 	}
 
 	for _, field := range requiredFields {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1444,9 +1444,9 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) 
 
 	// Parse Chart.yaml
 	type ChartDependency struct {
-		Name       string `yaml:"name"`
-		Repository string `yaml:"repository"`
-		Version    string `yaml:"version"`
+		Name       string                 `yaml:"name"`
+		Repository string                 `yaml:"repository"`
+		Data       map[string]interface{} `yaml:",inline"`
 	}
 	type ChartMeta struct {
 		Dependencies []ChartDependency      `yaml:"dependencies,omitempty"`

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -96,6 +96,7 @@ ${kubectl} create namespace ${test_ns} || fail "Could not create namespace ${tes
 
 # TEST CASES----------------------------------------------------------------------------------------------------------
 
+. ${dir}/test-cases/chart-deps-condition.sh
 . ${dir}/test-cases/fetch-forl-local-chart.sh
 . ${dir}/test-cases/suppress-output-line-regex.sh
 . ${dir}/test-cases/chartify-jsonPatches-and-strategicMergePatches.sh

--- a/test/integration/test-cases/chart-deps-condition.sh
+++ b/test/integration/test-cases/chart-deps-condition.sh
@@ -1,0 +1,13 @@
+chart_deps_condition_input_dir="${cases_dir}/chart-deps-condition/input"
+
+chart_deps_condition_tmp=$(mktemp -d)
+actual=${chart_deps_condition_tmp}/actual.yaml
+expected="${cases_dir}/chart-deps-condition/output/template"
+
+test_start "chart with dependencies and condition"
+
+# --concurrency 1 is a workaround for https://github.com/helmfile/helmfile/issues/2502
+${helmfile} -f ${chart_deps_condition_input_dir}/helmfile.yaml template --skip-deps --concurrency 1 > ${actual} || fail "\"helmfile template\" shouldn't fail"
+./dyff between -bs ${expected} ${actual} || fail "\"helmfile template\" should be consistent"
+
+test_pass "chart with dependencies and condition"

--- a/test/integration/test-cases/chart-deps-condition/input/chart/Chart.yaml
+++ b/test/integration/test-cases/chart-deps-condition/input/chart/Chart.yaml
@@ -1,0 +1,14 @@
+dependencies:
+  - name: subchart1
+    repository: file://charts/subchart1
+    condition: subchart1.install
+    version: 1.0.0
+  - name: subchart2
+    repository: file://charts/subchart2
+    version: 2.0.0
+apiVersion: v2
+appVersion: 3.0.0
+description: Test helm charts dependencies
+name: testchartsdeps
+type: application
+version: 3.0.0

--- a/test/integration/test-cases/chart-deps-condition/input/chart/charts/subchart1/Chart.yaml
+++ b/test/integration/test-cases/chart-deps-condition/input/chart/charts/subchart1/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: subchart1
+description: Test sub helm chart 1
+type: application
+version: 1.0.0
+appVersion: "1.0.0"

--- a/test/integration/test-cases/chart-deps-condition/input/chart/charts/subchart1/templates/cm.yaml
+++ b/test/integration/test-cases/chart-deps-condition/input/chart/charts/subchart1/templates/cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: testsub1
+data:
+  sub: 1

--- a/test/integration/test-cases/chart-deps-condition/input/chart/charts/subchart2/Chart.yaml
+++ b/test/integration/test-cases/chart-deps-condition/input/chart/charts/subchart2/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: subchart2
+description: Test sub helm chart 2
+type: application
+version: 2.0.0
+appVersion: "2.0.0"

--- a/test/integration/test-cases/chart-deps-condition/input/chart/charts/subchart2/templates/cm.yaml
+++ b/test/integration/test-cases/chart-deps-condition/input/chart/charts/subchart2/templates/cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: testsub2
+data:
+  sub: 2

--- a/test/integration/test-cases/chart-deps-condition/input/chart/values.yaml
+++ b/test/integration/test-cases/chart-deps-condition/input/chart/values.yaml
@@ -1,0 +1,2 @@
+subchart1:
+  install: true

--- a/test/integration/test-cases/chart-deps-condition/input/helmfile.yaml
+++ b/test/integration/test-cases/chart-deps-condition/input/helmfile.yaml
@@ -1,0 +1,57 @@
+# Test that subcharts 'condition' is working properly
+
+releases:
+# Releases without patches, so not using chartify
+- name: testdefault
+  chart: ./chart
+  namespace: testdefault
+- name: testinstallfalse
+  chart: ./chart
+  namespace: testinstallfalse
+  values:
+  - subchart1:
+      install: false
+- name: testinstalltrue
+  chart: ./chart
+  namespace: testcinstalltrue
+  values:
+  - subchart1:
+      install: true
+
+# Releases with patches, so using chartify
+- name: testchartifydefault
+  chart: ./chart
+  namespace: testchartifydefault
+  strategicMergePatches:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: testsub2
+    data:
+      sub: 42
+- name: testchartifyinstallfalse
+  chart: ./chart
+  namespace: testchartifyinstallfalse
+  values:
+  - subchart1:
+      install: false
+  strategicMergePatches:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: testsub2
+    data:
+      sub: 42
+- name: testchartifyinstalltrue
+  chart: ./chart
+  namespace: testchartifyinstalltrue
+  values:
+  - subchart1:
+      install: true
+  strategicMergePatches:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: testsub2
+    data:
+      sub: 42

--- a/test/integration/test-cases/chart-deps-condition/output/template
+++ b/test/integration/test-cases/chart-deps-condition/output/template
@@ -1,0 +1,86 @@
+---
+# Source: testchartsdeps/charts/subchart1/templates/cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: testsub1
+data:
+  sub: 1
+---
+# Source: testchartsdeps/charts/subchart2/templates/cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: testsub2
+data:
+  sub: 2
+
+---
+# Source: testchartsdeps/charts/subchart2/templates/cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: testsub2
+data:
+  sub: 2
+
+---
+# Source: testchartsdeps/charts/subchart1/templates/cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: testsub1
+data:
+  sub: 1
+---
+# Source: testchartsdeps/charts/subchart2/templates/cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: testsub2
+data:
+  sub: 2
+
+---
+# Source: testchartsdeps/templates/patched_resources.yaml
+apiVersion: v1
+data:
+  sub: 1
+kind: ConfigMap
+metadata:
+  name: testsub1
+---
+# Source: testchartsdeps/templates/patched_resources.yaml
+apiVersion: v1
+data:
+  sub: 42
+kind: ConfigMap
+metadata:
+  name: testsub2
+
+---
+# Source: testchartsdeps/templates/patched_resources.yaml
+apiVersion: v1
+data:
+  sub: 42
+kind: ConfigMap
+metadata:
+  name: testsub2
+
+---
+# Source: testchartsdeps/templates/patched_resources.yaml
+apiVersion: v1
+data:
+  sub: 1
+kind: ConfigMap
+metadata:
+  name: testsub1
+---
+# Source: testchartsdeps/templates/patched_resources.yaml
+apiVersion: v1
+data:
+  sub: 42
+kind: ConfigMap
+metadata:
+  name: testsub2
+


### PR DESCRIPTION
In rewriteChartDependencies we were only parsing name / repository / version, thus dropping keys like condition / import-values.

This at least fixes the use of condition.