### PR TITLE
fix: add mutex lock for concurrent rewriteChartDependencies access

### DIFF
--- a/pkg/state/chart_dependencies_rewrite_test.go
+++ b/pkg/state/chart_dependencies_rewrite_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"go.uber.org/zap"
@@ -501,5 +502,70 @@ dependencies:
 	// The relative path should have been converted to absolute
 	if strings.Contains(content, "file://./subdir/chart") {
 		t.Errorf("relative path with ./ should have been converted")
+	}
+}
+
+func TestRewriteChartDependencies_RaceCondition(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "helmfile-test-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	chartYaml := `apiVersion: v2
+name: test-chart
+version: 1.0.0
+dependencies:
+  - name: dep1
+    repository: file://../relative-chart
+    version: 1.0.0
+`
+
+	chartYamlPath := filepath.Join(tempDir, "Chart.yaml")
+	if err := os.WriteFile(chartYamlPath, []byte(chartYaml), 0644); err != nil {
+		t.Fatalf("failed to write Chart.yaml: %v", err)
+	}
+
+	// Run multiple goroutines concurrently on the same chart path
+	numGoroutines := 10
+	var wg sync.WaitGroup
+	errCh := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			logger := zap.NewNop().Sugar()
+			st := &HelmState{
+				logger: logger,
+				fs:     filesystem.DefaultFileSystem(),
+			}
+
+			cleanup, err := st.rewriteChartDependencies(tempDir)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			defer cleanup()
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		t.Errorf("goroutine error: %v", err)
+	}
+
+	// Verify Chart.yaml is still valid
+	data, err := os.ReadFile(chartYamlPath)
+	if err != nil {
+		t.Fatalf("failed to read Chart.yaml: %v", err)
+	}
+
+	// Should still have the dependencies section
+	if !strings.Contains(string(data), "dependencies:") {
+		t.Errorf("Chart.yaml should still have dependencies section")
 	}
 }

--- a/pkg/state/chart_dependencies_rewrite_test.go
+++ b/pkg/state/chart_dependencies_rewrite_test.go
@@ -599,7 +599,9 @@ dependencies:
 	if chartMeta.Dependencies[0].Name != "dep1" {
 		t.Errorf("expected dependency name 'dep1', got %q", chartMeta.Dependencies[0].Name)
 	}
-	if !strings.HasPrefix(chartMeta.Dependencies[0].Repository, "file://") {
-		t.Errorf("expected dependency repository to start with 'file://', got %q", chartMeta.Dependencies[0].Repository)
+	// The cleanup from each goroutine must have restored the original relative path.
+	const wantRepository = "file://../relative-chart"
+	if chartMeta.Dependencies[0].Repository != wantRepository {
+		t.Errorf("expected dependency repository %q (original relative path), got %q", wantRepository, chartMeta.Dependencies[0].Repository)
 	}
 }

--- a/pkg/state/chart_dependencies_rewrite_test.go
+++ b/pkg/state/chart_dependencies_rewrite_test.go
@@ -528,18 +528,22 @@ dependencies:
 	}
 
 	// Run multiple goroutines concurrently on the same chart path.
-	// A start barrier ensures all goroutines attempt rewriteChartDependencies simultaneously.
+	// A readiness WaitGroup ensures all goroutines are blocked before the start barrier is released,
+	// so calls to rewriteChartDependencies overlap as much as possible.
 	numGoroutines := 10
 	var wg sync.WaitGroup
+	var readyWg sync.WaitGroup
 	errCh := make(chan error, numGoroutines)
 	ready := make(chan struct{})
 
 	for i := 0; i < numGoroutines; i++ {
 		wg.Add(1)
+		readyWg.Add(1)
 		go func() {
 			defer wg.Done()
 
-			// Wait until all goroutines are ready so they start simultaneously.
+			// Signal that this goroutine is ready, then wait for the start signal.
+			readyWg.Done()
 			<-ready
 
 			logger := zap.NewNop().Sugar()
@@ -557,7 +561,8 @@ dependencies:
 		}()
 	}
 
-	// Release all goroutines at once to maximize contention.
+	// Wait until all goroutines are ready, then release them simultaneously.
+	readyWg.Wait()
 	close(ready)
 
 	wg.Wait()

--- a/pkg/state/chart_dependencies_rewrite_test.go
+++ b/pkg/state/chart_dependencies_rewrite_test.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/helmfile/helmfile/pkg/filesystem"
+	"github.com/helmfile/helmfile/pkg/yaml"
 )
 
 func TestRewriteChartDependencies(t *testing.T) {
@@ -558,14 +559,39 @@ dependencies:
 		t.Errorf("goroutine error: %v", err)
 	}
 
-	// Verify Chart.yaml is still valid
+	// Verify Chart.yaml is still valid by unmarshaling and checking expected fields
 	data, err := os.ReadFile(chartYamlPath)
 	if err != nil {
 		t.Fatalf("failed to read Chart.yaml: %v", err)
 	}
 
-	// Should still have the dependencies section
-	if !strings.Contains(string(data), "dependencies:") {
-		t.Errorf("Chart.yaml should still have dependencies section")
+	type ChartDependency struct {
+		Name       string `yaml:"name"`
+		Repository string `yaml:"repository"`
+		Version    string `yaml:"version"`
+	}
+	type ChartMeta struct {
+		APIVersion   string            `yaml:"apiVersion"`
+		Name         string            `yaml:"name"`
+		Version      string            `yaml:"version"`
+		Dependencies []ChartDependency `yaml:"dependencies,omitempty"`
+	}
+
+	var chartMeta ChartMeta
+	if err := yaml.Unmarshal(data, &chartMeta); err != nil {
+		t.Fatalf("Chart.yaml is not valid YAML after concurrent rewrites: %v", err)
+	}
+
+	if chartMeta.Name != "test-chart" {
+		t.Errorf("expected chart name 'test-chart', got %q", chartMeta.Name)
+	}
+	if len(chartMeta.Dependencies) != 1 {
+		t.Fatalf("expected 1 dependency, got %d", len(chartMeta.Dependencies))
+	}
+	if chartMeta.Dependencies[0].Name != "dep1" {
+		t.Errorf("expected dependency name 'dep1', got %q", chartMeta.Dependencies[0].Name)
+	}
+	if !strings.HasPrefix(chartMeta.Dependencies[0].Repository, "file://") {
+		t.Errorf("expected dependency repository to start with 'file://', got %q", chartMeta.Dependencies[0].Repository)
 	}
 }

--- a/pkg/state/chart_dependencies_rewrite_test.go
+++ b/pkg/state/chart_dependencies_rewrite_test.go
@@ -527,15 +527,20 @@ dependencies:
 		t.Fatalf("failed to write Chart.yaml: %v", err)
 	}
 
-	// Run multiple goroutines concurrently on the same chart path
+	// Run multiple goroutines concurrently on the same chart path.
+	// A start barrier ensures all goroutines attempt rewriteChartDependencies simultaneously.
 	numGoroutines := 10
 	var wg sync.WaitGroup
 	errCh := make(chan error, numGoroutines)
+	ready := make(chan struct{})
 
 	for i := 0; i < numGoroutines; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+
+			// Wait until all goroutines are ready so they start simultaneously.
+			<-ready
 
 			logger := zap.NewNop().Sugar()
 			st := &HelmState{
@@ -551,6 +556,9 @@ dependencies:
 			defer cleanup()
 		}()
 	}
+
+	// Release all goroutines at once to maximize contention.
+	close(ready)
 
 	wg.Wait()
 	close(errCh)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1471,7 +1471,8 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) 
 
 	var chartMeta ChartMeta
 	if err := yaml.Unmarshal(data, &chartMeta); err != nil {
-		return cleanup, err
+		mu.Unlock()
+		return func() {}, err
 	}
 
 	// Rewrite relative file:// dependencies to absolute paths
@@ -1487,7 +1488,8 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) 
 				absPath := filepath.Join(chartPath, relPath)
 				absPath, err = filepath.Abs(absPath)
 				if err != nil {
-					return cleanup, fmt.Errorf("failed to resolve absolute path for dependency %s: %w", dep.Name, err)
+					mu.Unlock()
+					return func() {}, fmt.Errorf("failed to resolve absolute path for dependency %s: %w", dep.Name, err)
 				}
 
 				st.logger.Debugf("Rewriting Chart dependency %s from %s to file://%s", dep.Name, dep.Repository, absPath)
@@ -1501,11 +1503,13 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) 
 	if modified {
 		updatedData, err := yaml.Marshal(&chartMeta)
 		if err != nil {
-			return cleanup, fmt.Errorf("failed to marshal Chart.yaml: %w", err)
+			mu.Unlock()
+			return func() {}, fmt.Errorf("failed to marshal Chart.yaml: %w", err)
 		}
 
 		if err := os.WriteFile(chartYamlPath, updatedData, 0644); err != nil {
-			return cleanup, fmt.Errorf("failed to write Chart.yaml: %w", err)
+			mu.Unlock()
+			return func() {}, fmt.Errorf("failed to write Chart.yaml: %w", err)
 		}
 
 		st.logger.Debugf("Rewrote Chart.yaml with absolute dependency paths at %s", chartYamlPath)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1417,7 +1417,18 @@ type PrepareChartKey struct {
 //
 // When running `helmfile template` on helm v2, or `helmfile lint` on both helm v2 and v3,
 // PrepareCharts will download and untar charts for linting and templating.
-//
+var chartDepsMutexMap sync.Map
+
+func (st *HelmState) getChartDepsMutex(chartPath string) *sync.Mutex {
+	mu, ok := chartDepsMutexMap.Load(chartPath)
+	if ok {
+		return mu.(*sync.Mutex)
+	}
+	newMu := &sync.Mutex{}
+	actualMu, _ := chartDepsMutexMap.LoadOrStore(chartPath, newMu)
+	return actualMu.(*sync.Mutex)
+}
+
 // rewriteChartDependencies rewrites relative file:// dependencies in Chart.yaml to absolute paths
 // to ensure they can be resolved from chartify's temporary directory
 func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) {
@@ -1428,9 +1439,13 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) 
 		return func() {}, nil
 	}
 
+	mu := st.getChartDepsMutex(chartPath)
+	mu.Lock()
+
 	// Read Chart.yaml
 	data, err := os.ReadFile(chartYamlPath)
 	if err != nil {
+		mu.Unlock()
 		return func() {}, err
 	}
 
@@ -1440,6 +1455,7 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) 
 		if err := os.WriteFile(chartYamlPath, originalContent, 0644); err != nil {
 			st.logger.Warnf("Failed to restore original Chart.yaml at %s: %v", chartYamlPath, err)
 		}
+		mu.Unlock()
 	}
 
 	// Parse Chart.yaml

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1407,28 +1407,6 @@ type PrepareChartKey struct {
 	Namespace, Name, KubeContext string
 }
 
-// PrepareCharts creates temporary directories of charts.
-//
-// Each resulting "chart" can be one of the followings:
-//
-// (1) local chart
-// (2) temporary local chart generated from kustomization or manifests
-// (3) remote chart
-//
-// When running `helmfile template` on helm v2, or `helmfile lint` on both helm v2 and v3,
-// PrepareCharts will download and untar charts for linting and templating.
-var chartDepsMutexMap sync.Map
-
-func (st *HelmState) getChartDepsMutex(chartPath string) *sync.Mutex {
-	mu, ok := chartDepsMutexMap.Load(chartPath)
-	if ok {
-		return mu.(*sync.Mutex)
-	}
-	newMu := &sync.Mutex{}
-	actualMu, _ := chartDepsMutexMap.LoadOrStore(chartPath, newMu)
-	return actualMu.(*sync.Mutex)
-}
-
 // rewriteChartDependencies rewrites relative file:// dependencies in Chart.yaml to absolute paths
 // to ensure they can be resolved from chartify's temporary directory
 func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) {
@@ -1439,7 +1417,8 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) 
 		return func() {}, nil
 	}
 
-	mu := st.getChartDepsMutex(chartPath)
+	// Reuse the existing per-path RWMutex for exclusive access to the chart directory.
+	mu := st.getNamedRWMutex(chartPath)
 	mu.Lock()
 
 	// Read Chart.yaml
@@ -1508,6 +1487,10 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) 
 		}
 
 		if err := os.WriteFile(chartYamlPath, updatedData, 0644); err != nil {
+			// File may be truncated/partially written; restore original content before releasing the lock.
+			if restoreErr := os.WriteFile(chartYamlPath, originalContent, 0644); restoreErr != nil {
+				st.logger.Warnf("Failed to restore Chart.yaml at %s after write error (%v): %v", chartYamlPath, err, restoreErr)
+			}
 			mu.Unlock()
 			return func() {}, fmt.Errorf("failed to write Chart.yaml: %w", err)
 		}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1408,7 +1408,10 @@ type PrepareChartKey struct {
 }
 
 // rewriteChartDependencies rewrites relative file:// dependencies in Chart.yaml to absolute paths
-// to ensure they can be resolved from chartify's temporary directory
+// to ensure they can be resolved from chartify's temporary directory.
+// When the file is actually rewritten the returned cleanup function restores the original content
+// and releases the per-chart mutex; when no rewrite is needed a no-op cleanup is returned and the
+// mutex is never held past this call.
 func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) {
 	chartYamlPath := filepath.Join(chartPath, "Chart.yaml")
 
@@ -1427,15 +1430,7 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) 
 		mu.Unlock()
 		return func() {}, err
 	}
-
 	originalContent := data
-	cleanup := func() {
-		// Restore original Chart.yaml
-		if err := os.WriteFile(chartYamlPath, originalContent, 0644); err != nil {
-			st.logger.Warnf("Failed to restore original Chart.yaml at %s: %v", chartYamlPath, err)
-		}
-		mu.Unlock()
-	}
 
 	// Parse Chart.yaml
 	type ChartDependency struct {
@@ -1449,7 +1444,7 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) 
 	}
 
 	var chartMeta ChartMeta
-	if err := yaml.Unmarshal(data, &chartMeta); err != nil {
+	if err := yaml.Unmarshal(originalContent, &chartMeta); err != nil {
 		mu.Unlock()
 		return func() {}, err
 	}
@@ -1478,27 +1473,36 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) 
 		}
 	}
 
-	// Write back if modified
-	if modified {
-		updatedData, err := yaml.Marshal(&chartMeta)
-		if err != nil {
-			mu.Unlock()
-			return func() {}, fmt.Errorf("failed to marshal Chart.yaml: %w", err)
-		}
-
-		if err := os.WriteFile(chartYamlPath, updatedData, 0644); err != nil {
-			// File may be truncated/partially written; restore original content before releasing the lock.
-			if restoreErr := os.WriteFile(chartYamlPath, originalContent, 0644); restoreErr != nil {
-				st.logger.Warnf("Failed to restore Chart.yaml at %s after write error (%v): %v", chartYamlPath, err, restoreErr)
-			}
-			mu.Unlock()
-			return func() {}, fmt.Errorf("failed to write Chart.yaml: %w", err)
-		}
-
-		st.logger.Debugf("Rewrote Chart.yaml with absolute dependency paths at %s", chartYamlPath)
+	// If nothing changed, release the lock immediately – no file I/O or lock held by caller needed.
+	if !modified {
+		mu.Unlock()
+		return func() {}, nil
 	}
 
-	return cleanup, nil
+	updatedData, err := yaml.Marshal(&chartMeta)
+	if err != nil {
+		mu.Unlock()
+		return func() {}, fmt.Errorf("failed to marshal Chart.yaml: %w", err)
+	}
+
+	if err := os.WriteFile(chartYamlPath, updatedData, 0644); err != nil {
+		// File may be truncated/partially written; restore original content before releasing the lock.
+		if restoreErr := os.WriteFile(chartYamlPath, originalContent, 0644); restoreErr != nil {
+			st.logger.Warnf("Failed to restore Chart.yaml at %s after write error (%v): %v", chartYamlPath, err, restoreErr)
+		}
+		mu.Unlock()
+		return func() {}, fmt.Errorf("failed to write Chart.yaml: %w", err)
+	}
+
+	st.logger.Debugf("Rewrote Chart.yaml with absolute dependency paths at %s", chartYamlPath)
+
+	// Return cleanup that restores original content and releases the lock.
+	return func() {
+		if restoreErr := os.WriteFile(chartYamlPath, originalContent, 0644); restoreErr != nil {
+			st.logger.Warnf("Failed to restore original Chart.yaml at %s: %v", chartYamlPath, restoreErr)
+		}
+		mu.Unlock()
+	}, nil
 }
 
 // Otherwise, if a chart is not a helm chart, it will call "chartify" to turn it into a chart.

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1473,7 +1473,8 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (func(), error) 
 		}
 	}
 
-	// If nothing changed, release the lock immediately – no file I/O or lock held by caller needed.
+	// If nothing changed, release the lock immediately. Chart.yaml has already been read and
+	// unmarshaled above, but no file write is needed and the lock is not held beyond this function.
 	if !modified {
 		mu.Unlock()
 		return func() {}, nil


### PR DESCRIPTION
## Summary

- Add per-chart-path mutex (`sync.Map`) to prevent race conditions when multiple goroutines concurrently call `rewriteChartDependencies` on the same chart path
- Restore original `Chart.yaml` content under the mutex lock to ensure atomicity
- Add race condition test (`TestRewriteChartDependencies_RaceCondition`) that runs 10 concurrent goroutines

## Why

`rewriteChartDependencies` modifies `Chart.yaml` (rewrite relative `file://` deps to absolute paths) and later restores it via a cleanup function. When multiple goroutines operate on the same chart path concurrently, this can cause data races and corrupted file content.

## Testing

- `TestRewriteChartDependencies_RaceCondition`: 10 goroutines concurrently rewrite the same chart, verifying no errors and `Chart.yaml` remains valid
- Existing tests continue to pass

Signed-off-by: yxxhero <yxxhero@users.noreply.github.com>