### PR TITLE
chore: Emit "cleanup" events later to match the behavior in "apply"

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -2267,13 +2267,6 @@ func (a *App) sync(r *Run, c SyncConfigProvider) (bool, []error) {
 		}
 	}
 
-	for id := range releasesWithNoChange {
-		r := releasesWithNoChange[id]
-		if _, err := st.TriggerCleanupEvent(&r, "sync"); err != nil {
-			a.Logger.Warnf("warn: %v\n", err)
-		}
-	}
-
 	names := []string{}
 	for _, r := range releasesToUpdate {
 		names = append(names, fmt.Sprintf("  %s (%s) UPDATED", r.Name, r.Chart))
@@ -2375,6 +2368,13 @@ Do you really want to sync?
 	}
 
 	affectedReleases.DisplayAffectedReleases(c.Logger())
+
+	for id := range releasesWithNoChange {
+		r := releasesWithNoChange[id]
+		if _, err := st.TriggerCleanupEvent(&r, "sync"); err != nil {
+			a.Logger.Warnf("warn: %v\n", err)
+		}
+	}
 
 	return true, errs
 }


### PR DESCRIPTION
# summary
This changes the behaviour of the cleanup event during sync to be triggered right before the function exits and matches the behaviour of apply