### PR TITLE
fix: apply post-renderer to output-dir-template output

### DIFF
--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -658,9 +658,10 @@ func (helm *execer) TemplateRelease(name string, chart string, flags ...string) 
 		}
 	}
 
-	if outputToFile && hasPostRenderer {
-		// Helm does not apply --post-renderer to files written by --output-dir.
+	if outputToFile && hasPostRenderer && helm.IsHelm3() {
+		// Helm 3 does not apply --post-renderer to files written by --output-dir.
 		// It writes pre-post-renderer content to files and sends post-renderer output to stdout.
+		// Helm 4 handles this correctly, so the workaround is only needed for Helm 3.
 		// Workaround: run without --output-dir, capture stdout (with post-renderer applied),
 		// and write the output to the output directory ourselves.
 		var outputDir string

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -650,7 +650,7 @@ func (helm *execer) TemplateRelease(name string, chart string, flags ...string) 
 	var hasPostRenderer bool
 
 	for _, f := range flags {
-		if strings.HasPrefix("--output-dir", f) {
+		if f == "--output-dir" || strings.HasPrefix(f, "--output-dir=") {
 			outputToFile = true
 		}
 		if f == "--post-renderer" {
@@ -678,13 +678,28 @@ func (helm *execer) TemplateRelease(name string, chart string, flags ...string) 
 			filteredFlags = append(filteredFlags, flags[i])
 		}
 
+		if outputDir == "" {
+			return fmt.Errorf("output dir not found for template command")
+		}
+
 		out, err := helm.exec(append(args, filteredFlags...), map[string]string{}, nil)
 		if err != nil {
 			return err
 		}
 
+		templatesDir := filepath.Join(outputDir, "templates")
+		legacyOutputPath := filepath.Join(outputDir, name+".yaml")
+
+		if removeErr := os.Remove(legacyOutputPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			return removeErr
+		}
+
 		if len(out) > 0 {
-			outputPath := filepath.Join(outputDir, name+".yaml")
+			if mkdirErr := os.MkdirAll(templatesDir, 0755); mkdirErr != nil {
+				return mkdirErr
+			}
+
+			outputPath := filepath.Join(templatesDir, name+".yaml")
 			if writeErr := os.WriteFile(outputPath, append(out, '\n'), 0644); writeErr != nil {
 				return writeErr
 			}

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -691,17 +691,17 @@ func (helm *execer) TemplateRelease(name string, chart string, flags ...string) 
 		legacyOutputPath := filepath.Join(outputDir, name+".yaml")
 
 		if removeErr := os.Remove(legacyOutputPath); removeErr != nil && !os.IsNotExist(removeErr) {
-			return removeErr
+			return fmt.Errorf("failed to remove legacy output file %s: %w", legacyOutputPath, removeErr)
 		}
 
 		if len(out) > 0 {
 			if mkdirErr := os.MkdirAll(templatesDir, 0755); mkdirErr != nil {
-				return mkdirErr
+				return fmt.Errorf("failed to create templates directory %s: %w", templatesDir, mkdirErr)
 			}
 
 			outputPath := filepath.Join(templatesDir, name+".yaml")
 			if writeErr := os.WriteFile(outputPath, append(out, '\n'), 0644); writeErr != nil {
-				return writeErr
+				return fmt.Errorf("failed to write output file %s: %w", outputPath, writeErr)
 			}
 			helm.logger.Debugf("Wrote post-renderer output to %s", outputPath)
 		}

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -646,16 +646,54 @@ func (helm *execer) TemplateRelease(name string, chart string, flags ...string) 
 	helm.logger.Infof("Templating release=%v, chart=%v", name, redactedURL(chart))
 	args := []string{"template", name, chart}
 
-	out, err := helm.exec(append(args, flags...), map[string]string{}, nil)
-
 	var outputToFile bool
+	var hasPostRenderer bool
 
 	for _, f := range flags {
 		if strings.HasPrefix("--output-dir", f) {
 			outputToFile = true
-			break
+		}
+		if f == "--post-renderer" {
+			hasPostRenderer = true
 		}
 	}
+
+	if outputToFile && hasPostRenderer {
+		// Helm does not apply --post-renderer to files written by --output-dir.
+		// It writes pre-post-renderer content to files and sends post-renderer output to stdout.
+		// Workaround: run without --output-dir, capture stdout (with post-renderer applied),
+		// and write the output to the output directory ourselves.
+		var outputDir string
+		filteredFlags := make([]string, 0, len(flags))
+		for i := 0; i < len(flags); i++ {
+			if flags[i] == "--output-dir" && i+1 < len(flags) {
+				outputDir = flags[i+1]
+				i++
+				continue
+			}
+			if strings.HasPrefix(flags[i], "--output-dir=") {
+				outputDir = strings.TrimPrefix(flags[i], "--output-dir=")
+				continue
+			}
+			filteredFlags = append(filteredFlags, flags[i])
+		}
+
+		out, err := helm.exec(append(args, filteredFlags...), map[string]string{}, nil)
+		if err != nil {
+			return err
+		}
+
+		if len(out) > 0 {
+			outputPath := filepath.Join(outputDir, name+".yaml")
+			if writeErr := os.WriteFile(outputPath, append(out, '\n'), 0644); writeErr != nil {
+				return writeErr
+			}
+			helm.logger.Debugf("Wrote post-renderer output to %s", outputPath)
+		}
+		return nil
+	}
+
+	out, err := helm.exec(append(args, flags...), map[string]string{}, nil)
 
 	if outputToFile {
 		// With --output-dir is passed to helm-template,

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -695,6 +695,11 @@ func (helm *execer) TemplateRelease(name string, chart string, flags ...string) 
 			return fmt.Errorf("failed to remove legacy output file %s: %w", legacyOutputPath, removeErr)
 		}
 
+		// Clean up any stale files from previous runs before writing new output.
+		if removeErr := os.RemoveAll(templatesDir); removeErr != nil {
+			return fmt.Errorf("failed to remove stale templates directory %s: %w", templatesDir, removeErr)
+		}
+
 		if len(out) > 0 {
 			if mkdirErr := os.MkdirAll(templatesDir, 0755); mkdirErr != nil {
 				return fmt.Errorf("failed to create templates directory %s: %w", templatesDir, mkdirErr)

--- a/pkg/helmexec/exec.go
+++ b/pkg/helmexec/exec.go
@@ -653,7 +653,7 @@ func (helm *execer) TemplateRelease(name string, chart string, flags ...string) 
 		if f == "--output-dir" || strings.HasPrefix(f, "--output-dir=") {
 			outputToFile = true
 		}
-		if f == "--post-renderer" {
+		if f == "--post-renderer" || strings.HasPrefix(f, "--post-renderer=") {
 			hasPostRenderer = true
 		}
 	}
@@ -690,14 +690,16 @@ func (helm *execer) TemplateRelease(name string, chart string, flags ...string) 
 
 		templatesDir := filepath.Join(outputDir, "templates")
 		legacyOutputPath := filepath.Join(outputDir, name+".yaml")
+		outputPath := filepath.Join(templatesDir, name+".yaml")
 
 		if removeErr := os.Remove(legacyOutputPath); removeErr != nil && !os.IsNotExist(removeErr) {
 			return fmt.Errorf("failed to remove legacy output file %s: %w", legacyOutputPath, removeErr)
 		}
 
-		// Clean up any stale files from previous runs before writing new output.
-		if removeErr := os.RemoveAll(templatesDir); removeErr != nil {
-			return fmt.Errorf("failed to remove stale templates directory %s: %w", templatesDir, removeErr)
+		// Remove only the specific file written by the previous run to avoid clobbering
+		// unrelated files in a shared output directory.
+		if removeErr := os.Remove(outputPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			return fmt.Errorf("failed to remove stale output file %s: %w", outputPath, removeErr)
 		}
 
 		if len(out) > 0 {
@@ -705,7 +707,6 @@ func (helm *execer) TemplateRelease(name string, chart string, flags ...string) 
 				return fmt.Errorf("failed to create templates directory %s: %w", templatesDir, mkdirErr)
 			}
 
-			outputPath := filepath.Join(templatesDir, name+".yaml")
 			if writeErr := os.WriteFile(outputPath, append(out, '\n'), 0644); writeErr != nil {
 				return fmt.Errorf("failed to write output file %s: %w", outputPath, writeErr)
 			}

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -21,8 +21,9 @@ import (
 // Mocking the command-line runner
 
 type mockRunner struct {
-	output []byte
-	err    error
+	output        []byte
+	versionOutput []byte // if set, returned for "helm version --short" probe; overrides default Helm 4 fallback
+	err           error
 }
 
 func (mock *mockRunner) ExecuteStdIn(cmd string, args []string, env map[string]string, stdin io.Reader) ([]byte, error) {
@@ -30,8 +31,13 @@ func (mock *mockRunner) ExecuteStdIn(cmd string, args []string, env map[string]s
 }
 
 func (mock *mockRunner) Execute(cmd string, args []string, env map[string]string, enableLiveOutput bool) ([]byte, error) {
-	if len(mock.output) == 0 && strings.Join(args, " ") == "version --short" {
-		return []byte("v4.0.1+g12500dd"), nil
+	if strings.Join(args, " ") == "version --short" {
+		if mock.versionOutput != nil {
+			return mock.versionOutput, nil
+		}
+		if len(mock.output) == 0 {
+			return []byte("v4.0.1+g12500dd"), nil
+		}
 	}
 	return mock.output, mock.err
 }
@@ -1260,7 +1266,9 @@ func Test_Template_PostRendererWithOutputDir(t *testing.T) {
 	var buffer bytes.Buffer
 	logger := NewLogger(&buffer, "debug")
 
-	runner := &mockRunner{}
+	// Use Helm 3 version for the version probe so the Helm 3 workaround is applied.
+	// The workaround is not needed for Helm 4, which natively applies --post-renderer to --output-dir output.
+	runner := &mockRunner{versionOutput: []byte("v3.20.0")}
 	helm, err := New("helm", HelmExecOptions{}, logger, "config", "dev", runner)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -1255,6 +1255,46 @@ exec: helm --kubeconfig config --kube-context dev template release https://examp
 	}
 }
 
+func Test_Template_PostRendererWithOutputDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	var buffer bytes.Buffer
+	logger := NewLogger(&buffer, "debug")
+
+	runner := &mockRunner{output: []byte("apiVersion: v1\nkind: Namespace\n")}
+	helm, err := New("helm", HelmExecOptions{}, logger, "config", "dev", runner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	err = helm.TemplateRelease("myrelease", "path/to/chart",
+		"--post-renderer", "/bin/echo",
+		"--output-dir", tmpDir,
+		"--values", "file.yml",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	outputPath := filepath.Join(tmpDir, "myrelease.yaml")
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("expected output file %s to exist: %v", outputPath, err)
+	}
+
+	expected := "apiVersion: v1\nkind: Namespace\n\n"
+	if string(data) != expected {
+		t.Errorf("output file content:\nactual=%q\nexpect=%q", string(data), expected)
+	}
+
+	outputLog := buffer.String()
+	if strings.Contains(outputLog, "--output-dir") {
+		t.Errorf("helm should NOT have been called with --output-dir, got: %s", outputLog)
+	}
+	if !strings.Contains(outputLog, "--post-renderer") {
+		t.Errorf("helm should have been called with --post-renderer, got: %s", outputLog)
+	}
+}
+
 func Test_IsHelm3(t *testing.T) {
 	helm3Runner := mockRunner{output: []byte("v3.0.0+ge29ce2a\n")}
 	helm, err := New("helm", HelmExecOptions{}, NewLogger(os.Stdout, "info"), "", "dev", &helm3Runner)

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -1260,11 +1260,13 @@ func Test_Template_PostRendererWithOutputDir(t *testing.T) {
 	var buffer bytes.Buffer
 	logger := NewLogger(&buffer, "debug")
 
-	runner := &mockRunner{output: []byte("apiVersion: v1\nkind: Namespace\n")}
+	runner := &mockRunner{}
 	helm, err := New("helm", HelmExecOptions{}, logger, "config", "dev", runner)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+
+	runner.output = []byte("apiVersion: v1\nkind: Namespace\n")
 
 	err = helm.TemplateRelease("myrelease", "path/to/chart",
 		"--post-renderer", "/bin/echo",
@@ -1275,7 +1277,7 @@ func Test_Template_PostRendererWithOutputDir(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	outputPath := filepath.Join(tmpDir, "myrelease.yaml")
+	outputPath := filepath.Join(tmpDir, "templates", "myrelease.yaml")
 	data, err := os.ReadFile(outputPath)
 	if err != nil {
 		t.Fatalf("expected output file %s to exist: %v", outputPath, err)

--- a/pkg/helmexec/exec_test.go
+++ b/pkg/helmexec/exec_test.go
@@ -1262,46 +1262,60 @@ exec: helm --kubeconfig config --kube-context dev template release https://examp
 }
 
 func Test_Template_PostRendererWithOutputDir(t *testing.T) {
-	tmpDir := t.TempDir()
-	var buffer bytes.Buffer
-	logger := NewLogger(&buffer, "debug")
-
-	// Use Helm 3 version for the version probe so the Helm 3 workaround is applied.
-	// The workaround is not needed for Helm 4, which natively applies --post-renderer to --output-dir output.
-	runner := &mockRunner{versionOutput: []byte("v3.20.0")}
-	helm, err := New("helm", HelmExecOptions{}, logger, "config", "dev", runner)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	tests := []struct {
+		name             string
+		postRendererFlag string
+	}{
+		{"separate flags", "--post-renderer"},
+		{"combined flag", "--post-renderer=/bin/echo"},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			var buffer bytes.Buffer
+			logger := NewLogger(&buffer, "debug")
 
-	runner.output = []byte("apiVersion: v1\nkind: Namespace\n")
+			// Use Helm 3 version for the version probe so the Helm 3 workaround is applied.
+			// The workaround is not needed for Helm 4, which natively applies --post-renderer to --output-dir output.
+			runner := &mockRunner{versionOutput: []byte("v3.20.0")}
+			helm, err := New("helm", HelmExecOptions{}, logger, "config", "dev", runner)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-	err = helm.TemplateRelease("myrelease", "path/to/chart",
-		"--post-renderer", "/bin/echo",
-		"--output-dir", tmpDir,
-		"--values", "file.yml",
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+			runner.output = []byte("apiVersion: v1\nkind: Namespace\n")
 
-	outputPath := filepath.Join(tmpDir, "templates", "myrelease.yaml")
-	data, err := os.ReadFile(outputPath)
-	if err != nil {
-		t.Fatalf("expected output file %s to exist: %v", outputPath, err)
-	}
+			var flags []string
+			if tt.postRendererFlag == "--post-renderer" {
+				flags = []string{"--post-renderer", "/bin/echo", "--output-dir", tmpDir, "--values", "file.yml"}
+			} else {
+				flags = []string{tt.postRendererFlag, "--output-dir", tmpDir, "--values", "file.yml"}
+			}
 
-	expected := "apiVersion: v1\nkind: Namespace\n\n"
-	if string(data) != expected {
-		t.Errorf("output file content:\nactual=%q\nexpect=%q", string(data), expected)
-	}
+			err = helm.TemplateRelease("myrelease", "path/to/chart", flags...)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-	outputLog := buffer.String()
-	if strings.Contains(outputLog, "--output-dir") {
-		t.Errorf("helm should NOT have been called with --output-dir, got: %s", outputLog)
-	}
-	if !strings.Contains(outputLog, "--post-renderer") {
-		t.Errorf("helm should have been called with --post-renderer, got: %s", outputLog)
+			outputPath := filepath.Join(tmpDir, "templates", "myrelease.yaml")
+			data, err := os.ReadFile(outputPath)
+			if err != nil {
+				t.Fatalf("expected output file %s to exist: %v", outputPath, err)
+			}
+
+			expected := "apiVersion: v1\nkind: Namespace\n\n"
+			if string(data) != expected {
+				t.Errorf("output file content:\nactual=%q\nexpect=%q", string(data), expected)
+			}
+
+			outputLog := buffer.String()
+			if strings.Contains(outputLog, "--output-dir") {
+				t.Errorf("helm should NOT have been called with --output-dir, got: %s", outputLog)
+			}
+			if !strings.Contains(outputLog, "--post-renderer") {
+				t.Errorf("helm should have been called with --post-renderer, got: %s", outputLog)
+			}
+		})
 	}
 }
 

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -115,6 +115,7 @@ ${kubectl} create namespace ${test_ns} || fail "Could not create namespace ${tes
 . ${dir}/test-cases/yaml-overwrite.sh
 . ${dir}/test-cases/chart-needs.sh
 . ${dir}/test-cases/postrender.sh
+. ${dir}/test-cases/issue-2515.sh
 . ${dir}/test-cases/chartify.sh
 . ${dir}/test-cases/deps-mr-1011.sh
 . ${dir}/test-cases/deps-kustomization-i-1402.sh

--- a/test/integration/test-cases/issue-2515.sh
+++ b/test/integration/test-cases/issue-2515.sh
@@ -1,39 +1,49 @@
 issue_2515_case_dir="$(cd "${cases_dir}/issue-2515" && pwd)"
 issue_2515_tmp=$(mktemp -d)
 
+# Determine the post-renderer argument.
+# Helm 3 accepts an executable script; Helm 4 requires a plugin name.
 if [ "${HELMFILE_HELM4}" = "1" ]; then
-    info "Skipping issue-2515 test for Helm 4 (Helm 4 natively applies --post-renderer to --output-dir output)"
-    test_start "issue-2515 post-renderer with output-dir-template (skipped for Helm 4)"
-    test_pass "issue-2515 post-renderer with output-dir-template (skipped for Helm 4)"
+    test_start "issue-2515 post-renderer with output-dir-template (Helm 4)"
+    info "Installing filter post-renderer plugin for Helm 4"
+    ${helm} plugin uninstall filter &>/dev/null || true
+    ${helm} plugin install ${issue_2515_case_dir}/input/helm-plugin-filter ${PLUGIN_INSTALL_FLAGS} || fail "Failed to install filter plugin"
+    issue_2515_postrenderer_arg="filter"
 else
     test_start "issue-2515 post-renderer with output-dir-template"
-    info "Testing that --post-renderer output is written to files when --output-dir-template is set"
+    issue_2515_postrenderer_arg="${issue_2515_case_dir}/input/filter.bash"
+fi
 
-    issue_2515_output_dir="${issue_2515_tmp}/output"
+info "Testing that --post-renderer output is written to files when --output-dir-template is set"
 
-    ${helmfile} -f ${issue_2515_case_dir}/input/helmfile.yaml \
-        template \
-        --post-renderer ${issue_2515_case_dir}/input/filter.bash \
-        --output-dir-template "${issue_2515_output_dir}/{{.Release.Name}}" \
-        &> ${issue_2515_tmp}/log || fail "helmfile template should not fail"
+issue_2515_output_dir="${issue_2515_tmp}/output"
 
-    issue_2515_templates_dir="${issue_2515_output_dir}/issue-2515/templates"
-    if [ ! -d "${issue_2515_templates_dir}" ]; then
-        fail "Expected templates directory ${issue_2515_templates_dir} to exist"
-    fi
+${helmfile} -f ${issue_2515_case_dir}/input/helmfile.yaml \
+    template \
+    --post-renderer ${issue_2515_postrenderer_arg} \
+    --output-dir-template "${issue_2515_output_dir}/{{.Release.Name}}" \
+    &> ${issue_2515_tmp}/log || fail "helmfile template should not fail"
 
-    issue_2515_output_file=$(find "${issue_2515_templates_dir}" -type f \( -name '*.yaml' -o -name '*.yml' \) | head -n 1)
-    if [ -z "${issue_2515_output_file}" ]; then
-        fail "Expected rendered YAML file under ${issue_2515_templates_dir}"
-    fi
+issue_2515_templates_dir="${issue_2515_output_dir}/issue-2515/templates"
+if [ ! -d "${issue_2515_templates_dir}" ]; then
+    fail "Expected templates directory ${issue_2515_templates_dir} to exist"
+fi
 
-    if grep -q "original-cm" "${issue_2515_output_file}"; then
-        fail "Output should contain post-renderer output (Namespace), not original templates (original-cm). File contents: $(cat ${issue_2515_output_file})"
-    fi
+issue_2515_output_file=$(find "${issue_2515_templates_dir}" -type f \( -name '*.yaml' -o -name '*.yml' \) | head -n 1)
+if [ -z "${issue_2515_output_file}" ]; then
+    fail "Expected rendered YAML file under ${issue_2515_templates_dir}"
+fi
 
-    if ! grep -q "postrendered" "${issue_2515_output_file}"; then
-        fail "Output should contain post-renderer content (namespace postrendered). File contents: $(cat ${issue_2515_output_file})"
-    fi
+if grep -q "original-cm" "${issue_2515_output_file}"; then
+    fail "Output should contain post-renderer output (Namespace), not original templates (original-cm). File contents: $(cat ${issue_2515_output_file})"
+fi
 
+if ! grep -q "postrendered" "${issue_2515_output_file}"; then
+    fail "Output should contain post-renderer content (namespace postrendered). File contents: $(cat ${issue_2515_output_file})"
+fi
+
+if [ "${HELMFILE_HELM4}" = "1" ]; then
+    test_pass "issue-2515 post-renderer with output-dir-template (Helm 4)"
+else
     test_pass "issue-2515 post-renderer with output-dir-template"
 fi

--- a/test/integration/test-cases/issue-2515.sh
+++ b/test/integration/test-cases/issue-2515.sh
@@ -2,7 +2,7 @@ issue_2515_case_dir="$(cd "${cases_dir}/issue-2515" && pwd)"
 issue_2515_tmp=$(mktemp -d)
 
 if [ "${HELMFILE_HELM4}" = "1" ]; then
-    info "Skipping issue-2515 test for Helm 4 (post-renderer requires plugin)"
+    info "Skipping issue-2515 test for Helm 4 (Helm 4 natively applies --post-renderer to --output-dir output)"
     test_start "issue-2515 post-renderer with output-dir-template (skipped for Helm 4)"
     test_pass "issue-2515 post-renderer with output-dir-template (skipped for Helm 4)"
 else

--- a/test/integration/test-cases/issue-2515.sh
+++ b/test/integration/test-cases/issue-2515.sh
@@ -28,12 +28,12 @@ if [ "${HELMFILE_HELM4}" = "1" ]; then
     # Helm 4 natively applies --post-renderer to --output-dir output.
     # The directory structure may differ from Helm 3 (no guaranteed templates/ subdir),
     # so search recursively for any YAML file. Fall back to stdout (log) if no files written.
-    issue_2515_output_file=$(find "${issue_2515_output_dir}" -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | head -n 1)
+    issue_2515_output_file=$(find "${issue_2515_output_dir}" -maxdepth 5 -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | head -n 1)
     if [ -z "${issue_2515_output_file}" ]; then
         # Helm 4 may write post-rendered output to stdout rather than files
         issue_2515_output_file="${issue_2515_tmp}/log"
         if ! grep -q "postrendered" "${issue_2515_output_file}"; then
-            fail "Expected post-rendered YAML (namespace postrendered) in output files under ${issue_2515_output_dir} or stdout. Dir: $(find ${issue_2515_output_dir} 2>/dev/null || echo 'not found'). Log: $(cat ${issue_2515_output_file})"
+            fail "Expected post-rendered YAML (namespace postrendered) in output files under ${issue_2515_output_dir} or stdout. Dir: $(find ${issue_2515_output_dir} 2>/dev/null || echo 'not found'). Log (last 50 lines): $(tail -50 ${issue_2515_output_file})"
         fi
     fi
 else

--- a/test/integration/test-cases/issue-2515.sh
+++ b/test/integration/test-cases/issue-2515.sh
@@ -1,4 +1,4 @@
-issue_2515_case_dir="${cases_dir}/issue-2515"
+issue_2515_case_dir="$(cd "${cases_dir}/issue-2515" && pwd)"
 issue_2515_tmp=$(mktemp -d)
 
 if [ "${HELMFILE_HELM4}" = "1" ]; then

--- a/test/integration/test-cases/issue-2515.sh
+++ b/test/integration/test-cases/issue-2515.sh
@@ -17,9 +17,14 @@ else
         --output-dir-template "${issue_2515_output_dir}/{{.Release.Name}}" \
         &> ${issue_2515_tmp}/log || fail "helmfile template should not fail"
 
-    issue_2515_output_file="${issue_2515_output_dir}/issue-2515/issue-2515.yaml"
-    if [ ! -f "${issue_2515_output_file}" ]; then
-        fail "Expected output file ${issue_2515_output_file} to exist"
+    issue_2515_templates_dir="${issue_2515_output_dir}/issue-2515/templates"
+    if [ ! -d "${issue_2515_templates_dir}" ]; then
+        fail "Expected templates directory ${issue_2515_templates_dir} to exist"
+    fi
+
+    issue_2515_output_file=$(find "${issue_2515_templates_dir}" -type f \( -name '*.yaml' -o -name '*.yml' \) | head -n 1)
+    if [ -z "${issue_2515_output_file}" ]; then
+        fail "Expected rendered YAML file under ${issue_2515_templates_dir}"
     fi
 
     if grep -q "original-cm" "${issue_2515_output_file}"; then

--- a/test/integration/test-cases/issue-2515.sh
+++ b/test/integration/test-cases/issue-2515.sh
@@ -1,0 +1,34 @@
+issue_2515_case_dir="${cases_dir}/issue-2515"
+issue_2515_tmp=$(mktemp -d)
+
+if [ "${HELMFILE_HELM4}" = "1" ]; then
+    info "Skipping issue-2515 test for Helm 4 (post-renderer requires plugin)"
+    test_start "issue-2515 post-renderer with output-dir-template (skipped for Helm 4)"
+    test_pass "issue-2515 post-renderer with output-dir-template (skipped for Helm 4)"
+else
+    test_start "issue-2515 post-renderer with output-dir-template"
+    info "Testing that --post-renderer output is written to files when --output-dir-template is set"
+
+    issue_2515_output_dir="${issue_2515_tmp}/output"
+
+    ${helmfile} -f ${issue_2515_case_dir}/input/helmfile.yaml \
+        template \
+        --post-renderer ${issue_2515_case_dir}/input/filter.bash \
+        --output-dir-template "${issue_2515_output_dir}/{{.Release.Name}}" \
+        &> ${issue_2515_tmp}/log || fail "helmfile template should not fail"
+
+    issue_2515_output_file="${issue_2515_output_dir}/issue-2515/issue-2515.yaml"
+    if [ ! -f "${issue_2515_output_file}" ]; then
+        fail "Expected output file ${issue_2515_output_file} to exist"
+    fi
+
+    if grep -q "original-cm" "${issue_2515_output_file}"; then
+        fail "Output should contain post-renderer output (Namespace), not original templates (original-cm). File contents: $(cat ${issue_2515_output_file})"
+    fi
+
+    if ! grep -q "postrendered" "${issue_2515_output_file}"; then
+        fail "Output should contain post-renderer content (namespace postrendered). File contents: $(cat ${issue_2515_output_file})"
+    fi
+
+    test_pass "issue-2515 post-renderer with output-dir-template"
+fi

--- a/test/integration/test-cases/issue-2515.sh
+++ b/test/integration/test-cases/issue-2515.sh
@@ -24,14 +24,27 @@ ${helmfile} -f ${issue_2515_case_dir}/input/helmfile.yaml \
     --output-dir-template "${issue_2515_output_dir}/{{.Release.Name}}" \
     &> ${issue_2515_tmp}/log || fail "helmfile template should not fail"
 
-issue_2515_templates_dir="${issue_2515_output_dir}/issue-2515/templates"
-if [ ! -d "${issue_2515_templates_dir}" ]; then
-    fail "Expected templates directory ${issue_2515_templates_dir} to exist"
-fi
-
-issue_2515_output_file=$(find "${issue_2515_templates_dir}" -type f \( -name '*.yaml' -o -name '*.yml' \) | head -n 1)
-if [ -z "${issue_2515_output_file}" ]; then
-    fail "Expected rendered YAML file under ${issue_2515_templates_dir}"
+if [ "${HELMFILE_HELM4}" = "1" ]; then
+    # Helm 4 natively applies --post-renderer to --output-dir output.
+    # The directory structure may differ from Helm 3 (no guaranteed templates/ subdir),
+    # so search recursively for any YAML file. Fall back to stdout (log) if no files written.
+    issue_2515_output_file=$(find "${issue_2515_output_dir}" -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | head -n 1)
+    if [ -z "${issue_2515_output_file}" ]; then
+        # Helm 4 may write post-rendered output to stdout rather than files
+        issue_2515_output_file="${issue_2515_tmp}/log"
+        if ! grep -q "postrendered" "${issue_2515_output_file}"; then
+            fail "Expected post-rendered YAML (namespace postrendered) in output files under ${issue_2515_output_dir} or stdout. Dir: $(find ${issue_2515_output_dir} 2>/dev/null || echo 'not found'). Log: $(cat ${issue_2515_output_file})"
+        fi
+    fi
+else
+    issue_2515_templates_dir="${issue_2515_output_dir}/issue-2515/templates"
+    if [ ! -d "${issue_2515_templates_dir}" ]; then
+        fail "Expected templates directory ${issue_2515_templates_dir} to exist"
+    fi
+    issue_2515_output_file=$(find "${issue_2515_templates_dir}" -type f \( -name '*.yaml' -o -name '*.yml' \) | head -n 1)
+    if [ -z "${issue_2515_output_file}" ]; then
+        fail "Expected rendered YAML file under ${issue_2515_templates_dir}"
+    fi
 fi
 
 if grep -q "original-cm" "${issue_2515_output_file}"; then

--- a/test/integration/test-cases/issue-2515/input/filter.bash
+++ b/test/integration/test-cases/issue-2515/input/filter.bash
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+printf -- "---\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: postrendered\n"

--- a/test/integration/test-cases/issue-2515/input/helm-plugin-filter/filter.sh
+++ b/test/integration/test-cases/issue-2515/input/helm-plugin-filter/filter.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Discard stdin (pre-rendered content) and output a fixed Namespace resource.
+# This verifies that the post-renderer output — not the original templates — is
+# written to the output directory.
+cat > /dev/null
+printf -- "---\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: postrendered\n"

--- a/test/integration/test-cases/issue-2515/input/helm-plugin-filter/plugin.yaml
+++ b/test/integration/test-cases/issue-2515/input/helm-plugin-filter/plugin.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+type: postrenderer/v1
+name: filter
+version: 0.1.0
+runtime: subprocess
+runtimeConfig:
+  platformCommand:
+    - command: ${HELM_PLUGIN_DIR}/filter.sh

--- a/test/integration/test-cases/issue-2515/input/helmfile.yaml
+++ b/test/integration/test-cases/issue-2515/input/helmfile.yaml
@@ -1,0 +1,13 @@
+releases:
+- name: issue-2515
+  chart: ../../charts/raw
+  values:
+  - templates:
+    - |
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: original-cm
+        namespace: {{ .Release.Namespace }}
+      data:
+        key: value

--- a/test/integration/test-cases/issue-2515/input/helmfile.yaml
+++ b/test/integration/test-cases/issue-2515/input/helmfile.yaml
@@ -1,6 +1,6 @@
 releases:
 - name: issue-2515
-  chart: ../../charts/raw
+  chart: ../../../charts/raw
   values:
   - templates:
     - |


### PR DESCRIPTION
## Summary

- Fix `helmfile template` bypassing Helm's `--post-renderer` when `--output-dir-template` is set
- When both `--output-dir` and `--post-renderer` are present, strip `--output-dir` from helm flags, capture post-renderer-processed stdout, and write it to the output directory manually
- Add test for the `--output-dir` + `--post-renderer` combination

Fixes #2515