### PR TITLE
fix: boolean false overrides dropped in multi-document helmfiles (#2527)

### DIFF
--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -205,3 +205,33 @@ func TestEnvironment_GetMergedValues_Issue2281_SparseArrayMerge(t *testing.T) {
 	assert.Equal(t, "second thing", elem1["thing"])
 	assert.Equal(t, "cmdline", elem1["anotherThing"])
 }
+
+func TestEnvironment_GetMergedValues_Issue2527_DefaultsOverrideValues(t *testing.T) {
+	env := &Environment{
+		Name: "test",
+		Defaults: map[string]any{
+			"helmDefaults": map[string]any{
+				"atomic":  false,
+				"wait":    true,
+				"timeout": 300,
+			},
+		},
+		Values: map[string]any{
+			"appName": "my-app",
+			"helmDefaults": map[string]any{
+				"atomic":  true,
+				"wait":    true,
+				"timeout": 300,
+			},
+		},
+		CLIOverrides: map[string]any{},
+	}
+
+	mergedValues, err := env.GetMergedValues()
+	require.NoError(t, err)
+
+	hd := mergedValues["helmDefaults"].(map[string]any)
+	assert.Equal(t, true, hd["atomic"], "Values should override Defaults atomic value")
+	assert.Equal(t, true, hd["wait"])
+	assert.Equal(t, 300, hd["timeout"])
+}

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -207,11 +207,13 @@ func TestEnvironment_GetMergedValues_Issue2281_SparseArrayMerge(t *testing.T) {
 }
 
 func TestEnvironment_GetMergedValues_Issue2527_ValuesOverrideDefaults(t *testing.T) {
+	// Regression test for https://github.com/helmfile/helmfile/issues/2527:
+	// A boolean false in Values must not be overridden by a true in Defaults.
 	env := &Environment{
 		Name: "test",
 		Defaults: map[string]any{
 			"helmDefaults": map[string]any{
-				"atomic":  false,
+				"atomic":  true,
 				"wait":    true,
 				"timeout": 300,
 			},
@@ -219,7 +221,7 @@ func TestEnvironment_GetMergedValues_Issue2527_ValuesOverrideDefaults(t *testing
 		Values: map[string]any{
 			"appName": "my-app",
 			"helmDefaults": map[string]any{
-				"atomic":  true,
+				"atomic":  false, // explicit false override must survive
 				"wait":    true,
 				"timeout": 300,
 			},
@@ -231,7 +233,7 @@ func TestEnvironment_GetMergedValues_Issue2527_ValuesOverrideDefaults(t *testing
 	require.NoError(t, err)
 
 	hd := mergedValues["helmDefaults"].(map[string]any)
-	assert.Equal(t, true, hd["atomic"], "Values should override Defaults atomic value")
+	assert.Equal(t, false, hd["atomic"], "Values false should override Defaults true for atomic")
 	assert.Equal(t, true, hd["wait"])
 	assert.Equal(t, 300, hd["timeout"])
 }

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -206,7 +206,7 @@ func TestEnvironment_GetMergedValues_Issue2281_SparseArrayMerge(t *testing.T) {
 	assert.Equal(t, "cmdline", elem1["anotherThing"])
 }
 
-func TestEnvironment_GetMergedValues_Issue2527_DefaultsOverrideValues(t *testing.T) {
+func TestEnvironment_GetMergedValues_Issue2527_ValuesOverrideDefaults(t *testing.T) {
 	env := &Environment{
 		Name: "test",
 		Defaults: map[string]any{

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"github.com/helmfile/helmfile/pkg/environment"
+	"github.com/helmfile/helmfile/pkg/maputil"
 )
 
 // TemplateSpec defines the structure of a reusable and composable template for helm releases.
@@ -21,11 +22,9 @@ type EnvironmentTemplateData struct {
 }
 
 func NewEnvironmentTemplateData(env environment.Environment, namespace string, values map[string]any) *EnvironmentTemplateData {
-	// Create a copy of the environment with merged values for template access.
-	// This ensures templates accessing .Environment.Values see the same merged values
-	// (Defaults + Values + CLIOverrides) as templates accessing .Values directly.
 	envCopy := env
-	envCopy.Values = values
+	envCopy.Values = maputil.MergeMaps(env.Values, env.CLIOverrides,
+		maputil.MergeOptions{ArrayStrategy: maputil.ArrayMergeStrategyMerge})
 	d := EnvironmentTemplateData{envCopy, namespace, values, nil}
 	d.StateValues = &d.Values
 	return &d

--- a/pkg/state/types_test.go
+++ b/pkg/state/types_test.go
@@ -1,0 +1,52 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/helmfile/helmfile/pkg/environment"
+)
+
+func TestNewEnvironmentTemplateData_EnvironmentValuesExcludesDefaults_Issue2527(t *testing.T) {
+	env := environment.Environment{
+		Name: "myenv",
+		Defaults: map[string]any{
+			"helmDefaults": map[string]any{
+				"atomic":  true,
+				"wait":    true,
+				"timeout": 300,
+			},
+		},
+		Values: map[string]any{
+			"appName": "my-app",
+		},
+		CLIOverrides: map[string]any{
+			"cliFlag": "cliValue",
+		},
+	}
+
+	mergedVals := map[string]any{
+		"appName": "my-app",
+		"cliFlag": "cliValue",
+		"helmDefaults": map[string]any{
+			"atomic":  true,
+			"wait":    true,
+			"timeout": 300,
+		},
+	}
+
+	tmplData := NewEnvironmentTemplateData(env, "ns", mergedVals)
+	require.NotNil(t, tmplData)
+
+	assert.Equal(t, mergedVals, tmplData.Values, ".Values should contain full merged values")
+
+	_, hasDefaults := tmplData.Environment.Values["helmDefaults"]
+	assert.False(t, hasDefaults, ".Environment.Values should NOT contain Defaults (helmDefaults)")
+
+	assert.Equal(t, "my-app", tmplData.Environment.Values["appName"],
+		".Environment.Values should contain env Values")
+	assert.Equal(t, "cliValue", tmplData.Environment.Values["cliFlag"],
+		".Environment.Values should contain CLI overrides")
+}


### PR DESCRIPTION
## Summary

- Fix boolean false (and other) overrides being silently dropped in multi-document helmfiles when environment values are re-assigned mid-helmfile, a regression introduced in #2367 (v1.3.0+).
- The root cause was `NewEnvironmentTemplateData` setting `.Environment.Values` to the full merged values (Defaults + Values + CLIOverrides), which caused Defaults to pollute the Values layer when users re-assigned environment values via `{{ toYaml .Environment.Values }}`.
- One-line fix: set `.Environment.Values` to `Values + CLIOverrides` only, excluding Defaults.

Fixes #2527

## Changes

- **`pkg/state/types.go`**: Changed `NewEnvironmentTemplateData` to set `envCopy.Values` to `MergeMaps(env.Values, env.CLIOverrides)` instead of the full `GetMergedValues()` result, preventing Defaults from leaking into `.Environment.Values`.
- **`pkg/environment/environment_test.go`**: Added regression test for Defaults/Values merge ordering.
- **`pkg/state/types_test.go`**: Added regression test verifying `.Environment.Values` excludes Defaults while still including CLI overrides.

## Test plan

- [x] All existing tests pass (`go test -race -p=1 ./pkg/...`)
- [x] New regression tests pass
- [x] `make check` passes
- [ ] Manual reproduction from #2527 (requires multi-part helmfile with defaults + env overrides)