### PR TITLE
fix: include release values in .Values for patch template rendering

### DIFF
--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -15,6 +14,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/helmfile/helmfile/pkg/environment"
+	"github.com/helmfile/helmfile/pkg/envvar"
 	"github.com/helmfile/helmfile/pkg/filesystem"
 	"github.com/helmfile/helmfile/pkg/remote"
 	"github.com/helmfile/helmfile/pkg/testhelper"
@@ -1397,6 +1397,8 @@ releaseNamespace: {{ .Release.Namespace }}
 }
 
 func TestGenerateTemporaryReleaseValuesFilesWithData_StringPath(t *testing.T) {
+	t.Setenv(envvar.TempDir, t.TempDir())
+
 	patchFile := "/project/patch.yaml.gotmpl"
 	patchContent := `enabled: {{ .Values.ingress.enabled }}
 host: {{ .Values.ingress.host }}
@@ -1420,11 +1422,6 @@ host: {{ .Values.ingress.host }}
 	)
 	require.NoError(t, err)
 	require.Len(t, generatedFiles, 1)
-	t.Cleanup(func() {
-		for _, f := range generatedFiles {
-			_ = os.Remove(f)
-		}
-	})
 
 	// The temp files are created on the real OS filesystem via os.Create, so we read them with os.ReadFile
 	content, err := filesystem.DefaultFileSystem().ReadFile(generatedFiles[0])
@@ -1434,6 +1431,8 @@ host: {{ .Values.ingress.host }}
 }
 
 func TestGenerateTemporaryReleaseValuesFilesWithData_InlineMap(t *testing.T) {
+	t.Setenv(envvar.TempDir, t.TempDir())
+
 	st := newTestHelmStateWithFiles(t, map[string]string{})
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
@@ -1453,11 +1452,6 @@ func TestGenerateTemporaryReleaseValuesFilesWithData_InlineMap(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, generatedFiles, 1)
-	t.Cleanup(func() {
-		for _, f := range generatedFiles {
-			_ = os.Remove(f)
-		}
-	})
 
 	// The temp files are created on the real OS filesystem via os.Create, so we read them with os.ReadFile
 	content, err := filesystem.DefaultFileSystem().ReadFile(generatedFiles[0])

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -1418,7 +1418,7 @@ host: {{ .Values.ingress.host }}
 	generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(
 		release,
 		[]any{"patch.yaml.gotmpl"},
-		tmplData,
+		func() (releaseTemplateData, error) { return tmplData, nil },
 	)
 	require.NoError(t, err)
 	require.Len(t, generatedFiles, 1)
@@ -1448,7 +1448,7 @@ func TestGenerateTemporaryReleaseValuesFilesWithData_InlineMap(t *testing.T) {
 	generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(
 		release,
 		[]any{inlineValues},
-		tmplData,
+		func() (releaseTemplateData, error) { return tmplData, nil },
 	)
 	require.NoError(t, err)
 	require.Len(t, generatedFiles, 1)
@@ -1470,7 +1470,7 @@ func TestGenerateTemporaryReleaseValuesFilesWithData_UnknownTypeError(t *testing
 	_, err := st.generateTemporaryReleaseValuesFilesWithData(
 		release,
 		[]any{42},
-		tmplData,
+		func() (releaseTemplateData, error) { return tmplData, nil },
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unexpected type of value")

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -1191,7 +1191,7 @@ func TestMergedReleaseTemplateData_InlineValues(t *testing.T) {
 	}
 }
 
-func newTestHelmStateWithFiles(t *testing.T, files map[string]string, basePath string) (*HelmState, func()) {
+func newTestHelmStateWithFiles(t *testing.T, files map[string]string, basePath string) *HelmState {
 	t.Helper()
 	logger := zaptest.NewLogger(t).Sugar()
 	valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
@@ -1200,7 +1200,7 @@ func newTestHelmStateWithFiles(t *testing.T, files map[string]string, basePath s
 	testFs := testhelper.NewTestFs(files)
 	testFs.Cwd = basePath
 
-	st := &HelmState{
+	return &HelmState{
 		logger:         logger,
 		fs:             testFs.ToFileSystem(),
 		valsRuntime:    valsRuntime,
@@ -1208,12 +1208,10 @@ func newTestHelmStateWithFiles(t *testing.T, files map[string]string, basePath s
 		FilePath:       basePath + "/helmfile.yaml",
 		RenderedValues: map[string]any{},
 	}
-	return st, func() {}
 }
 
 func TestResolveReleaseValues_Empty(t *testing.T) {
-	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
-	defer cleanup()
+	st := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
 	result, err := st.resolveReleaseValues(release)
@@ -1228,10 +1226,9 @@ image:
   repository: nginx
   tag: "1.21"
 `
-	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+	st := newTestHelmStateWithFiles(t, map[string]string{
 		valuesFile: valuesContent,
 	}, "/project")
-	defer cleanup()
 
 	release := &ReleaseSpec{
 		Name:  "myrelease",
@@ -1249,8 +1246,7 @@ image:
 }
 
 func TestResolveReleaseValues_InlineMap(t *testing.T) {
-	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
-	defer cleanup()
+	st := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
 
 	release := &ReleaseSpec{
 		Name:  "myrelease",
@@ -1284,11 +1280,10 @@ service:
 ingress:
   enabled: true
 `
-	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+	st := newTestHelmStateWithFiles(t, map[string]string{
 		baseValuesFile:     baseValuesContent,
 		overrideValuesFile: overrideValuesContent,
 	}, "/project")
-	defer cleanup()
 
 	release := &ReleaseSpec{
 		Name:  "myrelease",
@@ -1316,10 +1311,9 @@ func TestResolveReleaseValues_FileAndInlineMerged(t *testing.T) {
 	valuesFile := "/project/values.yaml"
 	valuesContent := `replicaCount: 1
 `
-	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+	st := newTestHelmStateWithFiles(t, map[string]string{
 		valuesFile: valuesContent,
 	}, "/project")
-	defer cleanup()
 
 	release := &ReleaseSpec{
 		Name:  "myrelease",
@@ -1343,10 +1337,9 @@ func TestRenderValuesFileToBytesWithData_PlainYAML(t *testing.T) {
 image:
   repository: nginx
 `
-	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+	st := newTestHelmStateWithFiles(t, map[string]string{
 		valuesFile: valuesContent,
 	}, "/project")
-	defer cleanup()
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
 	tmplData := st.createReleaseTemplateData(release, map[string]any{})
@@ -1362,10 +1355,9 @@ func TestRenderValuesFileToBytesWithData_WithValuesTemplate(t *testing.T) {
 	valuesContent := `replicaCount: {{ .Values.replicaCount }}
 enabled: {{ .Values.ingress.enabled }}
 `
-	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+	st := newTestHelmStateWithFiles(t, map[string]string{
 		valuesFile: valuesContent,
 	}, "/project")
-	defer cleanup()
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
 	tmplData := st.createReleaseTemplateData(release, map[string]any{
@@ -1386,10 +1378,9 @@ func TestRenderValuesFileToBytesWithData_WithReleaseTemplate(t *testing.T) {
 	valuesContent := `releaseName: {{ .Release.Name }}
 releaseNamespace: {{ .Release.Namespace }}
 `
-	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+	st := newTestHelmStateWithFiles(t, map[string]string{
 		valuesFile: valuesContent,
 	}, "/project")
-	defer cleanup()
 
 	release := &ReleaseSpec{Name: "myapp", Chart: "mychart", Namespace: "production"}
 	tmplData := st.createReleaseTemplateData(release, map[string]any{})
@@ -1405,10 +1396,9 @@ func TestGenerateTemporaryReleaseValuesFilesWithData_StringPath(t *testing.T) {
 	patchContent := `enabled: {{ .Values.ingress.enabled }}
 host: {{ .Values.ingress.host }}
 `
-	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+	st := newTestHelmStateWithFiles(t, map[string]string{
 		patchFile: patchContent,
 	}, "/project")
-	defer cleanup()
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
 	tmplData := st.createReleaseTemplateData(release, map[string]any{
@@ -1426,7 +1416,7 @@ host: {{ .Values.ingress.host }}
 	require.NoError(t, err)
 	require.Len(t, generatedFiles, 1)
 
-	// Read and verify the generated file content
+	// The temp files are created on the real OS filesystem via os.Create, so we read them with os.ReadFile
 	content, err := filesystem.DefaultFileSystem().ReadFile(generatedFiles[0])
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "enabled: true")
@@ -1434,8 +1424,7 @@ host: {{ .Values.ingress.host }}
 }
 
 func TestGenerateTemporaryReleaseValuesFilesWithData_InlineMap(t *testing.T) {
-	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
-	defer cleanup()
+	st := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
 	tmplData := st.createReleaseTemplateData(release, map[string]any{})
@@ -1455,6 +1444,7 @@ func TestGenerateTemporaryReleaseValuesFilesWithData_InlineMap(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, generatedFiles, 1)
 
+	// The temp files are created on the real OS filesystem via os.Create, so we read them with os.ReadFile
 	content, err := filesystem.DefaultFileSystem().ReadFile(generatedFiles[0])
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "replicaCount: 5")
@@ -1462,8 +1452,7 @@ func TestGenerateTemporaryReleaseValuesFilesWithData_InlineMap(t *testing.T) {
 }
 
 func TestGenerateTemporaryReleaseValuesFilesWithData_UnknownTypeError(t *testing.T) {
-	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
-	defer cleanup()
+	st := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
 	tmplData := st.createReleaseTemplateData(release, map[string]any{})

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -1192,7 +1192,6 @@ func TestMergedReleaseTemplateData_InlineValues(t *testing.T) {
 	if ingressMap["enabled"] != true {
 		t.Errorf("expected ingress.enabled to be true, got %v", ingressMap["enabled"])
 	}
-	}
 }
 
 func newTestHelmStateWithFiles(t *testing.T, files map[string]string) *HelmState {

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -1029,7 +1030,8 @@ func TestMergeEnvironments_PreservesMergeStrategy(t *testing.T) {
 
 func TestMergedReleaseTemplateData_IncludesReleaseValues(t *testing.T) {
 	logger := zaptest.NewLogger(t).Sugar()
-	testValsRuntime, _ := vals.New(vals.Options{CacheSize: 32})
+	testValsRuntime, err := vals.New(vals.Options{CacheSize: 32})
+	require.NoError(t, err)
 
 	yamlFile := "/example/path/to/helmfile.yaml"
 	yamlContent := []byte(`environments:
@@ -1097,7 +1099,8 @@ releases:
 
 func TestMergedReleaseTemplateData_ReleaseValuesOverrideEnvValues(t *testing.T) {
 	logger := zaptest.NewLogger(t).Sugar()
-	testValsRuntime, _ := vals.New(vals.Options{CacheSize: 32})
+	testValsRuntime, err := vals.New(vals.Options{CacheSize: 32})
+	require.NoError(t, err)
 
 	yamlFile := "/example/path/to/helmfile.yaml"
 	yamlContent := []byte(`environments:
@@ -1148,7 +1151,8 @@ releases:
 
 func TestMergedReleaseTemplateData_InlineValues(t *testing.T) {
 	logger := zaptest.NewLogger(t).Sugar()
-	testValsRuntime, _ := vals.New(vals.Options{CacheSize: 32})
+	testValsRuntime, err := vals.New(vals.Options{CacheSize: 32})
+	require.NoError(t, err)
 
 	yamlFile := "/example/path/to/helmfile.yaml"
 	yamlContent := []byte(`releases:
@@ -1416,6 +1420,11 @@ host: {{ .Values.ingress.host }}
 	)
 	require.NoError(t, err)
 	require.Len(t, generatedFiles, 1)
+	t.Cleanup(func() {
+		for _, f := range generatedFiles {
+			_ = os.Remove(f)
+		}
+	})
 
 	// The temp files are created on the real OS filesystem via os.Create, so we read them with os.ReadFile
 	content, err := filesystem.DefaultFileSystem().ReadFile(generatedFiles[0])
@@ -1444,6 +1453,11 @@ func TestGenerateTemporaryReleaseValuesFilesWithData_InlineMap(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, generatedFiles, 1)
+	t.Cleanup(func() {
+		for _, f := range generatedFiles {
+			_ = os.Remove(f)
+		}
+	})
 
 	// The temp files are created on the real OS filesystem via os.Create, so we read them with os.ReadFile
 	content, err := filesystem.DefaultFileSystem().ReadFile(generatedFiles[0])

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -1190,3 +1190,290 @@ func TestMergedReleaseTemplateData_InlineValues(t *testing.T) {
 	}
 	}
 }
+
+func newTestHelmStateWithFiles(t *testing.T, files map[string]string, basePath string) (*HelmState, func()) {
+	t.Helper()
+	logger := zaptest.NewLogger(t).Sugar()
+	valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
+	require.NoError(t, err)
+
+	testFs := testhelper.NewTestFs(files)
+	testFs.Cwd = basePath
+
+	st := &HelmState{
+		logger:         logger,
+		fs:             testFs.ToFileSystem(),
+		valsRuntime:    valsRuntime,
+		basePath:       basePath,
+		FilePath:       basePath + "/helmfile.yaml",
+		RenderedValues: map[string]any{},
+	}
+	return st, func() {}
+}
+
+func TestResolveReleaseValues_Empty(t *testing.T) {
+	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
+	defer cleanup()
+
+	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
+	result, err := st.resolveReleaseValues(release)
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestResolveReleaseValues_FromFile(t *testing.T) {
+	valuesFile := "/project/values.yaml"
+	valuesContent := `replicaCount: 2
+image:
+  repository: nginx
+  tag: "1.21"
+`
+	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+		valuesFile: valuesContent,
+	}, "/project")
+	defer cleanup()
+
+	release := &ReleaseSpec{
+		Name:  "myrelease",
+		Chart: "mychart",
+		Values: []any{
+			"values.yaml",
+		},
+	}
+	result, err := st.resolveReleaseValues(release)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result["replicaCount"])
+	imageMap, ok := result["image"].(map[string]any)
+	require.True(t, ok, "expected image to be a map")
+	assert.Equal(t, "nginx", imageMap["repository"])
+}
+
+func TestResolveReleaseValues_InlineMap(t *testing.T) {
+	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
+	defer cleanup()
+
+	release := &ReleaseSpec{
+		Name:  "myrelease",
+		Chart: "mychart",
+		Values: []any{
+			map[string]any{
+				"replicaCount": 5,
+				"service": map[string]any{
+					"type": "ClusterIP",
+					"port": 80,
+				},
+			},
+		},
+	}
+	result, err := st.resolveReleaseValues(release)
+	require.NoError(t, err)
+	assert.Equal(t, 5, result["replicaCount"])
+	serviceMap, ok := result["service"].(map[string]any)
+	require.True(t, ok, "expected service to be a map")
+	assert.Equal(t, "ClusterIP", serviceMap["type"])
+}
+
+func TestResolveReleaseValues_MultipleSourcesMerged(t *testing.T) {
+	baseValuesFile := "/project/base.yaml"
+	baseValuesContent := `replicaCount: 1
+service:
+  type: ClusterIP
+`
+	overrideValuesFile := "/project/override.yaml"
+	overrideValuesContent := `replicaCount: 3
+ingress:
+  enabled: true
+`
+	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+		baseValuesFile:     baseValuesContent,
+		overrideValuesFile: overrideValuesContent,
+	}, "/project")
+	defer cleanup()
+
+	release := &ReleaseSpec{
+		Name:  "myrelease",
+		Chart: "mychart",
+		Values: []any{
+			"base.yaml",
+			"override.yaml",
+		},
+	}
+	result, err := st.resolveReleaseValues(release)
+	require.NoError(t, err)
+	// override.yaml value wins
+	assert.Equal(t, 3, result["replicaCount"])
+	// from base.yaml
+	serviceMap, ok := result["service"].(map[string]any)
+	require.True(t, ok, "expected service to be a map")
+	assert.Equal(t, "ClusterIP", serviceMap["type"])
+	// from override.yaml
+	ingressMap, ok := result["ingress"].(map[string]any)
+	require.True(t, ok, "expected ingress to be a map")
+	assert.Equal(t, true, ingressMap["enabled"])
+}
+
+func TestResolveReleaseValues_FileAndInlineMerged(t *testing.T) {
+	valuesFile := "/project/values.yaml"
+	valuesContent := `replicaCount: 1
+`
+	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+		valuesFile: valuesContent,
+	}, "/project")
+	defer cleanup()
+
+	release := &ReleaseSpec{
+		Name:  "myrelease",
+		Chart: "mychart",
+		Values: []any{
+			"values.yaml",
+			map[string]any{
+				"extraEnv": "production",
+			},
+		},
+	}
+	result, err := st.resolveReleaseValues(release)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result["replicaCount"])
+	assert.Equal(t, "production", result["extraEnv"])
+}
+
+func TestRenderValuesFileToBytesWithData_PlainYAML(t *testing.T) {
+	valuesFile := "/project/values.yaml"
+	valuesContent := `replicaCount: 2
+image:
+  repository: nginx
+`
+	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+		valuesFile: valuesContent,
+	}, "/project")
+	defer cleanup()
+
+	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
+	tmplData := st.createReleaseTemplateData(release, map[string]any{})
+
+	result, err := st.renderValuesFileToBytesWithData(valuesFile, tmplData)
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "replicaCount: 2")
+	assert.Contains(t, string(result), "repository: nginx")
+}
+
+func TestRenderValuesFileToBytesWithData_WithValuesTemplate(t *testing.T) {
+	valuesFile := "/project/values.yaml.gotmpl"
+	valuesContent := `replicaCount: {{ .Values.replicaCount }}
+enabled: {{ .Values.ingress.enabled }}
+`
+	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+		valuesFile: valuesContent,
+	}, "/project")
+	defer cleanup()
+
+	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
+	tmplData := st.createReleaseTemplateData(release, map[string]any{
+		"replicaCount": 3,
+		"ingress": map[string]any{
+			"enabled": true,
+		},
+	})
+
+	result, err := st.renderValuesFileToBytesWithData(valuesFile, tmplData)
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "replicaCount: 3")
+	assert.Contains(t, string(result), "enabled: true")
+}
+
+func TestRenderValuesFileToBytesWithData_WithReleaseTemplate(t *testing.T) {
+	valuesFile := "/project/values.yaml.gotmpl"
+	valuesContent := `releaseName: {{ .Release.Name }}
+releaseNamespace: {{ .Release.Namespace }}
+`
+	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+		valuesFile: valuesContent,
+	}, "/project")
+	defer cleanup()
+
+	release := &ReleaseSpec{Name: "myapp", Chart: "mychart", Namespace: "production"}
+	tmplData := st.createReleaseTemplateData(release, map[string]any{})
+
+	result, err := st.renderValuesFileToBytesWithData(valuesFile, tmplData)
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "releaseName: myapp")
+	assert.Contains(t, string(result), "releaseNamespace: production")
+}
+
+func TestGenerateTemporaryReleaseValuesFilesWithData_StringPath(t *testing.T) {
+	patchFile := "/project/patch.yaml.gotmpl"
+	patchContent := `enabled: {{ .Values.ingress.enabled }}
+host: {{ .Values.ingress.host }}
+`
+	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{
+		patchFile: patchContent,
+	}, "/project")
+	defer cleanup()
+
+	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
+	tmplData := st.createReleaseTemplateData(release, map[string]any{
+		"ingress": map[string]any{
+			"enabled": true,
+			"host":    "example.com",
+		},
+	})
+
+	generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(
+		release,
+		[]any{"patch.yaml.gotmpl"},
+		tmplData,
+	)
+	require.NoError(t, err)
+	require.Len(t, generatedFiles, 1)
+
+	// Read and verify the generated file content
+	content, err := filesystem.DefaultFileSystem().ReadFile(generatedFiles[0])
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "enabled: true")
+	assert.Contains(t, string(content), "host: example.com")
+}
+
+func TestGenerateTemporaryReleaseValuesFilesWithData_InlineMap(t *testing.T) {
+	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
+	defer cleanup()
+
+	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
+	tmplData := st.createReleaseTemplateData(release, map[string]any{})
+
+	inlineValues := map[string]any{
+		"replicaCount": 5,
+		"service": map[string]any{
+			"type": "NodePort",
+		},
+	}
+
+	generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(
+		release,
+		[]any{inlineValues},
+		tmplData,
+	)
+	require.NoError(t, err)
+	require.Len(t, generatedFiles, 1)
+
+	content, err := filesystem.DefaultFileSystem().ReadFile(generatedFiles[0])
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "replicaCount: 5")
+	assert.Contains(t, string(content), "NodePort")
+}
+
+func TestGenerateTemporaryReleaseValuesFilesWithData_UnknownTypeError(t *testing.T) {
+	st, cleanup := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
+	defer cleanup()
+
+	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
+	tmplData := st.createReleaseTemplateData(release, map[string]any{})
+
+	// Passing an unsupported type (int) should return an error
+	_, err := st.generateTemporaryReleaseValuesFilesWithData(
+		release,
+		[]any{42},
+		tmplData,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected type of value")
+}

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -1191,8 +1191,9 @@ func TestMergedReleaseTemplateData_InlineValues(t *testing.T) {
 	}
 }
 
-func newTestHelmStateWithFiles(t *testing.T, files map[string]string, basePath string) *HelmState {
+func newTestHelmStateWithFiles(t *testing.T, files map[string]string) *HelmState {
 	t.Helper()
+	const basePath = "/project"
 	logger := zaptest.NewLogger(t).Sugar()
 	valsRuntime, err := vals.New(vals.Options{CacheSize: 32})
 	require.NoError(t, err)
@@ -1211,7 +1212,7 @@ func newTestHelmStateWithFiles(t *testing.T, files map[string]string, basePath s
 }
 
 func TestResolveReleaseValues_Empty(t *testing.T) {
-	st := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
+	st := newTestHelmStateWithFiles(t, map[string]string{})
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
 	result, err := st.resolveReleaseValues(release)
@@ -1228,7 +1229,7 @@ image:
 `
 	st := newTestHelmStateWithFiles(t, map[string]string{
 		valuesFile: valuesContent,
-	}, "/project")
+	})
 
 	release := &ReleaseSpec{
 		Name:  "myrelease",
@@ -1246,7 +1247,7 @@ image:
 }
 
 func TestResolveReleaseValues_InlineMap(t *testing.T) {
-	st := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
+	st := newTestHelmStateWithFiles(t, map[string]string{})
 
 	release := &ReleaseSpec{
 		Name:  "myrelease",
@@ -1283,7 +1284,7 @@ ingress:
 	st := newTestHelmStateWithFiles(t, map[string]string{
 		baseValuesFile:     baseValuesContent,
 		overrideValuesFile: overrideValuesContent,
-	}, "/project")
+	})
 
 	release := &ReleaseSpec{
 		Name:  "myrelease",
@@ -1313,7 +1314,7 @@ func TestResolveReleaseValues_FileAndInlineMerged(t *testing.T) {
 `
 	st := newTestHelmStateWithFiles(t, map[string]string{
 		valuesFile: valuesContent,
-	}, "/project")
+	})
 
 	release := &ReleaseSpec{
 		Name:  "myrelease",
@@ -1339,7 +1340,7 @@ image:
 `
 	st := newTestHelmStateWithFiles(t, map[string]string{
 		valuesFile: valuesContent,
-	}, "/project")
+	})
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
 	tmplData := st.createReleaseTemplateData(release, map[string]any{})
@@ -1357,7 +1358,7 @@ enabled: {{ .Values.ingress.enabled }}
 `
 	st := newTestHelmStateWithFiles(t, map[string]string{
 		valuesFile: valuesContent,
-	}, "/project")
+	})
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
 	tmplData := st.createReleaseTemplateData(release, map[string]any{
@@ -1380,7 +1381,7 @@ releaseNamespace: {{ .Release.Namespace }}
 `
 	st := newTestHelmStateWithFiles(t, map[string]string{
 		valuesFile: valuesContent,
-	}, "/project")
+	})
 
 	release := &ReleaseSpec{Name: "myapp", Chart: "mychart", Namespace: "production"}
 	tmplData := st.createReleaseTemplateData(release, map[string]any{})
@@ -1398,7 +1399,7 @@ host: {{ .Values.ingress.host }}
 `
 	st := newTestHelmStateWithFiles(t, map[string]string{
 		patchFile: patchContent,
-	}, "/project")
+	})
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
 	tmplData := st.createReleaseTemplateData(release, map[string]any{
@@ -1424,7 +1425,7 @@ host: {{ .Values.ingress.host }}
 }
 
 func TestGenerateTemporaryReleaseValuesFilesWithData_InlineMap(t *testing.T) {
-	st := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
+	st := newTestHelmStateWithFiles(t, map[string]string{})
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
 	tmplData := st.createReleaseTemplateData(release, map[string]any{})
@@ -1452,7 +1453,7 @@ func TestGenerateTemporaryReleaseValuesFilesWithData_InlineMap(t *testing.T) {
 }
 
 func TestGenerateTemporaryReleaseValuesFilesWithData_UnknownTypeError(t *testing.T) {
-	st := newTestHelmStateWithFiles(t, map[string]string{}, "/project")
+	st := newTestHelmStateWithFiles(t, map[string]string{})
 
 	release := &ReleaseSpec{Name: "myrelease", Chart: "mychart"}
 	tmplData := st.createReleaseTemplateData(release, map[string]any{})

--- a/pkg/state/create_test.go
+++ b/pkg/state/create_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"dario.cat/mergo"
+	"github.com/helmfile/vals"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -1023,5 +1024,169 @@ func TestMergeEnvironments_PreservesMergeStrategy(t *testing.T) {
 				t.Errorf("MergeStrategy after merge: want %q, got %q", tt.expected, got)
 			}
 		})
+	}
+}
+
+func TestMergedReleaseTemplateData_IncludesReleaseValues(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	testValsRuntime, _ := vals.New(vals.Options{CacheSize: 32})
+
+	yamlFile := "/example/path/to/helmfile.yaml"
+	yamlContent := []byte(`environments:
+  default:
+    values:
+    - env.yaml
+
+releases:
+- name: myrelease
+  chart: mychart
+  values:
+  - values.yaml
+`)
+
+	envYamlFile := "/example/path/to/env.yaml"
+	envYamlContent := []byte(`envKey: envValue`)
+
+	valuesFile := "/example/path/to/values.yaml"
+	valuesContent := []byte(`ingress:
+  enabled: true
+  host: example.com`)
+
+	testFs := testhelper.NewTestFs(map[string]string{
+		envYamlFile: string(envYamlContent),
+		valuesFile:  string(valuesContent),
+	})
+	testFs.Cwd = "/example/path/to"
+
+	r := remote.NewRemote(logger, testFs.Cwd, testFs.ToFileSystem())
+	env := environment.Environment{
+		Name: "default",
+	}
+	state, err := NewCreator(logger, testFs.ToFileSystem(), testValsRuntime, nil, "", "", r, false, "").
+		ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "default", true, true, true, &env, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	release := state.Releases[0]
+
+	templateData, err := state.mergedReleaseTemplateData(&release)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ingress, ok := templateData.Values["ingress"]
+	if !ok {
+		t.Fatalf("expected .Values to contain 'ingress' key from release values")
+	}
+	ingressMap, ok := ingress.(map[string]any)
+	if !ok {
+		t.Fatalf("expected ingress to be a map, got %T", ingress)
+	}
+	if ingressMap["enabled"] != true {
+		t.Errorf("expected ingress.enabled to be true, got %v", ingressMap["enabled"])
+	}
+	if ingressMap["host"] != "example.com" {
+		t.Errorf("expected ingress.host to be 'example.com', got %v", ingressMap["host"])
+	}
+
+	if templateData.Values["envKey"] != "envValue" {
+		t.Errorf("expected envKey to be 'envValue', got %v", templateData.Values["envKey"])
+	}
+}
+
+func TestMergedReleaseTemplateData_ReleaseValuesOverrideEnvValues(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	testValsRuntime, _ := vals.New(vals.Options{CacheSize: 32})
+
+	yamlFile := "/example/path/to/helmfile.yaml"
+	yamlContent := []byte(`environments:
+  default:
+    values:
+    - env.yaml
+
+releases:
+- name: myrelease
+  chart: mychart
+  values:
+  - values.yaml
+`)
+
+	envYamlFile := "/example/path/to/env.yaml"
+	envYamlContent := []byte(`replicaCount: 1`)
+
+	valuesFile := "/example/path/to/values.yaml"
+	valuesContent := []byte(`replicaCount: 3`)
+
+	testFs := testhelper.NewTestFs(map[string]string{
+		envYamlFile: string(envYamlContent),
+		valuesFile:  string(valuesContent),
+	})
+	testFs.Cwd = "/example/path/to"
+
+	r := remote.NewRemote(logger, testFs.Cwd, testFs.ToFileSystem())
+	env := environment.Environment{
+		Name: "default",
+	}
+	state, err := NewCreator(logger, testFs.ToFileSystem(), testValsRuntime, nil, "", "", r, false, "").
+		ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "default", true, true, true, &env, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	release := state.Releases[0]
+
+	templateData, err := state.mergedReleaseTemplateData(&release)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if templateData.Values["replicaCount"] != 3 {
+		t.Errorf("expected replicaCount to be 3 (release value overriding env), got %v", templateData.Values["replicaCount"])
+	}
+}
+
+func TestMergedReleaseTemplateData_InlineValues(t *testing.T) {
+	logger := zaptest.NewLogger(t).Sugar()
+	testValsRuntime, _ := vals.New(vals.Options{CacheSize: 32})
+
+	yamlFile := "/example/path/to/helmfile.yaml"
+	yamlContent := []byte(`releases:
+- name: myrelease
+  chart: mychart
+  values:
+  - ingress:
+      enabled: true
+      host: example.com
+`)
+
+	testFs := testhelper.NewTestFs(map[string]string{})
+	testFs.Cwd = "/example/path/to"
+
+	r := remote.NewRemote(logger, testFs.Cwd, testFs.ToFileSystem())
+	state, err := NewCreator(logger, testFs.ToFileSystem(), testValsRuntime, nil, "", "", r, false, "").
+		ParseAndLoad(yamlContent, filepath.Dir(yamlFile), yamlFile, "default", true, true, true, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	release := state.Releases[0]
+
+	templateData, err := state.mergedReleaseTemplateData(&release)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ingress, ok := templateData.Values["ingress"]
+	if !ok {
+		t.Fatalf("expected .Values to contain 'ingress' key from inline release values")
+	}
+	ingressMap, ok := ingress.(map[string]any)
+	if !ok {
+		t.Fatalf("expected ingress to be a map, got %T", ingress)
+	}
+	if ingressMap["enabled"] != true {
+		t.Errorf("expected ingress.enabled to be true, got %v", ingressMap["enabled"])
+	}
 	}
 }

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -474,9 +474,18 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 		shouldRun = true
 	}
 
+	var patchTemplateData *releaseTemplateData
+	if len(release.JSONPatches) > 0 || len(release.StrategicMergePatches) > 0 || len(release.Transformers) > 0 {
+		td, err := st.mergedReleaseTemplateData(release)
+		if err != nil {
+			return nil, clean, fmt.Errorf("failed to compute merged release values for patch rendering: %v", err)
+		}
+		patchTemplateData = &td
+	}
+
 	jsonPatches := release.JSONPatches
 	if len(jsonPatches) > 0 {
-		generatedFiles, err := st.generateTemporaryReleaseValuesFiles(release, jsonPatches)
+		generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(release, jsonPatches, *patchTemplateData)
 		if err != nil {
 			return nil, clean, err
 		}
@@ -490,7 +499,7 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 
 	strategicMergePatches := release.StrategicMergePatches
 	if len(strategicMergePatches) > 0 {
-		generatedFiles, err := st.generateTemporaryReleaseValuesFiles(release, strategicMergePatches)
+		generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(release, strategicMergePatches, *patchTemplateData)
 		if err != nil {
 			return nil, clean, err
 		}
@@ -504,7 +513,7 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 
 	transformers := release.Transformers
 	if len(transformers) > 0 {
-		generatedFiles, err := st.generateTemporaryReleaseValuesFiles(release, transformers)
+		generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(release, transformers, *patchTemplateData)
 		if err != nil {
 			return nil, clean, err
 		}

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -474,18 +474,28 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 		shouldRun = true
 	}
 
-	var patchTemplateData *releaseTemplateData
-	if len(release.JSONPatches) > 0 || len(release.StrategicMergePatches) > 0 || len(release.Transformers) > 0 {
-		td, err := st.mergedReleaseTemplateData(release)
-		if err != nil {
-			return nil, clean, fmt.Errorf("failed to compute merged release values for patch rendering: %v", err)
+	// patchTemplateData is computed lazily on first use: only when an actual string patch/transformer
+	// file path is rendered. Inline-map entries don't require template data at all, so we avoid
+	// unnecessary I/O for releases whose patches are all inline maps or that have no string entries.
+	var (
+		cachedPatchTemplateData    releaseTemplateData
+		cachedPatchTemplateDataErr error
+		cachedPatchTemplateDataSet bool
+	)
+	getPatchTemplateData := func() (releaseTemplateData, error) {
+		if !cachedPatchTemplateDataSet {
+			cachedPatchTemplateDataSet = true
+			cachedPatchTemplateData, cachedPatchTemplateDataErr = st.mergedReleaseTemplateData(release)
+			if cachedPatchTemplateDataErr != nil {
+				cachedPatchTemplateDataErr = fmt.Errorf("failed to compute merged release values for patch rendering: %v", cachedPatchTemplateDataErr)
+			}
 		}
-		patchTemplateData = &td
+		return cachedPatchTemplateData, cachedPatchTemplateDataErr
 	}
 
 	jsonPatches := release.JSONPatches
 	if len(jsonPatches) > 0 {
-		generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(release, jsonPatches, *patchTemplateData)
+		generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(release, jsonPatches, getPatchTemplateData)
 		if err != nil {
 			return nil, clean, err
 		}
@@ -499,7 +509,7 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 
 	strategicMergePatches := release.StrategicMergePatches
 	if len(strategicMergePatches) > 0 {
-		generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(release, strategicMergePatches, *patchTemplateData)
+		generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(release, strategicMergePatches, getPatchTemplateData)
 		if err != nil {
 			return nil, clean, err
 		}
@@ -513,7 +523,7 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 
 	transformers := release.Transformers
 	if len(transformers) > 0 {
-		generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(release, transformers, *patchTemplateData)
+		generatedFiles, err := st.generateTemporaryReleaseValuesFilesWithData(release, transformers, getPatchTemplateData)
 		if err != nil {
 			return nil, clean, err
 		}

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -487,7 +487,7 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 			cachedPatchTemplateDataSet = true
 			cachedPatchTemplateData, cachedPatchTemplateDataErr = st.mergedReleaseTemplateData(release)
 			if cachedPatchTemplateDataErr != nil {
-				cachedPatchTemplateDataErr = fmt.Errorf("failed to compute merged release values for patch rendering: %v", cachedPatchTemplateDataErr)
+				cachedPatchTemplateDataErr = fmt.Errorf("failed to compute merged release values for patch rendering: %w", cachedPatchTemplateDataErr)
 			}
 		}
 		return cachedPatchTemplateData, cachedPatchTemplateDataErr

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -4257,109 +4257,9 @@ func (st *HelmState) renderValuesFileToBytesWithData(path string, templateData r
 }
 
 func (st *HelmState) generateTemporaryReleaseValuesFilesWithData(release *ReleaseSpec, values []any, templateData releaseTemplateData) ([]string, error) {
-	generatedFiles := []string{}
-
-	for _, value := range values {
-		switch typedValue := value.(type) {
-		case string:
-			paths, skip, err := st.storage().resolveFile(st.getReleaseMissingFileHandler(release), "values", typedValue, st.getReleaseMissingFileHandlerConfig(release).resolveFileOptions()...)
-			if err != nil {
-				return generatedFiles, err
-			}
-			if skip {
-				continue
-			}
-
-			if len(paths) > 1 {
-				return generatedFiles, fmt.Errorf("glob patterns are not supported in patch/transformer values yet. please submit a feature request if necessary")
-			}
-			path := paths[0]
-
-			yamlBytes, err := st.renderValuesFileToBytesWithData(path, templateData)
-			if err != nil {
-				return generatedFiles, fmt.Errorf("failed to render values files \"%s\": %v", typedValue, err)
-			}
-
-			if err := func() error {
-				valfile, err := createTempValuesFile(release, yamlBytes)
-				if err != nil {
-					return err
-				}
-				defer func() {
-					_ = valfile.Close()
-				}()
-
-				if _, err := valfile.Write(yamlBytes); err != nil {
-					return fmt.Errorf("failed to write %s: %v", valfile.Name(), err)
-				}
-
-				st.logger.Debugf("Successfully generated the value file at %s. produced:\n%s", path, string(yamlBytes))
-
-				generatedFiles = append(generatedFiles, valfile.Name())
-
-				return nil
-			}(); err != nil {
-				return generatedFiles, err
-			}
-		case map[any]any:
-			strMap, err := maputil.CastKeysToStrings(typedValue)
-			if err != nil {
-				return generatedFiles, err
-			}
-			if err := func() error {
-				valfile, err := createTempValuesFile(release, strMap)
-				if err != nil {
-					return err
-				}
-				defer func() {
-					_ = valfile.Close()
-				}()
-
-				encoder := yaml.NewEncoder(valfile)
-				defer func() {
-					_ = encoder.Close()
-				}()
-
-				if err := encoder.Encode(strMap); err != nil {
-					return err
-				}
-
-				generatedFiles = append(generatedFiles, valfile.Name())
-
-				return nil
-			}(); err != nil {
-				return generatedFiles, err
-			}
-		case map[string]any:
-			if err := func() error {
-				valfile, err := createTempValuesFile(release, typedValue)
-				if err != nil {
-					return err
-				}
-				defer func() {
-					_ = valfile.Close()
-				}()
-
-				encoder := yaml.NewEncoder(valfile)
-				defer func() {
-					_ = encoder.Close()
-				}()
-
-				if err := encoder.Encode(typedValue); err != nil {
-					return err
-				}
-
-				generatedFiles = append(generatedFiles, valfile.Name())
-
-				return nil
-			}(); err != nil {
-				return generatedFiles, err
-			}
-		default:
-			return generatedFiles, fmt.Errorf("unexpected type of value: value=%v, type=%T", typedValue, typedValue)
-		}
-	}
-	return generatedFiles, nil
+	return st.generateTemporaryReleaseValuesFilesCore(release, values, func(path string) ([]byte, error) {
+		return st.renderValuesFileToBytesWithData(path, templateData)
+	})
 }
 
 func (st *HelmState) newReleaseTemplateFuncMap(dir string) template.FuncMap {
@@ -4498,6 +4398,14 @@ func (st *HelmState) getMissingFileHandler() *string {
 }
 
 func (st *HelmState) generateTemporaryReleaseValuesFiles(release *ReleaseSpec, values []any) ([]string, error) {
+	return st.generateTemporaryReleaseValuesFilesCore(release, values, func(path string) ([]byte, error) {
+		return st.RenderReleaseValuesFileToBytes(release, path)
+	})
+}
+
+// generateTemporaryReleaseValuesFilesCore is the shared implementation for generating temporary values files.
+// renderStringValue is called for each string value entry after the file path has been resolved.
+func (st *HelmState) generateTemporaryReleaseValuesFilesCore(release *ReleaseSpec, values []any, renderStringValue func(path string) ([]byte, error)) ([]string, error) {
 	generatedFiles := []string{}
 
 	for _, value := range values {
@@ -4516,45 +4424,86 @@ func (st *HelmState) generateTemporaryReleaseValuesFiles(release *ReleaseSpec, v
 			}
 			path := paths[0]
 
-			yamlBytes, err := st.RenderReleaseValuesFileToBytes(release, path)
+			yamlBytes, err := renderStringValue(path)
 			if err != nil {
 				return generatedFiles, fmt.Errorf("failed to render values files \"%s\": %v", typedValue, err)
 			}
 
-			valfile, err := createTempValuesFile(release, yamlBytes)
+			if err := func() error {
+				valfile, err := createTempValuesFile(release, yamlBytes)
+				if err != nil {
+					return err
+				}
+				defer func() {
+					_ = valfile.Close()
+				}()
+
+				if _, err := valfile.Write(yamlBytes); err != nil {
+					return fmt.Errorf("failed to write %s: %v", valfile.Name(), err)
+				}
+
+				st.logger.Debugf("Successfully generated the value file at %s. produced:\n%s", path, string(yamlBytes))
+
+				generatedFiles = append(generatedFiles, valfile.Name())
+
+				return nil
+			}(); err != nil {
+				return generatedFiles, err
+			}
+		case map[any]any:
+			strMap, err := maputil.CastKeysToStrings(typedValue)
 			if err != nil {
 				return generatedFiles, err
 			}
-			defer func() {
-				_ = valfile.Close()
-			}()
+			if err := func() error {
+				valfile, err := createTempValuesFile(release, strMap)
+				if err != nil {
+					return err
+				}
+				defer func() {
+					_ = valfile.Close()
+				}()
 
-			if _, err := valfile.Write(yamlBytes); err != nil {
-				return generatedFiles, fmt.Errorf("failed to write %s: %v", valfile.Name(), err)
-			}
+				encoder := yaml.NewEncoder(valfile)
+				defer func() {
+					_ = encoder.Close()
+				}()
 
-			st.logger.Debugf("Successfully generated the value file at %s. produced:\n%s", path, string(yamlBytes))
+				if err := encoder.Encode(strMap); err != nil {
+					return err
+				}
 
-			generatedFiles = append(generatedFiles, valfile.Name())
-		case map[any]any, map[string]any:
-			valfile, err := createTempValuesFile(release, typedValue)
-			if err != nil {
+				generatedFiles = append(generatedFiles, valfile.Name())
+
+				return nil
+			}(); err != nil {
 				return generatedFiles, err
 			}
-			defer func() {
-				_ = valfile.Close()
-			}()
+		case map[string]any:
+			if err := func() error {
+				valfile, err := createTempValuesFile(release, typedValue)
+				if err != nil {
+					return err
+				}
+				defer func() {
+					_ = valfile.Close()
+				}()
 
-			encoder := yaml.NewEncoder(valfile)
-			defer func() {
-				_ = encoder.Close()
-			}()
+				encoder := yaml.NewEncoder(valfile)
+				defer func() {
+					_ = encoder.Close()
+				}()
 
-			if err := encoder.Encode(typedValue); err != nil {
+				if err := encoder.Encode(typedValue); err != nil {
+					return err
+				}
+
+				generatedFiles = append(generatedFiles, valfile.Name())
+
+				return nil
+			}(); err != nil {
 				return generatedFiles, err
 			}
-
-			generatedFiles = append(generatedFiles, valfile.Name())
 		default:
 			return generatedFiles, fmt.Errorf("unexpected type of value: value=%v, type=%T", typedValue, typedValue)
 		}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -4194,7 +4194,7 @@ func (st *HelmState) resolveReleaseValues(release *ReleaseSpec) (map[string]any,
 				continue
 			}
 			if len(paths) > 1 {
-				return nil, fmt.Errorf("glob patterns in release values is not supported for template data resolution")
+				return nil, fmt.Errorf("glob patterns in release values are not supported for template data resolution: value=%q, resolvedPaths=%v", typedValue, paths)
 			}
 			path := paths[0]
 
@@ -4232,6 +4232,7 @@ func (st *HelmState) renderValuesFileToBytesWithData(path string, templateData r
 		return nil, err
 	}
 
+	// If 'ref+.*' exists in file, run vals against the file
 	match, err := regexp.Match("ref\\+.*", rawBytes)
 	if err != nil {
 		return nil, err
@@ -4270,7 +4271,7 @@ func (st *HelmState) generateTemporaryReleaseValuesFilesWithData(release *Releas
 			}
 
 			if len(paths) > 1 {
-				return generatedFiles, fmt.Errorf("glob patterns in release values and secrets is not supported yet. please submit a feature request if necessary")
+				return generatedFiles, fmt.Errorf("glob patterns are not supported in patch/transformer values yet. please submit a feature request if necessary")
 			}
 			path := paths[0]
 
@@ -4279,40 +4280,81 @@ func (st *HelmState) generateTemporaryReleaseValuesFilesWithData(release *Releas
 				return generatedFiles, fmt.Errorf("failed to render values files \"%s\": %v", typedValue, err)
 			}
 
-			valfile, err := createTempValuesFile(release, yamlBytes)
+			if err := func() error {
+				valfile, err := createTempValuesFile(release, yamlBytes)
+				if err != nil {
+					return err
+				}
+				defer func() {
+					_ = valfile.Close()
+				}()
+
+				if _, err := valfile.Write(yamlBytes); err != nil {
+					return fmt.Errorf("failed to write %s: %v", valfile.Name(), err)
+				}
+
+				st.logger.Debugf("Successfully generated the value file at %s. produced:\n%s", path, string(yamlBytes))
+
+				generatedFiles = append(generatedFiles, valfile.Name())
+
+				return nil
+			}(); err != nil {
+				return generatedFiles, err
+			}
+		case map[any]any:
+			strMap, err := maputil.CastKeysToStrings(typedValue)
 			if err != nil {
 				return generatedFiles, err
 			}
-			defer func() {
-				_ = valfile.Close()
-			}()
+			if err := func() error {
+				valfile, err := createTempValuesFile(release, strMap)
+				if err != nil {
+					return err
+				}
+				defer func() {
+					_ = valfile.Close()
+				}()
 
-			if _, err := valfile.Write(yamlBytes); err != nil {
-				return generatedFiles, fmt.Errorf("failed to write %s: %v", valfile.Name(), err)
-			}
+				encoder := yaml.NewEncoder(valfile)
+				defer func() {
+					_ = encoder.Close()
+				}()
 
-			st.logger.Debugf("Successfully generated the value file at %s. produced:\n%s", path, string(yamlBytes))
+				if err := encoder.Encode(strMap); err != nil {
+					return err
+				}
 
-			generatedFiles = append(generatedFiles, valfile.Name())
-		case map[any]any, map[string]any:
-			valfile, err := createTempValuesFile(release, typedValue)
-			if err != nil {
+				generatedFiles = append(generatedFiles, valfile.Name())
+
+				return nil
+			}(); err != nil {
 				return generatedFiles, err
 			}
-			defer func() {
-				_ = valfile.Close()
-			}()
+		case map[string]any:
+			if err := func() error {
+				valfile, err := createTempValuesFile(release, typedValue)
+				if err != nil {
+					return err
+				}
+				defer func() {
+					_ = valfile.Close()
+				}()
 
-			encoder := yaml.NewEncoder(valfile)
-			defer func() {
-				_ = encoder.Close()
-			}()
+				encoder := yaml.NewEncoder(valfile)
+				defer func() {
+					_ = encoder.Close()
+				}()
 
-			if err := encoder.Encode(typedValue); err != nil {
+				if err := encoder.Encode(typedValue); err != nil {
+					return err
+				}
+
+				generatedFiles = append(generatedFiles, valfile.Name())
+
+				return nil
+			}(); err != nil {
 				return generatedFiles, err
 			}
-
-			generatedFiles = append(generatedFiles, valfile.Name())
 		default:
 			return generatedFiles, fmt.Errorf("unexpected type of value: value=%v, type=%T", typedValue, typedValue)
 		}
@@ -4328,35 +4370,7 @@ func (st *HelmState) newReleaseTemplateFuncMap(dir string) template.FuncMap {
 
 func (st *HelmState) RenderReleaseValuesFileToBytes(release *ReleaseSpec, path string) ([]byte, error) {
 	templateData := st.newReleaseTemplateData(release)
-
-	r := tmpl.NewFileRenderer(st.fs, filepath.Dir(path), templateData)
-	rawBytes, err := r.RenderToBytes(path)
-	if err != nil {
-		return nil, err
-	}
-
-	// If 'ref+.*' exists in file, run vals against the file
-	match, err := regexp.Match("ref\\+.*", rawBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	if match {
-		var rawYaml map[string]any
-
-		if err := yaml.Unmarshal(rawBytes, &rawYaml); err != nil {
-			return nil, err
-		}
-
-		parsedYaml, err := st.valsRuntime.Eval(rawYaml)
-		if err != nil {
-			return nil, err
-		}
-
-		return yaml.Marshal(parsedYaml)
-	}
-
-	return rawBytes, nil
+	return st.renderValuesFileToBytesWithData(path, templateData)
 }
 
 func (st *HelmState) storage() *Storage {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -4150,6 +4150,176 @@ func (st *HelmState) newReleaseTemplateData(release *ReleaseSpec) releaseTemplat
 	return templateData
 }
 
+func (st *HelmState) mergedReleaseTemplateData(release *ReleaseSpec) (releaseTemplateData, error) {
+	releaseValues, err := st.resolveReleaseValues(release)
+	if err != nil {
+		return releaseTemplateData{}, err
+	}
+	mergedVals := maputil.MergeMaps(st.Values(), releaseValues)
+	return st.createReleaseTemplateData(release, mergedVals), nil
+}
+
+func (st *HelmState) resolveReleaseValues(release *ReleaseSpec) (map[string]any, error) {
+	merged := map[string]any{}
+
+	values := []any{}
+	for _, v := range release.Values {
+		switch typedValue := v.(type) {
+		case string:
+			path := st.storage().normalizePath(release.ValuesPathPrefix + typedValue)
+			values = append(values, path)
+		default:
+			values = append(values, v)
+		}
+	}
+
+	valuesMapSecretsRendered, err := st.valsRuntime.Eval(map[string]any{"values": values})
+	if err != nil {
+		return nil, err
+	}
+
+	valuesSecretsRendered, ok := valuesMapSecretsRendered["values"].([]any)
+	if !ok {
+		return nil, fmt.Errorf("failed to render values in %s for release %s: type %T isn't supported", st.FilePath, release.Name, valuesMapSecretsRendered["values"])
+	}
+
+	for _, v := range valuesSecretsRendered {
+		switch typedValue := v.(type) {
+		case string:
+			paths, skip, err := st.storage().resolveFile(st.getReleaseMissingFileHandler(release), "values", typedValue, st.getReleaseMissingFileHandlerConfig(release).resolveFileOptions()...)
+			if err != nil {
+				return nil, err
+			}
+			if skip {
+				continue
+			}
+			if len(paths) > 1 {
+				return nil, fmt.Errorf("glob patterns in release values is not supported for template data resolution")
+			}
+			path := paths[0]
+
+			yamlBytes, err := st.RenderReleaseValuesFileToBytes(release, path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to render values file \"%s\": %v", typedValue, err)
+			}
+
+			var vals map[string]any
+			if err := yaml.Unmarshal(yamlBytes, &vals); err != nil {
+				return nil, fmt.Errorf("failed to parse values file \"%s\": %v", typedValue, err)
+			}
+
+			merged = maputil.MergeMaps(merged, vals)
+		case map[any]any:
+			strMap, err := maputil.CastKeysToStrings(typedValue)
+			if err != nil {
+				return nil, err
+			}
+			merged = maputil.MergeMaps(merged, strMap)
+		case map[string]any:
+			merged = maputil.MergeMaps(merged, typedValue)
+		default:
+			return nil, fmt.Errorf("unexpected type of value in release values: value=%v, type=%T", typedValue, typedValue)
+		}
+	}
+
+	return merged, nil
+}
+
+func (st *HelmState) renderValuesFileToBytesWithData(path string, templateData releaseTemplateData) ([]byte, error) {
+	r := tmpl.NewFileRenderer(st.fs, filepath.Dir(path), templateData)
+	rawBytes, err := r.RenderToBytes(path)
+	if err != nil {
+		return nil, err
+	}
+
+	match, err := regexp.Match("ref\\+.*", rawBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if match {
+		var rawYaml map[string]any
+
+		if err := yaml.Unmarshal(rawBytes, &rawYaml); err != nil {
+			return nil, err
+		}
+
+		parsedYaml, err := st.valsRuntime.Eval(rawYaml)
+		if err != nil {
+			return nil, err
+		}
+
+		return yaml.Marshal(parsedYaml)
+	}
+
+	return rawBytes, nil
+}
+
+func (st *HelmState) generateTemporaryReleaseValuesFilesWithData(release *ReleaseSpec, values []any, templateData releaseTemplateData) ([]string, error) {
+	generatedFiles := []string{}
+
+	for _, value := range values {
+		switch typedValue := value.(type) {
+		case string:
+			paths, skip, err := st.storage().resolveFile(st.getReleaseMissingFileHandler(release), "values", typedValue, st.getReleaseMissingFileHandlerConfig(release).resolveFileOptions()...)
+			if err != nil {
+				return generatedFiles, err
+			}
+			if skip {
+				continue
+			}
+
+			if len(paths) > 1 {
+				return generatedFiles, fmt.Errorf("glob patterns in release values and secrets is not supported yet. please submit a feature request if necessary")
+			}
+			path := paths[0]
+
+			yamlBytes, err := st.renderValuesFileToBytesWithData(path, templateData)
+			if err != nil {
+				return generatedFiles, fmt.Errorf("failed to render values files \"%s\": %v", typedValue, err)
+			}
+
+			valfile, err := createTempValuesFile(release, yamlBytes)
+			if err != nil {
+				return generatedFiles, err
+			}
+			defer func() {
+				_ = valfile.Close()
+			}()
+
+			if _, err := valfile.Write(yamlBytes); err != nil {
+				return generatedFiles, fmt.Errorf("failed to write %s: %v", valfile.Name(), err)
+			}
+
+			st.logger.Debugf("Successfully generated the value file at %s. produced:\n%s", path, string(yamlBytes))
+
+			generatedFiles = append(generatedFiles, valfile.Name())
+		case map[any]any, map[string]any:
+			valfile, err := createTempValuesFile(release, typedValue)
+			if err != nil {
+				return generatedFiles, err
+			}
+			defer func() {
+				_ = valfile.Close()
+			}()
+
+			encoder := yaml.NewEncoder(valfile)
+			defer func() {
+				_ = encoder.Close()
+			}()
+
+			if err := encoder.Encode(typedValue); err != nil {
+				return generatedFiles, err
+			}
+
+			generatedFiles = append(generatedFiles, valfile.Name())
+		default:
+			return generatedFiles, fmt.Errorf("unexpected type of value: value=%v, type=%T", typedValue, typedValue)
+		}
+	}
+	return generatedFiles, nil
+}
+
 func (st *HelmState) newReleaseTemplateFuncMap(dir string) template.FuncMap {
 	r := tmpl.NewFileRenderer(st.fs, dir, nil)
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -4267,8 +4267,12 @@ func (st *HelmState) renderValuesFileToBytesWithData(path string, templateData r
 	return rawBytes, nil
 }
 
-func (st *HelmState) generateTemporaryReleaseValuesFilesWithData(release *ReleaseSpec, values []any, templateData releaseTemplateData) ([]string, error) {
+func (st *HelmState) generateTemporaryReleaseValuesFilesWithData(release *ReleaseSpec, values []any, getTemplateData func() (releaseTemplateData, error)) ([]string, error) {
 	return st.generateTemporaryReleaseValuesFilesCore(release, values, func(path string) ([]byte, error) {
+		templateData, err := getTemplateData()
+		if err != nil {
+			return nil, err
+		}
 		return st.renderValuesFileToBytesWithData(path, templateData)
 	})
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -4159,9 +4159,9 @@ func (st *HelmState) mergedReleaseTemplateData(release *ReleaseSpec) (releaseTem
 	return st.createReleaseTemplateData(release, mergedVals), nil
 }
 
-func (st *HelmState) resolveReleaseValues(release *ReleaseSpec) (map[string]any, error) {
-	merged := map[string]any{}
-
+// prepareReleaseValuesEntries normalizes release.Values path entries (applying ValuesPathPrefix)
+// and evaluates any vals ref+ secrets, returning the fully-rendered values slice ready for processing.
+func (st *HelmState) prepareReleaseValuesEntries(release *ReleaseSpec) ([]any, error) {
 	values := []any{}
 	for _, v := range release.Values {
 		switch typedValue := v.(type) {
@@ -4169,7 +4169,7 @@ func (st *HelmState) resolveReleaseValues(release *ReleaseSpec) (map[string]any,
 			path := st.storage().normalizePath(release.ValuesPathPrefix + typedValue)
 			values = append(values, path)
 		default:
-			values = append(values, v)
+			values = append(values, typedValue)
 		}
 	}
 
@@ -4181,6 +4181,17 @@ func (st *HelmState) resolveReleaseValues(release *ReleaseSpec) (map[string]any,
 	valuesSecretsRendered, ok := valuesMapSecretsRendered["values"].([]any)
 	if !ok {
 		return nil, fmt.Errorf("failed to render values in %s for release %s: type %T isn't supported", st.FilePath, release.Name, valuesMapSecretsRendered["values"])
+	}
+
+	return valuesSecretsRendered, nil
+}
+
+func (st *HelmState) resolveReleaseValues(release *ReleaseSpec) (map[string]any, error) {
+	merged := map[string]any{}
+
+	valuesSecretsRendered, err := st.prepareReleaseValuesEntries(release)
+	if err != nil {
+		return nil, err
 	}
 
 	for _, v := range valuesSecretsRendered {
@@ -4442,7 +4453,7 @@ func (st *HelmState) generateTemporaryReleaseValuesFilesCore(release *ReleaseSpe
 					return fmt.Errorf("failed to write %s: %v", valfile.Name(), err)
 				}
 
-				st.logger.Debugf("Successfully generated the value file at %s. produced:\n%s", path, string(yamlBytes))
+				st.logger.Debugf("Successfully generated the value file from %s to %s", path, valfile.Name())
 
 				generatedFiles = append(generatedFiles, valfile.Name())
 
@@ -4512,25 +4523,9 @@ func (st *HelmState) generateTemporaryReleaseValuesFilesCore(release *ReleaseSpe
 }
 
 func (st *HelmState) generateVanillaValuesFiles(release *ReleaseSpec) ([]string, error) {
-	values := []any{}
-	for _, v := range release.Values {
-		switch typedValue := v.(type) {
-		case string:
-			path := st.storage().normalizePath(release.ValuesPathPrefix + typedValue)
-			values = append(values, path)
-		default:
-			values = append(values, v)
-		}
-	}
-
-	valuesMapSecretsRendered, err := st.valsRuntime.Eval(map[string]any{"values": values})
+	valuesSecretsRendered, err := st.prepareReleaseValuesEntries(release)
 	if err != nil {
 		return nil, err
-	}
-
-	valuesSecretsRendered, ok := valuesMapSecretsRendered["values"].([]any)
-	if !ok {
-		return nil, fmt.Errorf("Failed to render values in %s for release %s: type %T isn't supported", st.FilePath, release.Name, valuesMapSecretsRendered["values"])
 	}
 
 	generatedFiles, err := st.generateTemporaryReleaseValuesFiles(release, valuesSecretsRendered)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -4214,12 +4214,20 @@ func (st *HelmState) resolveReleaseValues(release *ReleaseSpec) (map[string]any,
 				return nil, fmt.Errorf("failed to render values file \"%s\": %v", typedValue, err)
 			}
 
-			var vals map[string]any
-			if err := yaml.Unmarshal(yamlBytes, &vals); err != nil {
+			var rawVals map[string]any
+			if err := yaml.Unmarshal(yamlBytes, &rawVals); err != nil {
 				return nil, fmt.Errorf("failed to parse values file \"%s\": %v", typedValue, err)
 			}
 
-			merged = maputil.MergeMaps(merged, vals)
+			// Normalize nested keys: yaml v2 may produce map[any]any for nested maps.
+			// CastKeysToStrings recurses through both map[any]any and map[string]any so it is
+			// safe to call even when yaml v3 is in use and keys are already strings.
+			normalizedVals, err := maputil.CastKeysToStrings(rawVals)
+			if err != nil {
+				return nil, fmt.Errorf("failed to normalize keys in values file \"%s\": %v", typedValue, err)
+			}
+
+			merged = maputil.MergeMaps(merged, normalizedVals)
 		case map[any]any:
 			strMap, err := maputil.CastKeysToStrings(typedValue)
 			if err != nil {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -4211,12 +4211,12 @@ func (st *HelmState) resolveReleaseValues(release *ReleaseSpec) (map[string]any,
 
 			yamlBytes, err := st.RenderReleaseValuesFileToBytes(release, path)
 			if err != nil {
-				return nil, fmt.Errorf("failed to render values file \"%s\": %v", typedValue, err)
+				return nil, fmt.Errorf("failed to render values file \"%s\": %w", typedValue, err)
 			}
 
 			var rawVals map[string]any
 			if err := yaml.Unmarshal(yamlBytes, &rawVals); err != nil {
-				return nil, fmt.Errorf("failed to parse values file \"%s\": %v", typedValue, err)
+				return nil, fmt.Errorf("failed to parse values file \"%s\": %w", typedValue, err)
 			}
 
 			// Normalize nested keys: yaml v2 may produce map[any]any for nested maps.
@@ -4224,7 +4224,7 @@ func (st *HelmState) resolveReleaseValues(release *ReleaseSpec) (map[string]any,
 			// safe to call even when yaml v3 is in use and keys are already strings.
 			normalizedVals, err := maputil.CastKeysToStrings(rawVals)
 			if err != nil {
-				return nil, fmt.Errorf("failed to normalize keys in values file \"%s\": %v", typedValue, err)
+				return nil, fmt.Errorf("failed to normalize keys in values file \"%s\": %w", typedValue, err)
 			}
 
 			merged = maputil.MergeMaps(merged, normalizedVals)


### PR DESCRIPTION
## Summary

- Fix `.Values` in `jsonPatches`, `strategicMergePatches`, and `transformers` gotmpl files to include the release's own values (from `values:` entries), not just environment values
- Before this fix, `{{ .Values.ingress.enabled }}` in a patch template would fail with "map has no entry for key" when `ingress.enabled` was set in the release's values file
- After this fix, `.Values` in patch templates = merged(environment values, release values)

## Changes

- `pkg/state/state.go`: Added `resolveReleaseValues()`, `mergedReleaseTemplateData()`, `renderValuesFileToBytesWithData()`, `generateTemporaryReleaseValuesFilesWithData()` methods
- `pkg/state/helmx.go`: Modified `PrepareChartify` to compute merged template data before rendering patches
- `pkg/state/create_test.go`: Added 3 tests for the new behavior

Fixes #1904