### PR TITLE
fix: use --post-renderer-args=VALUE format to prevent Helm flag parsing failure

### DIFF
--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -3106,6 +3106,9 @@ func hasFlagWithValue(flags []string, flagName, value string) bool {
 		if f == flagName && i+1 < len(flags) && flags[i+1] == value {
 			return true
 		}
+		if f == flagName+"="+value {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -3100,7 +3100,8 @@ func newPostRendererTestApp(t *testing.T, files map[string]string) (*App, *mockH
 	return app, helm
 }
 
-// hasFlagWithValue reports whether flags contains "--flagName value" as adjacent entries.
+// hasFlagWithValue reports whether flags contains either "--flagName value" as adjacent entries
+// or "--flagName=value" as a single entry.
 func hasFlagWithValue(flags []string, flagName, value string) bool {
 	for i, f := range flags {
 		if f == flagName && i+1 < len(flags) && flags[i+1] == value {
@@ -3165,10 +3166,10 @@ releases:
 				t.Errorf("expected --post-renderer foo in flags, got %v", flags)
 			}
 			if !hasFlagWithValue(flags, "--post-renderer-args", "--arg1") {
-				t.Errorf("expected --post-renderer-args --arg1 in flags, got %v", flags)
+				t.Errorf("expected --post-renderer-args=--arg1 or --post-renderer-args --arg1 in flags, got %v", flags)
 			}
 			if !hasFlagWithValue(flags, "--post-renderer-args", "--arg2") {
-				t.Errorf("expected --post-renderer-args --arg2 in flags, got %v", flags)
+				t.Errorf("expected --post-renderer-args=--arg2 or --post-renderer-args --arg2 in flags, got %v", flags)
 			}
 		})
 	}
@@ -3222,7 +3223,7 @@ releases:
 
 			flags := helm.templated[0].flags
 			if !hasFlagWithValue(flags, "--post-renderer-args", "--cli-arg") {
-				t.Errorf("expected --post-renderer-args --cli-arg in flags (CLI should override helmDefaults), got %v", flags)
+				t.Errorf("expected --post-renderer-args=--cli-arg or --post-renderer-args --cli-arg in flags (CLI should override helmDefaults), got %v", flags)
 			}
 			if hasFlagWithValue(flags, "--post-renderer-args", "--default-arg") {
 				t.Errorf("unexpected --post-renderer-args --default-arg in flags (CLI should override helmDefaults), got %v", flags)
@@ -3279,7 +3280,7 @@ releases:
 
 			flags := helm.templated[0].flags
 			if !hasFlagWithValue(flags, "--post-renderer-args", "--release-arg") {
-				t.Errorf("expected --post-renderer-args --release-arg in flags (release should override CLI), got %v", flags)
+				t.Errorf("expected --post-renderer-args=--release-arg or --post-renderer-args --release-arg in flags (release should override CLI), got %v", flags)
 			}
 			if hasFlagWithValue(flags, "--post-renderer-args", "--cli-arg") {
 				t.Errorf("unexpected --post-renderer-args --cli-arg in flags (release should override CLI), got %v", flags)

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -127,7 +127,7 @@ func (st *HelmState) appendPostRenderArgsFlags(flags []string, release *ReleaseS
 	}
 	for _, arg := range postRendererArgsFlags {
 		if arg != "" {
-			flags = append(flags, "--post-renderer-args", arg)
+			flags = append(flags, "--post-renderer-args="+arg)
 		}
 	}
 	return flags

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -926,8 +926,8 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--post-renderer-args", "--arg1",
-				"--post-renderer-args", "--arg2",
+				"--post-renderer-args=--arg1",
+				"--post-renderer-args=--arg2",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -949,7 +949,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--post-renderer-args", "--release-arg",
+				"--post-renderer-args=--release-arg",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -972,7 +972,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--post-renderer-args", "--release-arg",
+				"--post-renderer-args=--release-arg",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -997,7 +997,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--post-renderer-args", "--cli-arg",
+				"--post-renderer-args=--cli-arg",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -1022,7 +1022,7 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--post-renderer-args", "--release-arg",
+				"--post-renderer-args=--release-arg",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -1340,8 +1340,8 @@ func TestHelmState_flagsForTemplate(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--post-renderer-args", "--arg1",
-				"--post-renderer-args", "--arg2",
+				"--post-renderer-args=--arg1",
+				"--post-renderer-args=--arg2",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -1363,7 +1363,7 @@ func TestHelmState_flagsForTemplate(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--post-renderer-args", "--release-arg",
+				"--post-renderer-args=--release-arg",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -1386,7 +1386,7 @@ func TestHelmState_flagsForTemplate(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--post-renderer-args", "--release-arg",
+				"--post-renderer-args=--release-arg",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -1411,7 +1411,7 @@ func TestHelmState_flagsForTemplate(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--post-renderer-args", "--cli-arg",
+				"--post-renderer-args=--cli-arg",
 				"--namespace", "test-namespace",
 			},
 		},
@@ -1436,7 +1436,7 @@ func TestHelmState_flagsForTemplate(t *testing.T) {
 			},
 			want: []string{
 				"--version", "0.1",
-				"--post-renderer-args", "--release-arg",
+				"--post-renderer-args=--release-arg",
 				"--namespace", "test-namespace",
 			},
 		},

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -1027,6 +1027,28 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 		},
 		{
+			name: "post-renderer-args-short-flag-value",
+			defaults: HelmSpec{
+				Verify:          false,
+				CreateNamespace: &enable,
+			},
+			version: semver.MustParse("3.10.0"),
+			release: &ReleaseSpec{
+				Chart:            "test/chart",
+				Version:          "0.1",
+				Verify:           &disable,
+				Name:             "test-charts",
+				Namespace:        "test-namespace",
+				CreateNamespace:  &disable,
+				PostRendererArgs: []string{"-v"},
+			},
+			want: []string{
+				"--version", "0.1",
+				"--post-renderer-args=-v",
+				"--namespace", "test-namespace",
+			},
+		},
+		{
 			name: "description-from-release",
 			defaults: HelmSpec{
 				Verify:          false,
@@ -1437,6 +1459,28 @@ func TestHelmState_flagsForTemplate(t *testing.T) {
 			want: []string{
 				"--version", "0.1",
 				"--post-renderer-args=--release-arg",
+				"--namespace", "test-namespace",
+			},
+		},
+		{
+			name: "post-renderer-args-short-flag-value",
+			defaults: HelmSpec{
+				Verify:          false,
+				CreateNamespace: &enable,
+			},
+			version: semver.MustParse("3.10.0"),
+			release: &ReleaseSpec{
+				Chart:            "test/chart",
+				Version:          "0.1",
+				Verify:           &disable,
+				Name:             "test-charts",
+				Namespace:        "test-namespace",
+				CreateNamespace:  &disable,
+				PostRendererArgs: []string{"-v"},
+			},
+			want: []string{
+				"--version", "0.1",
+				"--post-renderer-args=-v",
 				"--namespace", "test-namespace",
 			},
 		},


### PR DESCRIPTION
## Summary

- Changed `--post-renderer-args` to use `--post-renderer-args=VALUE` format instead of passing flag and value as separate arguments
- This prevents Helm from misinterpreting post-renderer args that look like flags (e.g. `-v`) as independent Helm flags

## Problem

When `postRendererArgs` contains values like short flags (e.g. `-v`), passing `--post-renderer-args` and the value as separate arguments causes Helm to interpret the value as its own flag:

```
--post-renderer foo --post-renderer-args -v --namespace ns
```

Helm sees `-v` as a standalone flag rather than the value for `--post-renderer-args`.

## Solution

Using the `--post-renderer-args=VALUE` format unambiguously binds the value to the flag:

```
--post-renderer foo --post-renderer-args=-v --namespace ns
```

Fixes #2563

Signed-off-by: opencode <opencode@users.noreply.github.com>