### PR TITLE
feat: add 'create' subcommand to scaffold helmfile deployment projects

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/helmfile/helmfile/pkg/app"
+	"github.com/helmfile/helmfile/pkg/config"
+)
+
+func NewCreateCmd(globalCfg *config.GlobalImpl) *cobra.Command {
+	options := config.NewCreateOptions()
+	cmd := &cobra.Command{
+		Use:   "create [NAME]",
+		Short: "Create a helmfile deployment project scaffold",
+		Long: `Create a helmfile deployment project with best-practice directory structure.
+
+Generates:
+  - helmfile.yaml          Main configuration with commented examples
+  - environments/           Environment-specific value files
+  - values/                 Release-specific value files
+
+If NAME is provided, creates the project in a new directory named NAME.
+Otherwise, creates the project in the current directory.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				options.Name = args[0]
+			}
+			createImpl := config.NewCreateImpl(globalCfg, options)
+			if err := createImpl.ValidateConfig(); err != nil {
+				return err
+			}
+			a := app.New(createImpl)
+			return toCLIError(createImpl.GlobalImpl, a.Create(createImpl))
+		},
+	}
+	f := cmd.Flags()
+	f.StringVarP(&options.OutputDir, "output-dir", "o", "", "Output directory (default: NAME or current directory)")
+	f.BoolVar(&options.Force, "force", false, "Overwrite existing helmfile.yaml")
+
+	return cmd
+}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -27,6 +27,9 @@ Otherwise, creates the project in the current directory.`,
 				options.Name = args[0]
 			}
 			createImpl := config.NewCreateImpl(globalCfg, options)
+			if err := config.NewCLIConfigImpl(createImpl.GlobalImpl); err != nil {
+				return err
+			}
 			if err := createImpl.ValidateConfig(); err != nil {
 				return err
 			}
@@ -36,7 +39,7 @@ Otherwise, creates the project in the current directory.`,
 	}
 	f := cmd.Flags()
 	f.StringVarP(&options.OutputDir, "output-dir", "o", "", "Output directory (default: NAME or current directory)")
-	f.BoolVar(&options.Force, "force", false, "Overwrite existing helmfile.yaml")
+	f.BoolVar(&options.Force, "force", false, "Overwrite existing scaffold files (helmfile.yaml, environments/default.yaml, values/.gitkeep)")
 
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,6 +92,7 @@ func NewRootCmd(globalConfig *config.GlobalOptions) (*cobra.Command, error) {
 	}
 
 	cmd.AddCommand(
+		NewCreateCmd(globalImpl),
 		NewInitCmd(globalImpl),
 		NewApplyCmd(globalImpl),
 		NewBuildCmd(globalImpl),

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -325,6 +325,14 @@ type InitConfigProvider interface {
 	Force() bool
 }
 
+type CreateConfigProvider interface {
+	Name() string
+	OutputDir() string
+	Force() bool
+
+	loggingConfig
+}
+
 type PrintEnvConfigProvider interface {
 	Output() string
 }

--- a/pkg/app/create.go
+++ b/pkg/app/create.go
@@ -69,7 +69,7 @@ func (a *App) Create(c CreateConfigProvider) error {
 	outputDir := c.OutputDir()
 	absDir, err := filepath.Abs(outputDir)
 	if err != nil {
-		return fmt.Errorf("failed to resolve output directory: %w", err)
+		return appError("", fmt.Errorf("failed to resolve output directory: %w", err))
 	}
 
 	// Scaffold file paths (intermediate directories may not exist yet).
@@ -87,18 +87,18 @@ func (a *App) Create(c CreateConfigProvider) error {
 			if statErr == nil {
 				existing = append(existing, p)
 			} else if !os.IsNotExist(statErr) {
-				return fmt.Errorf("failed to check %s: %w", p, statErr)
+				return appError("", fmt.Errorf("failed to check %s: %w", p, statErr))
 			}
 		}
 		if len(existing) > 0 {
-			return fmt.Errorf("the following files already exist, use --force to overwrite: %s", strings.Join(existing, ", "))
+			return appError("", fmt.Errorf("the following files already exist, use --force to overwrite: %s", strings.Join(existing, ", ")))
 		}
 	}
 
 	// Create directories.
 	for _, dir := range []string{absDir, filepath.Join(absDir, "environments"), filepath.Join(absDir, "values")} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+			return appError("", fmt.Errorf("failed to create directory %s: %w", dir, err))
 		}
 	}
 
@@ -113,7 +113,7 @@ func (a *App) Create(c CreateConfigProvider) error {
 	}
 	for _, f := range files {
 		if err := writeScaffoldFile(f.path, f.content, c.Force()); err != nil {
-			return fmt.Errorf("failed to write %s: %w", f.path, err)
+			return appError("", fmt.Errorf("failed to write %s: %w", f.path, err))
 		}
 		c.Logger().Infof("created %s", f.path)
 	}

--- a/pkg/app/create.go
+++ b/pkg/app/create.go
@@ -112,7 +112,7 @@ func (a *App) Create(c CreateConfigProvider) error {
 		{gitkeepPath, []byte("")},
 	}
 	for _, f := range files {
-		if err := os.WriteFile(f.path, f.content, 0o644); err != nil {
+		if err := writeScaffoldFile(f.path, f.content, c.Force()); err != nil {
 			return fmt.Errorf("failed to write %s: %w", f.path, err)
 		}
 		c.Logger().Infof("created %s", f.path)
@@ -120,4 +120,23 @@ func (a *App) Create(c CreateConfigProvider) error {
 
 	c.Logger().Infof("\nhelmfile project created in %s\n\nNext steps:\n  cd %s\n  # Edit helmfile.yaml to add your releases\n  helmfile apply", absDir, absDir)
 	return nil
+}
+
+// writeScaffoldFile writes content to path. When force is false it uses
+// O_EXCL so that a file appearing between the preflight check and the write
+// is caught rather than silently overwritten (TOCTOU protection).
+func writeScaffoldFile(path string, content []byte, force bool) error {
+	if force {
+		return os.WriteFile(path, content, 0o644)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	_, werr := f.Write(content)
+	cerr := f.Close()
+	if werr != nil {
+		return werr
+	}
+	return cerr
 }

--- a/pkg/app/create.go
+++ b/pkg/app/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -71,52 +72,51 @@ func (a *App) Create(c CreateConfigProvider) error {
 		return fmt.Errorf("failed to resolve output directory: %w", err)
 	}
 
-	if err := os.MkdirAll(absDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", absDir, err)
-	}
-
+	// Scaffold file paths (intermediate directories may not exist yet).
 	helmfilePath := filepath.Join(absDir, "helmfile.yaml")
-	if err := writeFileIfNotExists(helmfilePath, []byte(helmfileYAMLTemplate), c.Force()); err != nil {
-		return err
-	}
-	c.Logger().Infof("created %s", helmfilePath)
+	envFilePath := filepath.Join(absDir, "environments", "default.yaml")
+	gitkeepPath := filepath.Join(absDir, "values", ".gitkeep")
 
-	envDir := filepath.Join(absDir, "environments")
-	if err := os.MkdirAll(envDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", envDir, err)
-	}
-
-	envFilePath := filepath.Join(envDir, "default.yaml")
-	if err := writeFileIfNotExists(envFilePath, []byte(envDefaultYAMLTemplate), c.Force()); err != nil {
-		return err
-	}
-	c.Logger().Infof("created %s", envFilePath)
-
-	valuesDir := filepath.Join(absDir, "values")
-	if err := os.MkdirAll(valuesDir, 0o755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", valuesDir, err)
+	// Preflight: when --force is not set, check all scaffold paths before
+	// writing anything so the command fails atomically rather than leaving a
+	// partially-written project directory.
+	if !c.Force() {
+		var existing []string
+		for _, p := range []string{helmfilePath, envFilePath, gitkeepPath} {
+			if _, err := os.Stat(p); err == nil {
+				existing = append(existing, p)
+			}
+		}
+		if len(existing) > 0 {
+			return fmt.Errorf("the following files already exist, use --force to overwrite: %s", strings.Join(existing, ", "))
+		}
 	}
 
-	gitkeepPath := filepath.Join(valuesDir, ".gitkeep")
-	if err := writeFileIfNotExists(gitkeepPath, []byte(""), c.Force()); err != nil {
-		return err
+	// Create directories.
+	for _, dir := range []string{absDir, filepath.Join(absDir, "environments"), filepath.Join(absDir, "values")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dir, err)
+		}
 	}
-	c.Logger().Infof("created %s", gitkeepPath)
+
+	// Write scaffold files.
+	files := []struct {
+		path    string
+		content []byte
+	}{
+		{helmfilePath, []byte(helmfileYAMLTemplate)},
+		{envFilePath, []byte(envDefaultYAMLTemplate)},
+		{gitkeepPath, []byte("")},
+	}
+	for _, f := range files {
+		if err := os.WriteFile(f.path, f.content, 0o644); err != nil {
+			return fmt.Errorf("failed to write %s: %w", f.path, err)
+		}
+		c.Logger().Infof("created %s", f.path)
+	}
 
 	c.Logger().Infof("\nhelmfile project created in %s\n\nNext steps:\n  cd %s\n  # Edit helmfile.yaml to add your releases\n  helmfile apply", absDir, absDir)
 	return nil
 }
 
-// writeFileIfNotExists writes content to path. When force is false and the file
-// already exists, it returns an error instead of overwriting.
-func writeFileIfNotExists(path string, content []byte, force bool) error {
-	if !force {
-		if _, err := os.Stat(path); err == nil {
-			return fmt.Errorf("%s already exists, use --force to overwrite", path)
-		}
-	}
-	if err := os.WriteFile(path, content, 0o644); err != nil {
-		return fmt.Errorf("failed to write %s: %w", path, err)
-	}
-	return nil
-}
+

--- a/pkg/app/create.go
+++ b/pkg/app/create.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	helmfileYAMLTemplate = `# Helmfile configuration
+# Documentation: https://helmfile.readthedocs.io/
+
+# Common Helm defaults applied to all releases
+helmDefaults:
+  createNamespace: true
+  wait: true
+  timeout: 300
+
+# # Helm chart repositories
+# repositories:
+#   - name: bitnami
+#     url: https://charts.bitnami.com/bitnami
+#   - name: ingress-nginx
+#     url: https://kubernetes.github.io/ingress-nginx
+#   - name: prometheus-community
+#     url: https://prometheus-community.github.io/helm-charts
+
+# # Environment-specific values
+# # Usage: helmfile -e <environment> apply
+# environments:
+#   default:
+#     values:
+#       - environments/default.yaml
+#   staging:
+#     values:
+#       - environments/staging.yaml
+#   production:
+#     values:
+#       - environments/production.yaml
+
+# # Helm releases
+# releases:
+#   - name: my-app
+#     namespace: my-app
+#     chart: bitnami/nginx
+#     version: ~18.0.0
+#     values:
+#       - values/my-app.yaml
+#     # secrets:
+#     #   - secrets/my-app.yaml
+#     # hooks:
+#     #   - events: ["presync"]
+#     #     command: kubectl
+#     #     args: ["apply", "-f", "manifests/"]
+`
+
+	envDefaultYAMLTemplate = `# Default environment values
+# These values are available in helmfile.yaml as {{ .Values }}
+# Example:
+# replicaCount: 1
+# image:
+#   repository: nginx
+#   tag: latest
+`
+)
+
+func (a *App) Create(c CreateConfigProvider) error {
+	outputDir := c.OutputDir()
+	absDir, err := filepath.Abs(outputDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve output directory: %w", err)
+	}
+
+	if err := os.MkdirAll(absDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", absDir, err)
+	}
+
+	helmfilePath := filepath.Join(absDir, "helmfile.yaml")
+	if err := os.WriteFile(helmfilePath, []byte(helmfileYAMLTemplate), 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", helmfilePath, err)
+	}
+	c.Logger().Infof("created %s", helmfilePath)
+
+	envDir := filepath.Join(absDir, "environments")
+	if err := os.MkdirAll(envDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", envDir, err)
+	}
+
+	envFilePath := filepath.Join(envDir, "default.yaml")
+	if err := os.WriteFile(envFilePath, []byte(envDefaultYAMLTemplate), 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", envFilePath, err)
+	}
+	c.Logger().Infof("created %s", envFilePath)
+
+	valuesDir := filepath.Join(absDir, "values")
+	if err := os.MkdirAll(valuesDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", valuesDir, err)
+	}
+
+	gitkeepPath := filepath.Join(valuesDir, ".gitkeep")
+	if err := os.WriteFile(gitkeepPath, []byte(""), 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", gitkeepPath, err)
+	}
+	c.Logger().Infof("created %s", gitkeepPath)
+
+	c.Logger().Infof("\nhelmfile project created in %s\n\nNext steps:\n  cd %s\n  # Edit helmfile.yaml to add your releases\n  helmfile apply", absDir, absDir)
+	return nil
+}

--- a/pkg/app/create.go
+++ b/pkg/app/create.go
@@ -76,8 +76,8 @@ func (a *App) Create(c CreateConfigProvider) error {
 	}
 
 	helmfilePath := filepath.Join(absDir, "helmfile.yaml")
-	if err := os.WriteFile(helmfilePath, []byte(helmfileYAMLTemplate), 0o644); err != nil {
-		return fmt.Errorf("failed to write %s: %w", helmfilePath, err)
+	if err := writeFileIfNotExists(helmfilePath, []byte(helmfileYAMLTemplate), c.Force()); err != nil {
+		return err
 	}
 	c.Logger().Infof("created %s", helmfilePath)
 
@@ -87,8 +87,8 @@ func (a *App) Create(c CreateConfigProvider) error {
 	}
 
 	envFilePath := filepath.Join(envDir, "default.yaml")
-	if err := os.WriteFile(envFilePath, []byte(envDefaultYAMLTemplate), 0o644); err != nil {
-		return fmt.Errorf("failed to write %s: %w", envFilePath, err)
+	if err := writeFileIfNotExists(envFilePath, []byte(envDefaultYAMLTemplate), c.Force()); err != nil {
+		return err
 	}
 	c.Logger().Infof("created %s", envFilePath)
 
@@ -98,11 +98,25 @@ func (a *App) Create(c CreateConfigProvider) error {
 	}
 
 	gitkeepPath := filepath.Join(valuesDir, ".gitkeep")
-	if err := os.WriteFile(gitkeepPath, []byte(""), 0o644); err != nil {
-		return fmt.Errorf("failed to write %s: %w", gitkeepPath, err)
+	if err := writeFileIfNotExists(gitkeepPath, []byte(""), c.Force()); err != nil {
+		return err
 	}
 	c.Logger().Infof("created %s", gitkeepPath)
 
 	c.Logger().Infof("\nhelmfile project created in %s\n\nNext steps:\n  cd %s\n  # Edit helmfile.yaml to add your releases\n  helmfile apply", absDir, absDir)
+	return nil
+}
+
+// writeFileIfNotExists writes content to path. When force is false and the file
+// already exists, it returns an error instead of overwriting.
+func writeFileIfNotExists(path string, content []byte, force bool) error {
+	if !force {
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Errorf("%s already exists, use --force to overwrite", path)
+		}
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
 	return nil
 }

--- a/pkg/app/create.go
+++ b/pkg/app/create.go
@@ -131,6 +131,9 @@ func writeScaffoldFile(path string, content []byte, force bool) error {
 	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
 	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("file %s already exists, use --force to overwrite: %w", path, err)
+		}
 		return err
 	}
 	_, werr := f.Write(content)

--- a/pkg/app/create.go
+++ b/pkg/app/create.go
@@ -83,8 +83,11 @@ func (a *App) Create(c CreateConfigProvider) error {
 	if !c.Force() {
 		var existing []string
 		for _, p := range []string{helmfilePath, envFilePath, gitkeepPath} {
-			if _, err := os.Stat(p); err == nil {
+			_, statErr := os.Stat(p)
+			if statErr == nil {
 				existing = append(existing, p)
+			} else if !os.IsNotExist(statErr) {
+				return fmt.Errorf("failed to check %s: %w", p, statErr)
 			}
 		}
 		if len(existing) > 0 {
@@ -118,5 +121,3 @@ func (a *App) Create(c CreateConfigProvider) error {
 	c.Logger().Infof("\nhelmfile project created in %s\n\nNext steps:\n  cd %s\n  # Edit helmfile.yaml to add your releases\n  helmfile apply", absDir, absDir)
 	return nil
 }
-
-

--- a/pkg/app/create_test.go
+++ b/pkg/app/create_test.go
@@ -177,3 +177,32 @@ func assertFileExists(t *testing.T, path string) {
 	_, err := os.Stat(path)
 	assert.NoError(t, err, "file %s should exist", path)
 }
+
+func TestWriteScaffoldFile_CreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new.yaml")
+	require.NoError(t, writeScaffoldFile(path, []byte("hello"), false))
+	assertFileContent(t, path, "hello")
+}
+
+func TestWriteScaffoldFile_ExistingFileNoForce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("original"), 0o644))
+
+	err := writeScaffoldFile(path, []byte("new"), false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--force")
+
+	// Original content must be unchanged.
+	assertFileContent(t, path, "original")
+}
+
+func TestWriteScaffoldFile_ExistingFileWithForce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("original"), 0o644))
+
+	require.NoError(t, writeScaffoldFile(path, []byte("new"), true))
+	assertFileContent(t, path, "new")
+}

--- a/pkg/app/create_test.go
+++ b/pkg/app/create_test.go
@@ -70,7 +70,7 @@ func TestCreate_ExistingHelmfileYAMLNoForce(t *testing.T) {
 
 	err := a.Create(cfg)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already exists")
+	assert.Contains(t, err.Error(), "already exist")
 	assert.Contains(t, err.Error(), "--force")
 
 	// Verify the existing file was not overwritten.
@@ -90,7 +90,7 @@ func TestCreate_ExistingEnvDefaultYAMLNoForce(t *testing.T) {
 
 	err := a.Create(cfg)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already exists")
+	assert.Contains(t, err.Error(), "already exist")
 	assert.Contains(t, err.Error(), "--force")
 
 	// Verify the existing file was not overwritten.
@@ -110,13 +110,34 @@ func TestCreate_ExistingGitkeepNoForce(t *testing.T) {
 
 	err := a.Create(cfg)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already exists")
+	assert.Contains(t, err.Error(), "already exist")
 	assert.Contains(t, err.Error(), "--force")
 
 	// Verify the existing file was not overwritten.
 	content, readErr := os.ReadFile(filepath.Join(valuesDir, ".gitkeep"))
 	require.NoError(t, readErr)
 	assert.Equal(t, "existing", string(content))
+}
+
+// TestCreate_PreflightAtomicOnLaterConflict verifies that when only a later
+// scaffold file exists (e.g. environments/default.yaml but not helmfile.yaml),
+// the preflight check catches it and no files are written at all.
+func TestCreate_PreflightAtomicOnLaterConflict(t *testing.T) {
+	dir := t.TempDir()
+	envDir := filepath.Join(dir, "environments")
+	require.NoError(t, os.MkdirAll(envDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(envDir, "default.yaml"), []byte("existing"), 0o644))
+
+	a := &App{}
+	cfg := newMockCreateConfig(dir, false)
+
+	err := a.Create(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exist")
+
+	// helmfile.yaml must NOT have been created (preflight aborted before any write).
+	_, statErr := os.Stat(filepath.Join(dir, "helmfile.yaml"))
+	assert.True(t, os.IsNotExist(statErr), "helmfile.yaml should not have been created")
 }
 
 func TestCreate_ExistingFilesWithForce(t *testing.T) {

--- a/pkg/app/create_test.go
+++ b/pkg/app/create_test.go
@@ -1,0 +1,158 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// mockCreateConfigProvider is a test double for CreateConfigProvider.
+type mockCreateConfigProvider struct {
+	name      string
+	outputDir string
+	force     bool
+	logger    *zap.SugaredLogger
+}
+
+func (m *mockCreateConfigProvider) Name() string      { return m.name }
+func (m *mockCreateConfigProvider) OutputDir() string { return m.outputDir }
+func (m *mockCreateConfigProvider) Force() bool       { return m.force }
+func (m *mockCreateConfigProvider) Logger() *zap.SugaredLogger {
+	if m.logger != nil {
+		return m.logger
+	}
+	return newTestLogger()
+}
+
+func newMockCreateConfig(outputDir string, force bool) *mockCreateConfigProvider {
+	return &mockCreateConfigProvider{outputDir: outputDir, force: force}
+}
+
+func TestCreate_NewDirectory(t *testing.T) {
+	dir := t.TempDir()
+	outDir := filepath.Join(dir, "myproject")
+
+	a := &App{}
+	cfg := newMockCreateConfig(outDir, false)
+
+	require.NoError(t, a.Create(cfg))
+
+	// Verify all scaffold files were created.
+	assertFileContent(t, filepath.Join(outDir, "helmfile.yaml"), helmfileYAMLTemplate)
+	assertFileContent(t, filepath.Join(outDir, "environments", "default.yaml"), envDefaultYAMLTemplate)
+	assertFileExists(t, filepath.Join(outDir, "values", ".gitkeep"))
+}
+
+func TestCreate_CurrentDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	a := &App{}
+	cfg := newMockCreateConfig(dir, false)
+
+	require.NoError(t, a.Create(cfg))
+
+	assertFileContent(t, filepath.Join(dir, "helmfile.yaml"), helmfileYAMLTemplate)
+	assertFileContent(t, filepath.Join(dir, "environments", "default.yaml"), envDefaultYAMLTemplate)
+	assertFileExists(t, filepath.Join(dir, "values", ".gitkeep"))
+}
+
+func TestCreate_ExistingHelmfileYAMLNoForce(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-create helmfile.yaml
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "helmfile.yaml"), []byte("existing"), 0o644))
+
+	a := &App{}
+	cfg := newMockCreateConfig(dir, false)
+
+	err := a.Create(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+	assert.Contains(t, err.Error(), "--force")
+
+	// Verify the existing file was not overwritten.
+	content, readErr := os.ReadFile(filepath.Join(dir, "helmfile.yaml"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "existing", string(content))
+}
+
+func TestCreate_ExistingEnvDefaultYAMLNoForce(t *testing.T) {
+	dir := t.TempDir()
+	envDir := filepath.Join(dir, "environments")
+	require.NoError(t, os.MkdirAll(envDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(envDir, "default.yaml"), []byte("existing"), 0o644))
+
+	a := &App{}
+	cfg := newMockCreateConfig(dir, false)
+
+	err := a.Create(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+	assert.Contains(t, err.Error(), "--force")
+
+	// Verify the existing file was not overwritten.
+	content, readErr := os.ReadFile(filepath.Join(envDir, "default.yaml"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "existing", string(content))
+}
+
+func TestCreate_ExistingGitkeepNoForce(t *testing.T) {
+	dir := t.TempDir()
+	valuesDir := filepath.Join(dir, "values")
+	require.NoError(t, os.MkdirAll(valuesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(valuesDir, ".gitkeep"), []byte("existing"), 0o644))
+
+	a := &App{}
+	cfg := newMockCreateConfig(dir, false)
+
+	err := a.Create(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+	assert.Contains(t, err.Error(), "--force")
+
+	// Verify the existing file was not overwritten.
+	content, readErr := os.ReadFile(filepath.Join(valuesDir, ".gitkeep"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "existing", string(content))
+}
+
+func TestCreate_ExistingFilesWithForce(t *testing.T) {
+	dir := t.TempDir()
+
+	// Pre-create all scaffold files with different content.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "helmfile.yaml"), []byte("old"), 0o644))
+	envDir := filepath.Join(dir, "environments")
+	require.NoError(t, os.MkdirAll(envDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(envDir, "default.yaml"), []byte("old"), 0o644))
+	valuesDir := filepath.Join(dir, "values")
+	require.NoError(t, os.MkdirAll(valuesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(valuesDir, ".gitkeep"), []byte("old"), 0o644))
+
+	a := &App{}
+	cfg := newMockCreateConfig(dir, true)
+
+	require.NoError(t, a.Create(cfg))
+
+	// Verify scaffold files were overwritten with the template content.
+	assertFileContent(t, filepath.Join(dir, "helmfile.yaml"), helmfileYAMLTemplate)
+	assertFileContent(t, filepath.Join(dir, "environments", "default.yaml"), envDefaultYAMLTemplate)
+	assertFileExists(t, filepath.Join(dir, "values", ".gitkeep"))
+}
+
+// assertFileContent asserts that the file at path exists and contains wantContent.
+func assertFileContent(t *testing.T, path, wantContent string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "file %s should exist", path)
+	assert.Equal(t, wantContent, string(content))
+}
+
+// assertFileExists asserts that the file at path exists.
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.NoError(t, err, "file %s should exist", path)
+}

--- a/pkg/config/create.go
+++ b/pkg/config/create.go
@@ -65,10 +65,20 @@ func (c *CreateImpl) ValidateConfig() error {
 	if err != nil {
 		return fmt.Errorf("failed to resolve output directory: %w", err)
 	}
-	helmfilePath := filepath.Join(absDir, "helmfile.yaml")
 	if !c.Force() {
-		if _, err := os.Stat(helmfilePath); err == nil {
-			return fmt.Errorf("helmfile.yaml already exists in %s, use --force to overwrite", absDir)
+		scaffoldPaths := []string{
+			filepath.Join(absDir, "helmfile.yaml"),
+			filepath.Join(absDir, "environments", "default.yaml"),
+			filepath.Join(absDir, "values", ".gitkeep"),
+		}
+		var existing []string
+		for _, p := range scaffoldPaths {
+			if _, err := os.Stat(p); err == nil {
+				existing = append(existing, p)
+			}
+		}
+		if len(existing) > 0 {
+			return fmt.Errorf("the following files already exist in %s, use --force to overwrite: %s", absDir, strings.Join(existing, ", "))
 		}
 	}
 	return nil

--- a/pkg/config/create.go
+++ b/pkg/config/create.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -58,30 +56,6 @@ func (c *CreateImpl) ValidateConfig() error {
 		}
 		if strings.TrimSpace(name) == "" {
 			return fmt.Errorf("project name must not be empty or whitespace only")
-		}
-	}
-	outputDir := c.OutputDir()
-	absDir, err := filepath.Abs(outputDir)
-	if err != nil {
-		return fmt.Errorf("failed to resolve output directory: %w", err)
-	}
-	if !c.Force() {
-		scaffoldPaths := []string{
-			filepath.Join(absDir, "helmfile.yaml"),
-			filepath.Join(absDir, "environments", "default.yaml"),
-			filepath.Join(absDir, "values", ".gitkeep"),
-		}
-		var existing []string
-		for _, p := range scaffoldPaths {
-			_, statErr := os.Stat(p)
-			if statErr == nil {
-				existing = append(existing, p)
-			} else if !os.IsNotExist(statErr) {
-				return fmt.Errorf("failed to check %s: %w", p, statErr)
-			}
-		}
-		if len(existing) > 0 {
-			return fmt.Errorf("the following files already exist, use --force to overwrite: %s", strings.Join(existing, ", "))
 		}
 	}
 	return c.GlobalImpl.ValidateConfig()

--- a/pkg/config/create.go
+++ b/pkg/config/create.go
@@ -81,5 +81,5 @@ func (c *CreateImpl) ValidateConfig() error {
 			return fmt.Errorf("the following files already exist, use --force to overwrite: %s", strings.Join(existing, ", "))
 		}
 	}
-	return nil
+	return c.GlobalImpl.ValidateConfig()
 }

--- a/pkg/config/create.go
+++ b/pkg/config/create.go
@@ -78,7 +78,7 @@ func (c *CreateImpl) ValidateConfig() error {
 			}
 		}
 		if len(existing) > 0 {
-			return fmt.Errorf("the following files already exist in %s, use --force to overwrite: %s", absDir, strings.Join(existing, ", "))
+			return fmt.Errorf("the following files already exist, use --force to overwrite: %s", strings.Join(existing, ", "))
 		}
 	}
 	return nil

--- a/pkg/config/create.go
+++ b/pkg/config/create.go
@@ -51,7 +51,7 @@ func (c *CreateImpl) ValidateConfig() error {
 		if strings.ContainsAny(name, "/\\") {
 			return fmt.Errorf("invalid project name %q: must not contain path separators", name)
 		}
-		if name == ".." {
+		if name == ".." || name == "." {
 			return fmt.Errorf("invalid project name %q", name)
 		}
 		if strings.TrimSpace(name) == "" {

--- a/pkg/config/create.go
+++ b/pkg/config/create.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type CreateOptions struct {
+	Name      string
+	OutputDir string
+	Force     bool
+}
+
+func NewCreateOptions() *CreateOptions {
+	return &CreateOptions{}
+}
+
+type CreateImpl struct {
+	*GlobalImpl
+	*CreateOptions
+}
+
+func NewCreateImpl(g *GlobalImpl, o *CreateOptions) *CreateImpl {
+	return &CreateImpl{
+		GlobalImpl:    g,
+		CreateOptions: o,
+	}
+}
+
+func (c *CreateImpl) Name() string {
+	return c.CreateOptions.Name
+}
+
+func (c *CreateImpl) OutputDir() string {
+	if c.CreateOptions.OutputDir != "" {
+		return c.CreateOptions.OutputDir
+	}
+	if c.CreateOptions.Name != "" {
+		return c.CreateOptions.Name
+	}
+	return "."
+}
+
+func (c *CreateImpl) Force() bool {
+	return c.CreateOptions.Force
+}
+
+func (c *CreateImpl) ValidateConfig() error {
+	name := c.CreateOptions.Name
+	if name != "" {
+		if strings.ContainsAny(name, "/\\") {
+			return fmt.Errorf("invalid project name %q: must not contain path separators", name)
+		}
+		if name == ".." {
+			return fmt.Errorf("invalid project name %q", name)
+		}
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("project name must not be empty or whitespace only")
+		}
+	}
+	outputDir := c.OutputDir()
+	absDir, err := filepath.Abs(outputDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve output directory: %w", err)
+	}
+	helmfilePath := filepath.Join(absDir, "helmfile.yaml")
+	if !c.Force() {
+		if _, err := os.Stat(helmfilePath); err == nil {
+			return fmt.Errorf("helmfile.yaml already exists in %s, use --force to overwrite", absDir)
+		}
+	}
+	return nil
+}

--- a/pkg/config/create.go
+++ b/pkg/config/create.go
@@ -73,8 +73,11 @@ func (c *CreateImpl) ValidateConfig() error {
 		}
 		var existing []string
 		for _, p := range scaffoldPaths {
-			if _, err := os.Stat(p); err == nil {
+			_, statErr := os.Stat(p)
+			if statErr == nil {
 				existing = append(existing, p)
+			} else if !os.IsNotExist(statErr) {
+				return fmt.Errorf("failed to check %s: %w", p, statErr)
 			}
 		}
 		if len(existing) > 0 {

--- a/pkg/config/create_test.go
+++ b/pkg/config/create_test.go
@@ -36,6 +36,13 @@ func TestCreateImpl_ValidateConfig_NameDotDot(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid project name")
 }
 
+func TestCreateImpl_ValidateConfig_NameDot(t *testing.T) {
+	c := newTestCreateImplWithDefaults(".", "", false)
+	err := c.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid project name")
+}
+
 func TestCreateImpl_ValidateConfig_WhitespaceOnlyName(t *testing.T) {
 	c := newTestCreateImplWithDefaults("   ", "", false)
 	err := c.ValidateConfig()

--- a/pkg/config/create_test.go
+++ b/pkg/config/create_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestCreateImpl(name, outputDir string, force bool) *CreateImpl {
+func newTestCreateImplWithDefaults(name, outputDir string, force bool) *CreateImpl {
 	return NewCreateImpl(NewGlobalImpl(&GlobalOptions{}), &CreateOptions{
 		Name:      name,
 		OutputDir: outputDir,
@@ -18,21 +18,21 @@ func newTestCreateImpl(name, outputDir string, force bool) *CreateImpl {
 }
 
 func TestCreateImpl_ValidateConfig_NameWithForwardSlash(t *testing.T) {
-	c := newTestCreateImpl("foo/bar", "", false)
+	c := newTestCreateImplWithDefaults("foo/bar", "", false)
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not contain path separators")
 }
 
 func TestCreateImpl_ValidateConfig_NameWithBackslash(t *testing.T) {
-	c := newTestCreateImpl(`foo\bar`, "", false)
+	c := newTestCreateImplWithDefaults(`foo\bar`, "", false)
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not contain path separators")
 }
 
 func TestCreateImpl_ValidateConfig_NameDotDot(t *testing.T) {
-	c := newTestCreateImpl("..", "", false)
+	c := newTestCreateImplWithDefaults("..", "", false)
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid project name")
@@ -40,8 +40,9 @@ func TestCreateImpl_ValidateConfig_NameDotDot(t *testing.T) {
 
 func TestCreateImpl_ValidateConfig_ValidName(t *testing.T) {
 	dir := t.TempDir()
-	c := newTestCreateImpl("myproject", dir, false)
-	// outputDir is set explicitly so no files will be checked under "myproject"
+	// outputDir points to an empty temp dir so no scaffold files exist and the
+	// name validation succeeds cleanly.
+	c := newTestCreateImplWithDefaults("myproject", dir, false)
 	require.NoError(t, c.ValidateConfig())
 }
 
@@ -49,7 +50,7 @@ func TestCreateImpl_ValidateConfig_ExistingHelmfileYAMLNoForce(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "helmfile.yaml"), []byte("x"), 0o644))
 
-	c := newTestCreateImpl("", dir, false)
+	c := newTestCreateImplWithDefaults("", dir, false)
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exist")
@@ -62,7 +63,7 @@ func TestCreateImpl_ValidateConfig_ExistingEnvDefaultYAMLNoForce(t *testing.T) {
 	require.NoError(t, os.MkdirAll(envDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(envDir, "default.yaml"), []byte("x"), 0o644))
 
-	c := newTestCreateImpl("", dir, false)
+	c := newTestCreateImplWithDefaults("", dir, false)
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exist")
@@ -75,7 +76,7 @@ func TestCreateImpl_ValidateConfig_ExistingGitkeepNoForce(t *testing.T) {
 	require.NoError(t, os.MkdirAll(valuesDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(valuesDir, ".gitkeep"), []byte(""), 0o644))
 
-	c := newTestCreateImpl("", dir, false)
+	c := newTestCreateImplWithDefaults("", dir, false)
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already exist")
@@ -89,7 +90,7 @@ func TestCreateImpl_ValidateConfig_ExistingFilesWithForce(t *testing.T) {
 	require.NoError(t, os.MkdirAll(envDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(envDir, "default.yaml"), []byte("x"), 0o644))
 
-	c := newTestCreateImpl("", dir, true)
+	c := newTestCreateImplWithDefaults("", dir, true)
 	require.NoError(t, c.ValidateConfig())
 }
 

--- a/pkg/config/create_test.go
+++ b/pkg/config/create_test.go
@@ -38,6 +38,13 @@ func TestCreateImpl_ValidateConfig_NameDotDot(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid project name")
 }
 
+func TestCreateImpl_ValidateConfig_WhitespaceOnlyName(t *testing.T) {
+	c := newTestCreateImplWithDefaults("   ", "", false)
+	err := c.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be empty or whitespace only")
+}
+
 func TestCreateImpl_ValidateConfig_ValidName(t *testing.T) {
 	dir := t.TempDir()
 	// outputDir points to an empty temp dir so no scaffold files exist and the

--- a/pkg/config/create_test.go
+++ b/pkg/config/create_test.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,58 +44,7 @@ func TestCreateImpl_ValidateConfig_WhitespaceOnlyName(t *testing.T) {
 }
 
 func TestCreateImpl_ValidateConfig_ValidName(t *testing.T) {
-	dir := t.TempDir()
-	// outputDir points to an empty temp dir so no scaffold files exist and the
-	// name validation succeeds cleanly.
-	c := newTestCreateImplWithDefaults("myproject", dir, false)
-	require.NoError(t, c.ValidateConfig())
-}
-
-func TestCreateImpl_ValidateConfig_ExistingHelmfileYAMLNoForce(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "helmfile.yaml"), []byte("x"), 0o644))
-
-	c := newTestCreateImplWithDefaults("", dir, false)
-	err := c.ValidateConfig()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already exist")
-	assert.Contains(t, err.Error(), "--force")
-}
-
-func TestCreateImpl_ValidateConfig_ExistingEnvDefaultYAMLNoForce(t *testing.T) {
-	dir := t.TempDir()
-	envDir := filepath.Join(dir, "environments")
-	require.NoError(t, os.MkdirAll(envDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(envDir, "default.yaml"), []byte("x"), 0o644))
-
-	c := newTestCreateImplWithDefaults("", dir, false)
-	err := c.ValidateConfig()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already exist")
-	assert.Contains(t, err.Error(), "--force")
-}
-
-func TestCreateImpl_ValidateConfig_ExistingGitkeepNoForce(t *testing.T) {
-	dir := t.TempDir()
-	valuesDir := filepath.Join(dir, "values")
-	require.NoError(t, os.MkdirAll(valuesDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(valuesDir, ".gitkeep"), []byte(""), 0o644))
-
-	c := newTestCreateImplWithDefaults("", dir, false)
-	err := c.ValidateConfig()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already exist")
-	assert.Contains(t, err.Error(), "--force")
-}
-
-func TestCreateImpl_ValidateConfig_ExistingFilesWithForce(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "helmfile.yaml"), []byte("x"), 0o644))
-	envDir := filepath.Join(dir, "environments")
-	require.NoError(t, os.MkdirAll(envDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(envDir, "default.yaml"), []byte("x"), 0o644))
-
-	c := newTestCreateImplWithDefaults("", dir, true)
+	c := newTestCreateImplWithDefaults("myproject", "", false)
 	require.NoError(t, c.ValidateConfig())
 }
 
@@ -105,7 +52,7 @@ func TestCreateImpl_ValidateConfig_GlobalColorConflict(t *testing.T) {
 	// Delegates to GlobalImpl.ValidateConfig which rejects --color + --no-color.
 	c := NewCreateImpl(
 		NewGlobalImpl(&GlobalOptions{Color: true, NoColor: true}),
-		&CreateOptions{OutputDir: t.TempDir()},
+		&CreateOptions{},
 	)
 	err := c.ValidateConfig()
 	require.Error(t, err)

--- a/pkg/config/create_test.go
+++ b/pkg/config/create_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCreateImpl(name, outputDir string, force bool) *CreateImpl {
+	return NewCreateImpl(NewGlobalImpl(&GlobalOptions{}), &CreateOptions{
+		Name:      name,
+		OutputDir: outputDir,
+		Force:     force,
+	})
+}
+
+func TestCreateImpl_ValidateConfig_NameWithForwardSlash(t *testing.T) {
+	c := newTestCreateImpl("foo/bar", "", false)
+	err := c.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not contain path separators")
+}
+
+func TestCreateImpl_ValidateConfig_NameWithBackslash(t *testing.T) {
+	c := newTestCreateImpl(`foo\bar`, "", false)
+	err := c.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not contain path separators")
+}
+
+func TestCreateImpl_ValidateConfig_NameDotDot(t *testing.T) {
+	c := newTestCreateImpl("..", "", false)
+	err := c.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid project name")
+}
+
+func TestCreateImpl_ValidateConfig_ValidName(t *testing.T) {
+	dir := t.TempDir()
+	c := newTestCreateImpl("myproject", dir, false)
+	// outputDir is set explicitly so no files will be checked under "myproject"
+	require.NoError(t, c.ValidateConfig())
+}
+
+func TestCreateImpl_ValidateConfig_ExistingHelmfileYAMLNoForce(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "helmfile.yaml"), []byte("x"), 0o644))
+
+	c := newTestCreateImpl("", dir, false)
+	err := c.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exist")
+	assert.Contains(t, err.Error(), "--force")
+}
+
+func TestCreateImpl_ValidateConfig_ExistingEnvDefaultYAMLNoForce(t *testing.T) {
+	dir := t.TempDir()
+	envDir := filepath.Join(dir, "environments")
+	require.NoError(t, os.MkdirAll(envDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(envDir, "default.yaml"), []byte("x"), 0o644))
+
+	c := newTestCreateImpl("", dir, false)
+	err := c.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exist")
+	assert.Contains(t, err.Error(), "--force")
+}
+
+func TestCreateImpl_ValidateConfig_ExistingGitkeepNoForce(t *testing.T) {
+	dir := t.TempDir()
+	valuesDir := filepath.Join(dir, "values")
+	require.NoError(t, os.MkdirAll(valuesDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(valuesDir, ".gitkeep"), []byte(""), 0o644))
+
+	c := newTestCreateImpl("", dir, false)
+	err := c.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exist")
+	assert.Contains(t, err.Error(), "--force")
+}
+
+func TestCreateImpl_ValidateConfig_ExistingFilesWithForce(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "helmfile.yaml"), []byte("x"), 0o644))
+	envDir := filepath.Join(dir, "environments")
+	require.NoError(t, os.MkdirAll(envDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(envDir, "default.yaml"), []byte("x"), 0o644))
+
+	c := newTestCreateImpl("", dir, true)
+	require.NoError(t, c.ValidateConfig())
+}
+
+func TestCreateImpl_ValidateConfig_GlobalColorConflict(t *testing.T) {
+	// Delegates to GlobalImpl.ValidateConfig which rejects --color + --no-color.
+	c := NewCreateImpl(
+		NewGlobalImpl(&GlobalOptions{Color: true, NoColor: true}),
+		&CreateOptions{OutputDir: t.TempDir()},
+	)
+	err := c.ValidateConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--color")
+	assert.Contains(t, err.Error(), "--no-color")
+}

--- a/pkg/config/create_test.go
+++ b/pkg/config/create_test.go
@@ -7,50 +7,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestCreateImplWithDefaults(name string, force bool) *CreateImpl {
+func newTestCreateImplWithDefaults(name string) *CreateImpl {
 	return NewCreateImpl(NewGlobalImpl(&GlobalOptions{}), &CreateOptions{
-		Name:  name,
-		Force: force,
+		Name: name,
 	})
 }
 
 func TestCreateImpl_ValidateConfig_NameWithForwardSlash(t *testing.T) {
-	c := newTestCreateImplWithDefaults("foo/bar", false)
+	c := newTestCreateImplWithDefaults("foo/bar")
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not contain path separators")
 }
 
 func TestCreateImpl_ValidateConfig_NameWithBackslash(t *testing.T) {
-	c := newTestCreateImplWithDefaults(`foo\bar`, false)
+	c := newTestCreateImplWithDefaults(`foo\bar`)
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not contain path separators")
 }
 
 func TestCreateImpl_ValidateConfig_NameDotDot(t *testing.T) {
-	c := newTestCreateImplWithDefaults("..", false)
+	c := newTestCreateImplWithDefaults("..")
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid project name")
 }
 
 func TestCreateImpl_ValidateConfig_NameDot(t *testing.T) {
-	c := newTestCreateImplWithDefaults(".", false)
+	c := newTestCreateImplWithDefaults(".")
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid project name")
 }
 
 func TestCreateImpl_ValidateConfig_WhitespaceOnlyName(t *testing.T) {
-	c := newTestCreateImplWithDefaults("   ", false)
+	c := newTestCreateImplWithDefaults("   ")
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not be empty or whitespace only")
 }
 
 func TestCreateImpl_ValidateConfig_ValidName(t *testing.T) {
-	c := newTestCreateImplWithDefaults("myproject", false)
+	c := newTestCreateImplWithDefaults("myproject")
 	require.NoError(t, c.ValidateConfig())
 }
 

--- a/pkg/config/create_test.go
+++ b/pkg/config/create_test.go
@@ -7,51 +7,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestCreateImplWithDefaults(name, outputDir string, force bool) *CreateImpl {
+func newTestCreateImplWithDefaults(name string, force bool) *CreateImpl {
 	return NewCreateImpl(NewGlobalImpl(&GlobalOptions{}), &CreateOptions{
-		Name:      name,
-		OutputDir: outputDir,
-		Force:     force,
+		Name:  name,
+		Force: force,
 	})
 }
 
 func TestCreateImpl_ValidateConfig_NameWithForwardSlash(t *testing.T) {
-	c := newTestCreateImplWithDefaults("foo/bar", "", false)
+	c := newTestCreateImplWithDefaults("foo/bar", false)
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not contain path separators")
 }
 
 func TestCreateImpl_ValidateConfig_NameWithBackslash(t *testing.T) {
-	c := newTestCreateImplWithDefaults(`foo\bar`, "", false)
+	c := newTestCreateImplWithDefaults(`foo\bar`, false)
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not contain path separators")
 }
 
 func TestCreateImpl_ValidateConfig_NameDotDot(t *testing.T) {
-	c := newTestCreateImplWithDefaults("..", "", false)
+	c := newTestCreateImplWithDefaults("..", false)
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid project name")
 }
 
 func TestCreateImpl_ValidateConfig_NameDot(t *testing.T) {
-	c := newTestCreateImplWithDefaults(".", "", false)
+	c := newTestCreateImplWithDefaults(".", false)
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid project name")
 }
 
 func TestCreateImpl_ValidateConfig_WhitespaceOnlyName(t *testing.T) {
-	c := newTestCreateImplWithDefaults("   ", "", false)
+	c := newTestCreateImplWithDefaults("   ", false)
 	err := c.ValidateConfig()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must not be empty or whitespace only")
 }
 
 func TestCreateImpl_ValidateConfig_ValidName(t *testing.T) {
-	c := newTestCreateImplWithDefaults("myproject", "", false)
+	c := newTestCreateImplWithDefaults("myproject", false)
 	require.NoError(t, c.ValidateConfig())
 }
 


### PR DESCRIPTION
## Summary

- Add `helmfile create [NAME]` subcommand that generates a best-practice helmfile project scaffold
- Generates `helmfile.yaml` (with commented examples for helmDefaults, repositories, environments, releases), `environments/default.yaml`, and `values/.gitkeep`
- Supports `--output-dir/-o` for custom output path, `--force` to overwrite existing files, and validates project name against path traversal

## Usage

```bash
helmfile create myproject          # creates ./myproject/ with scaffold
helmfile create                     # creates scaffold in current directory
helmfile create -o /custom/path    # creates scaffold in custom path
helmfile create myproject --force  # overwrite existing helmfile.yaml
```

## Generated structure

```
myproject/
├── helmfile.yaml           # Main config with commented examples
├── environments/
│   └── default.yaml        # Default environment values
└── values/
    └── .gitkeep            # Placeholder for release values
```

## Test plan

- [x] `helmfile create myproject` creates correct directory structure
- [x] `helmfile create` creates scaffold in current directory
- [x] `--output-dir` flag overrides output path
- [x] Duplicate detection refuses without `--force`, allows with `--force`
- [x] Invalid names with path separators (`../`, `/`) are rejected
- [x] `go vet` passes
- [x] `go build` succeeds