### PR TITLE
fix(state): resolve OCI repo prefix in ad-hoc release dependencies

### DIFF
--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -427,6 +427,9 @@ func (st *HelmState) PrepareChartify(helm helmexec.Interface, release *ReleaseSp
 			if err != nil {
 				return nil, clean, err
 			}
+		} else if rewritten, ok := st.resolveOCIAdhocDepChart(d.Chart); ok {
+			st.logger.Debugf("ad-hoc dependency %q rewritten to %q (matched OCI repo entry)", d.Chart, rewritten)
+			chart = rewritten
 		}
 
 		c.Opts.AdhocChartDependencies = append(c.Opts.AdhocChartDependencies, chartify.ChartDependency{

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1392,6 +1392,28 @@ func (st *HelmState) GetRepositoryAndNameFromChartName(chartName string) (*Repos
 	return nil, chartName
 }
 
+// resolveOCIAdhocDepChart rewrites a release `dependencies[].chart` value that
+// uses the named-repo prefix form ("repoName/chartName") into a full oci:// URL
+// when the prefix matches a `repositories:` entry with `oci: true`. It returns
+// (rewritten, true) on a hit and ("", false) otherwise.
+//
+// This avoids the chartify path that does `helm repo list` to look up the
+// repository URL: that lookup never finds OCI repos because helm 3+ does not
+// register OCI registries as named repos (it uses `helm registry login`
+// instead). By the time chartify sees an `oci://` URL it already takes the
+// correct branch, so rewriting here is enough to make the named-repo form
+// behave the same as the explicit URL form.
+func (st *HelmState) resolveOCIAdhocDepChart(chart string) (string, bool) {
+	if strings.HasPrefix(chart, "oci://") {
+		return "", false
+	}
+	repo, name := st.GetRepositoryAndNameFromChartName(chart)
+	if repo == nil || !repo.OCI {
+		return "", false
+	}
+	return "oci://" + strings.TrimSuffix(repo.URL, "/") + "/" + name, true
+}
+
 var rwMutexMap sync.Map
 
 // getNamedRWMutex retrieves or creates a sync.RWMutex for a given name.

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -6039,3 +6039,74 @@ func TestHelmState_getKubeContext(t *testing.T) {
 		})
 	}
 }
+
+// resolveOCIAdhocDepChart should rewrite a release `dependencies[].chart` value
+// that uses the named-repo prefix form into a full oci:// URL whenever the
+// matching `repositories:` entry has `oci: true`. All other inputs must pass
+// through unchanged so we never disturb existing behavior.
+func TestResolveOCIAdhocDepChart(t *testing.T) {
+	state := &HelmState{
+		ReleaseSetSpec: ReleaseSetSpec{
+			Repositories: []RepositorySpec{
+				{Name: "ociregistry", URL: "registry.example.com:5000/charts", OCI: true},
+				{Name: "ociregistry-trailing", URL: "registry.example.com:5000/charts/", OCI: true},
+				{Name: "stable", URL: "https://charts.helm.sh/stable"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		chart     string
+		wantOK    bool
+		wantChart string
+	}{
+		{
+			name:      "named OCI repo prefix is rewritten to oci:// URL",
+			chart:     "ociregistry/redis",
+			wantOK:    true,
+			wantChart: "oci://registry.example.com:5000/charts/redis",
+		},
+		{
+			name:      "trailing slash on repo URL does not produce a double slash",
+			chart:     "ociregistry-trailing/redis",
+			wantOK:    true,
+			wantChart: "oci://registry.example.com:5000/charts/redis",
+		},
+		{
+			name:   "non-OCI repo prefix is left alone for chartify's helm-repo-list path",
+			chart:  "stable/nginx",
+			wantOK: false,
+		},
+		{
+			name:   "explicit oci:// URL is left alone (already in chartify's OCI branch)",
+			chart:  "oci://registry.example.com:5000/charts/redis",
+			wantOK: false,
+		},
+		{
+			name:   "unknown repo prefix is left alone",
+			chart:  "unknownrepo/something",
+			wantOK: false,
+		},
+		{
+			name:   "single-segment chart (no slash) is left alone",
+			chart:  "localchart",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := state.resolveOCIAdhocDepChart(tt.chart)
+			if ok != tt.wantOK {
+				t.Errorf("ok: want %v, got %v", tt.wantOK, ok)
+			}
+			if tt.wantOK && got != tt.wantChart {
+				t.Errorf("rewritten chart: want %q, got %q", tt.wantChart, got)
+			}
+			if !tt.wantOK && got != "" {
+				t.Errorf("expected empty rewrite when ok=false, got %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When a release's `dependencies[].chart` is given as `<repoName>/<chart>` and the matching `repositories:` entry has `oci: true`, helmfile now rewrites it to `oci://<repoURL>/<chart>` before handing it to chartify. Without this rewrite, chartify falls into its `helm repo list` lookup branch, which never finds OCI repos because since helm 3 OCI registries are no longer registered as named repos (they live in the `helm registry login` state instead). The user-visible failure was:

```
failed reading adhoc dependencies: no helm list entry found for repository "<name>". please `helm repo add` it!
```

Explicit `oci://` URLs already worked through chartify's OCI branch on `main`; this change makes the `<repoName>/<chart>` form behave the same way.

Fixes #1756.

## Why this fix lives in helmfile, not chartify

Chartify's OCI branch is already correct: it produces a valid `Chart.yaml` dependency entry with `repository: oci://...` that `helm dependency build` resolves. The bug is purely upstream of chartify: helmfile passes the `<repoName>/<chart>` string through verbatim, never consulting its own `repositories:` list. Resolving the prefix in helmfile keeps chartify untouched and reuses the code path that's already proven to work for explicit `oci://` URLs.

## Reproduction (verified)

A local OCI registry plus a minimal helmfile reproduces the bug on `main` and is fixed by this PR:

```bash
docker run -d --rm -p 5555:5000 --name reg registry:2
helm create redis-mock && helm package redis-mock
helm push redis-mock-0.1.0.tgz oci://localhost:5555/test
```

```yaml
# helmfile.yaml
repositories:
  - name: localreg
    url: localhost:5555/test
    oci: true

releases:
  - name: parent
    chart: ./parent-app
    dependencies:
      - chart: localreg/redis-mock     # the bug case
        version: 0.1.0
```

Before: `failed reading adhoc dependencies: no helm list entry found for repository "localreg"`.

After: chart renders, with a debug log confirming the rewrite:

```
ad-hoc dependency "localreg/redis-mock" rewritten to "oci://localhost:5555/test/redis-mock" (matched OCI repo entry)
```

## Scope

The rewrite is deliberately conservative. The six cases covered in `TestResolveOCIAdhocDepChart`:

| Input | Result |
|---|---|
| `ociregistry/redis` (matches OCI repo) | rewritten to `oci://...` |
| `ociregistry-trailing/redis` (URL ends with `/`) | rewritten without double slash |
| `stable/nginx` (matches non-OCI repo) | unchanged: chartify's existing repo-list path handles it |
| `oci://...` (explicit URL) | unchanged: already in chartify's OCI branch |
| `unknownrepo/something` | unchanged: chartify reports the repo-not-found error as before |
| `localchart` (no slash) | unchanged |

Local-directory dependencies (`st.fs.DirectoryExistsAt(chart)`) keep their existing absolute-path resolution and are not affected by the rewrite.

## Note on comment by @artemis-mike in #1756

They used a full `oci://` URL form ([comment](https://github.com/helmfile/helmfile/issues/1756#issuecomment-4065947696)) and report a different downstream error (`found in Chart.yaml, but missing in charts/ directory`). I could not reproduce that one without their exact setup (private registry, remote parent chart, basic auth). Explicit `oci://` URL deps work in my reproduction on `main` already. That case is likely either auth-state or remote-parent specific and out of scope for this PR; I'd suggest opening a focused issue for it once we have a clean repro.
