### PR TITLE
fix: remove naked return by returning expected values

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -728,7 +728,7 @@ func (a *App) PrintState(c StateConfigProvider) error {
 			errs = append(errs, err)
 		}
 
-		return
+		return false, errs
 	}, false, SetFilter(true))
 }
 


### PR DESCRIPTION
The linter fails on this, because it is a naked return, so we should return the expected values