### PR TITLE
fix: Fix broken `trackLogs` functionality in Kubedog tracker

### DIFF
--- a/pkg/kubedog/tracker.go
+++ b/pkg/kubedog/tracker.go
@@ -201,6 +201,32 @@ type trackTarget struct {
 	namespace string
 }
 
+// defaultSaveLogsReplicas is the number of pods per resource for which kubedog
+// will stream logs when log tracking is enabled. kubedog ignores logs unless
+// SaveLogsOnlyForNumberOfReplicas is positive (see ignoreLogs in
+// pkg/tracker/deployment/tracker.go), so leaving it at 0 silently suppresses
+// all log output even when trackLogs is true.
+const defaultSaveLogsReplicas = 10
+
+// buildTrackerOptions constructs the kubedog tracker options from the tracker's
+// configured TrackOptions. It is factored out of TrackResources so the option
+// mapping (in particular enabling log streaming) can be unit tested without a
+// live cluster.
+func (t *Tracker) buildTrackerOptions(ctx context.Context) tracker.Options {
+	opts := tracker.Options{
+		ParentContext: ctx,
+		Timeout:       t.trackOptions.Timeout,
+		LogsFromTime:  time.Now().Add(-t.trackOptions.LogsSince),
+		IgnoreLogs:    !t.trackOptions.Logs,
+	}
+
+	if t.trackOptions.Logs {
+		opts.SaveLogsOnlyForNumberOfReplicas = defaultSaveLogsReplicas
+	}
+
+	return opts
+}
+
 func (t *Tracker) TrackResources(ctx context.Context, resources []*resource.Resource) error {
 	if len(resources) == 0 {
 		t.logger.Info("No resources to track")
@@ -231,16 +257,7 @@ func (t *Tracker) TrackResources(ctx context.Context, resources []*resource.Reso
 		informer.ConcurrentInformerFactoryOptions{},
 	)
 
-	opts := tracker.Options{
-		ParentContext: ctx,
-		Timeout:       t.trackOptions.Timeout,
-		LogsFromTime:  time.Now().Add(-t.trackOptions.LogsSince),
-		IgnoreLogs:    !t.trackOptions.Logs,
-	}
-
-	if t.trackOptions.Logs {
-		opts.SaveLogsOnlyForNumberOfReplicas = 10
-	}
+	opts := t.buildTrackerOptions(ctx)
 
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(targets))

--- a/pkg/kubedog/tracker.go
+++ b/pkg/kubedog/tracker.go
@@ -238,6 +238,10 @@ func (t *Tracker) TrackResources(ctx context.Context, resources []*resource.Reso
 		IgnoreLogs:    !t.trackOptions.Logs,
 	}
 
+        if t.trackOptions.Logs {
+              opts.SaveLogsOnlyForNumberOfReplicas = 10
+        }
+
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(targets))
 

--- a/pkg/kubedog/tracker.go
+++ b/pkg/kubedog/tracker.go
@@ -238,9 +238,9 @@ func (t *Tracker) TrackResources(ctx context.Context, resources []*resource.Reso
 		IgnoreLogs:    !t.trackOptions.Logs,
 	}
 
-        if t.trackOptions.Logs {
-              opts.SaveLogsOnlyForNumberOfReplicas = 10
-        }
+	if t.trackOptions.Logs {
+		opts.SaveLogsOnlyForNumberOfReplicas = 10
+	}
 
 	var wg sync.WaitGroup
 	errCh := make(chan error, len(targets))

--- a/pkg/kubedog/tracker_test.go
+++ b/pkg/kubedog/tracker_test.go
@@ -1,6 +1,7 @@
 package kubedog
 
 import (
+	"context"
 	"math"
 	"os"
 	"testing"
@@ -274,4 +275,32 @@ users:
 		// If no error, tracker should be created successfully
 		assert.NotNil(t, tr)
 	}
+}
+
+func TestBuildTrackerOptions_LogsEnabled(t *testing.T) {
+	tr := &Tracker{
+		trackOptions: NewTrackOptions().WithLogs(true),
+	}
+
+	opts := tr.buildTrackerOptions(context.Background())
+
+	// With logs enabled, kubedog must be told to stream logs and to save logs
+	// for a positive number of replicas, otherwise log output is silently
+	// suppressed.
+	assert.False(t, opts.IgnoreLogs)
+	assert.Equal(t, defaultSaveLogsReplicas, opts.SaveLogsOnlyForNumberOfReplicas)
+	assert.Equal(t, 5*time.Minute, opts.Timeout)
+}
+
+func TestBuildTrackerOptions_LogsDisabled(t *testing.T) {
+	tr := &Tracker{
+		trackOptions: NewTrackOptions().WithLogs(false),
+	}
+
+	opts := tr.buildTrackerOptions(context.Background())
+
+	// With logs disabled, kubedog should ignore logs and not save any replicas'
+	// logs (leaving the default zero value).
+	assert.True(t, opts.IgnoreLogs)
+	assert.Zero(t, opts.SaveLogsOnlyForNumberOfReplicas)
 }


### PR DESCRIPTION
When using helmfile with the following setup

```
releases:
  - name: my-app
    chart: ./mychart
    trackMode: kubedog
    trackLogs: true
    trackFailOnError: true
```

We don't actually see any logs from the container being printed.

This is because when building the options for the Kubedog tracker, we never specify `SaveLogsOnlyForNumberOfReplicas` which means this defaults to 0.

Looking at the logic in `pkg/tracker/deployment/tracker.go` we see

```
ignoreLogs := job.ignoreLogs || job.savingLogsReplicas >= job.SaveLogsOnlyForNumberOfReplicas
```

With job.SaveLogsOnlyForNumberOfReplicas always defaulting to 0, this will always ignore logs

This change sets it to a reasonable default of tracking logs from up to 10 pods.