### PR TITLE
Add App.WithFileSystem

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -103,6 +103,12 @@ func New(conf ConfigProvider) *App {
 	})
 }
 
+// WithFileSystem swaps the FileSystem this App reads through while loading state.
+func (a *App) WithFileSystem(fs *filesystem.FileSystem) *App {
+	a.fs = fs
+	return a
+}
+
 func Init(app *App) *App {
 	var err error
 	app.valsRuntime, err = plugins.ValsInstance()

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -48,6 +48,16 @@ func injectFs(app *App, fs *testhelper.TestFs) *App {
 	return app
 }
 
+func TestAppWithFileSystem(t *testing.T) {
+	app := &App{}
+	fs := ffs.DefaultFileSystem()
+
+	got := app.WithFileSystem(fs)
+
+	require.Same(t, app, got)
+	require.Same(t, fs, app.fs)
+}
+
 func expectNoCallsToHelm(app *App) {
 	expectNoCallsToHelmVersion(app)
 }


### PR DESCRIPTION
## What

Add `App.WithFileSystem()` so library consumers can inject a custom
`*filesystem.FileSystem` into `pkg/app.App`.

## Why

`App` already stores a filesystem internally, and state loading already reads
through it. Exposing a small setter lets out-of-tree tooling observe or wrap file
reads during state loading without patching `pkg/filesystem`.

This follows the same library-consumer direction as #2520, while keeping the
existing `App.fs` field unexported.

## Validation

```text
go test ./pkg/app -run TestAppWithFileSystem
```
