### PR TITLE
docs: fix duplicated word in hcl_funcs log description

### DIFF
--- a/docs/hcl_funcs.md
+++ b/docs/hcl_funcs.md
@@ -330,7 +330,7 @@ length([1,2,3])
 # 3
 ```
 #### log
-`log` returns returns the logarithm of a given number in a given base.
+`log` returns the logarithm of a given number in a given base.
 ```
 log(number, base)
 ```


### PR DESCRIPTION
The `log` entry in the HCL functions reference reads "returns returns the logarithm". Removed the duplicated "returns".
