### PR TITLE
fix: kubedog tracking with atomic flag and nil pointer panic on context cancel

### DIFF
--- a/pkg/helmexec/runner.go
+++ b/pkg/helmexec/runner.go
@@ -93,15 +93,32 @@ func Output(ctx context.Context, c *exec.Cmd, stripArgsValuesOnExitError bool, l
 	c.Stderr = io.MultiWriter(append([]io.Writer{&stderr, &combined}, logWriters...)...)
 
 	var err error
-	ch := make(chan error)
-	go func() {
-		ch <- c.Run()
-	}()
-	select {
-	case err = <-ch:
-	case <-ctx.Done():
-		_ = c.Process.Signal(os.Interrupt)
-		err = <-ch
+	// Start the command synchronously so that c.Process is fully initialized
+	// before we spawn the Wait goroutine below. Previously this used c.Run()
+	// inside the goroutine, which raced the select's ctx.Done() branch on
+	// c.Process (Start writes it, Done read it). See helmfile issue #2448.
+	//
+	// On Start failure we fall through to the shared error-handling switch below
+	// (the default branch wraps it as "unexpected error: ..."), matching the
+	// previous behavior where Run()'s error flowed through the same path.
+	if startErr := c.Start(); startErr != nil {
+		err = startErr
+	} else {
+		ch := make(chan error)
+		go func() {
+			ch <- c.Wait()
+		}()
+		select {
+		case err = <-ch:
+		case <-ctx.Done():
+			// Guard against nil Process: defensively skip the signal if the
+			// process has not been initialized. After a successful Start this
+			// should not happen, but we keep the guard for safety.
+			if c.Process != nil {
+				_ = c.Process.Signal(os.Interrupt)
+			}
+			err = <-ch
+		}
 	}
 
 	if err != nil {
@@ -162,7 +179,12 @@ func LiveOutput(ctx context.Context, c *exec.Cmd, stripArgsValuesOnExitError boo
 		select {
 		case err = <-ch:
 		case <-ctx.Done():
-			_ = c.Process.Signal(os.Interrupt)
+			// Guard against nil Process for safety/consistency with Output.
+			// After a successful Start c.Process is always non-nil, but we
+			// keep the guard defensive. See helmfile issue #2448.
+			if c.Process != nil {
+				_ = c.Process.Signal(os.Interrupt)
+			}
 			err = <-ch
 		}
 		_ = writer.Close()

--- a/pkg/helmexec/runner_test.go
+++ b/pkg/helmexec/runner_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestShellRunner_Execute(t *testing.T) {
@@ -96,5 +97,75 @@ Usage:  helm template [NAME] [CHART] [flags]
 				t.Errorf("LiveOutput() got unespected %v", got)
 			}
 		})
+	}
+}
+
+// TestOutput_NilProcessOnCanceledContext verifies that Output does not panic
+// when the context is already canceled. The command is started synchronously
+// before the select, so a canceled context no longer races on c.Process.
+// See helmfile issue #2448.
+func TestOutput_NilProcessOnCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cmd := exec.Command("sleep", "10")
+	_, err := Output(ctx, cmd, false, &logWriterGenerator{
+		log: NewLogger(&bytes.Buffer{}, "debug"),
+	})
+	if err == nil {
+		t.Fatal("expected error due to canceled context, got nil")
+	}
+}
+
+// TestLiveOutput_CanceledContextNoPanic verifies that LiveOutput does not
+// panic when the context is canceled while or after a fast command runs.
+func TestLiveOutput_CanceledContextNoPanic(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			<-time.After(time.Millisecond)
+			cancel()
+		}()
+
+		cmd := exec.Command("true")
+		_, _ = LiveOutput(ctx, cmd, false, &bytes.Buffer{})
+	}
+}
+
+// TestOutput_StartFailureErrorWrapping verifies that a Start() failure (e.g.
+// binary not found) is wrapped through the same "unexpected error:" path as
+// the previous c.Run()-in-goroutine implementation did. This guards against
+// behavioral regressions in the error message format.
+func TestOutput_StartFailureErrorWrapping(t *testing.T) {
+	cmd := exec.Command("this-binary-does-not-exist-2448")
+	_, err := Output(context.Background(), cmd, false, &logWriterGenerator{
+		log: NewLogger(&bytes.Buffer{}, "debug"),
+	})
+	if err == nil {
+		t.Fatal("expected error from non-existent command, got nil")
+	}
+	if !strings.Contains(err.Error(), "unexpected error:") {
+		t.Errorf("expected error to be wrapped as 'unexpected error:', got: %v", err)
+	}
+}
+
+// TestOutput_CanceledContextAfterExit verifies Output does not panic when the
+// context is canceled right after a fast command finishes. This stresses the
+// race between the command exiting (Process could be reaped) and ctx.Done().
+func TestOutput_CanceledContextAfterExit(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		cmd := exec.Command("true")
+		go func() {
+			<-time.After(time.Millisecond)
+			cancel()
+		}()
+
+		_, err := Output(ctx, cmd, false, &logWriterGenerator{
+			log: NewLogger(&bytes.Buffer{}, "debug"),
+		})
+		// "true" should exit 0; even if canceled we tolerate a context error.
+		_ = err
 	}
 }

--- a/pkg/state/helmx.go
+++ b/pkg/state/helmx.go
@@ -303,6 +303,24 @@ func (st *HelmState) appendWaitFlags(flags []string, helm helmexec.Interface, re
 	return flags
 }
 
+// appendAtomicFlags appends the helm --atomic flag (a.k.a. --rollback-on-failure
+// in Helm 4) when the user requested it via release-level or helmDefaults
+// configuration. When trackMode is "kubedog", the flag is suppressed: Helm's own
+// --atomic would wait for resources and roll back on failure, deleting the
+// failing pods before kubedog gets a chance to observe and report on them.
+// Helmfile relies on kubedog to detect readiness/failure in that mode instead.
+func (st *HelmState) appendAtomicFlags(flags []string, release *ReleaseSpec, ops *SyncOpts) []string {
+	if st.shouldUseKubedog(release, ops) {
+		return flags
+	}
+
+	if release.Atomic != nil && *release.Atomic || release.Atomic == nil && st.HelmDefaults.Atomic {
+		flags = append(flags, "--atomic")
+	}
+
+	return flags
+}
+
 // append post-renderer flags to helm flags
 func (st *HelmState) appendCascadeFlags(flags []string, helm helmexec.Interface, release *ReleaseSpec, cascade string) []string {
 	// see https://github.com/helm/helm/releases/tag/v3.12.1

--- a/pkg/state/helmx_test.go
+++ b/pkg/state/helmx_test.go
@@ -264,6 +264,91 @@ func TestAppendWaitFlags(t *testing.T) {
 	}
 }
 
+func TestAppendAtomicFlags(t *testing.T) {
+	enable := true
+	disable := false
+	tests := []struct {
+		name     string
+		release  *ReleaseSpec
+		syncOpts *SyncOpts
+		helmSpec HelmSpec
+		expected []string
+	}{
+		{
+			name:     "release atomic",
+			release:  &ReleaseSpec{Atomic: &enable},
+			syncOpts: nil,
+			helmSpec: HelmSpec{},
+			expected: []string{"--atomic"},
+		},
+		{
+			name:     "helm defaults atomic",
+			release:  &ReleaseSpec{},
+			syncOpts: nil,
+			helmSpec: HelmSpec{Atomic: true},
+			expected: []string{"--atomic"},
+		},
+		{
+			name:     "release atomic false overrides default",
+			release:  &ReleaseSpec{Atomic: &disable},
+			syncOpts: nil,
+			helmSpec: HelmSpec{Atomic: true},
+			expected: []string{},
+		},
+		{
+			name:     "no atomic",
+			release:  &ReleaseSpec{},
+			syncOpts: nil,
+			helmSpec: HelmSpec{},
+			expected: []string{},
+		},
+		{
+			name:     "kubedog track mode skips --atomic from release",
+			release:  &ReleaseSpec{Atomic: &enable, TrackMode: "kubedog"},
+			syncOpts: nil,
+			helmSpec: HelmSpec{},
+			expected: []string{},
+		},
+		{
+			name:     "kubedog track mode skips --atomic from syncOpts",
+			release:  &ReleaseSpec{Atomic: &enable},
+			syncOpts: &SyncOpts{TrackMode: "kubedog"},
+			helmSpec: HelmSpec{},
+			expected: []string{},
+		},
+		{
+			name:     "kubedog track mode skips --atomic from helmDefaults",
+			release:  &ReleaseSpec{Atomic: &enable},
+			syncOpts: nil,
+			helmSpec: HelmSpec{TrackMode: "kubedog"},
+			expected: []string{},
+		},
+		{
+			name:     "kubedog track mode skips --atomic from helmDefaults atomic",
+			release:  &ReleaseSpec{},
+			syncOpts: nil,
+			helmSpec: HelmSpec{Atomic: true, TrackMode: "kubedog"},
+			expected: []string{},
+		},
+		{
+			name:     "helm track mode keeps --atomic",
+			release:  &ReleaseSpec{Atomic: &enable, TrackMode: "helm"},
+			syncOpts: nil,
+			helmSpec: HelmSpec{},
+			expected: []string{"--atomic"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &HelmState{}
+			st.HelmDefaults = tt.helmSpec
+			got := st.appendAtomicFlags([]string{}, tt.release, tt.syncOpts)
+			require.Equalf(t, tt.expected, got, "appendAtomicFlags() = %v, want %v", got, tt.expected)
+		})
+	}
+}
+
 func TestAppendCascadeFlags(t *testing.T) {
 	type args struct {
 		flags    []string

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -3746,9 +3746,7 @@ func (st *HelmState) flagsForUpgrade(helm helmexec.Interface, release *ReleaseSp
 		flags = append(flags, "--recreate-pods")
 	}
 
-	if release.Atomic != nil && *release.Atomic || release.Atomic == nil && st.HelmDefaults.Atomic {
-		flags = append(flags, "--atomic")
-	}
+	flags = st.appendAtomicFlags(flags, release, opt)
 
 	if release.CleanupOnFail != nil && *release.CleanupOnFail || release.CleanupOnFail == nil && st.HelmDefaults.CleanupOnFail {
 		flags = append(flags, "--cleanup-on-fail")

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -695,6 +695,57 @@ func TestHelmState_flagsForUpgrade(t *testing.T) {
 			},
 		},
 		{
+			name: "atomic-suppressed-by-kubedog-trackmode-from-release",
+			defaults: HelmSpec{
+				Atomic: true,
+			},
+			release: &ReleaseSpec{
+				Chart:     "test/chart",
+				Version:   "0.1",
+				Name:      "test-charts",
+				Namespace: "test-namespace",
+				TrackMode: "kubedog",
+			},
+			want: []string{
+				"--version", "0.1",
+				"--namespace", "test-namespace",
+			},
+		},
+		{
+			name: "atomic-suppressed-by-kubedog-trackmode-from-cli",
+			defaults: HelmSpec{
+				Atomic: true,
+			},
+			release: &ReleaseSpec{
+				Chart:     "test/chart",
+				Version:   "0.1",
+				Name:      "test-charts",
+				Namespace: "test-namespace",
+			},
+			syncOpts: &SyncOpts{TrackMode: "kubedog"},
+			want: []string{
+				"--version", "0.1",
+				"--namespace", "test-namespace",
+			},
+		},
+		{
+			name: "atomic-suppressed-by-kubedog-trackmode-from-defaults",
+			defaults: HelmSpec{
+				Atomic:    true,
+				TrackMode: "kubedog",
+			},
+			release: &ReleaseSpec{
+				Chart:     "test/chart",
+				Version:   "0.1",
+				Name:      "test-charts",
+				Namespace: "test-namespace",
+			},
+			want: []string{
+				"--version", "0.1",
+				"--namespace", "test-namespace",
+			},
+		},
+		{
 			name: "cleanup-on-fail",
 			defaults: HelmSpec{
 				CleanupOnFail: false,


### PR DESCRIPTION
## Summary

Fixes two issues reported in #2448 ([comment](https://github.com/helmfile/helmfile/issues/2448#issuecomment-4745621046)).

### 1. Nil pointer panic in SIGINT handler (`pkg/helmexec/runner.go`)

When the context was cancelled, `c.Process.Signal(os.Interrupt)` could panic with a nil `Process`.

**Root cause** (found via `-race`): `Output()` ran `c.Run()` (= `Start()`+`Wait()`) inside a goroutine, so `c.Process` was **written** by `Start()` concurrently with the select's `ctx.Done()` **read** — a data race even in the original code.

**Fix**: Split `c.Run()` into synchronous `c.Start()` + goroutine `c.Wait()`, matching `LiveOutput()`'s existing pattern. This ensures `c.Process` is fully initialized before the select. Added `if c.Process != nil` guards in both `Output` and `LiveOutput` for defensive safety.

### 2. `--atomic` flag not suppressed for kubedog tracking (`pkg/state`)

Helm's `--atomic` waits for resources and rolls back on failure, **deleting failing pods before kubedog can observe them** — defeating the purpose of kubedog tracking.

**Fix**: New `appendAtomicFlags()` method suppresses `--atomic` when `trackMode == "kubedog"`, mirroring how `--wait` and `--wait-for-jobs` are already suppressed for kubedog.

## Test plan

- [x] `TestOutput_NilProcessOnCanceledContext` — canceled context + Output, no panic
- [x] `TestOutput_CanceledContextAfterExit` — 50 iterations race stress test (passes `-race`)
- [x] `TestOutput_StartFailureErrorWrapping` — Start() failure error wrapping preserved
- [x] `TestLiveOutput_CanceledContextNoPanic` — LiveOutput cancel, no panic
- [x] `TestAppendAtomicFlags` (9 cases) — unit: release/default/CLI × kubedog suppression
- [x] `flagsForUpgrade` atomic+kubedog (3 integration cases) — end-to-end flag suppression
- [x] `-race` + `golangci-lint` + `go vet` all clean
- [x] Full `pkg/app`, `pkg/state`, `pkg/helmexec`, `pkg/config` test suites pass

## Notes

- Helm 4 deprecates `--atomic` in favor of `--rollback-on-failure` — pre-existing Helm 4 compat gap, out of scope.
- Implementing helmfile's own rollback-on-kubedog-failure is a separate feature enhancement.

Fixes #2448