### PR TITLE
fix: serialize concurrent helm operations for same chart to fix #768

### DIFF
--- a/pkg/state/issue_768_test.go
+++ b/pkg/state/issue_768_test.go
@@ -1,0 +1,249 @@
+package state
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/helmfile/helmfile/pkg/exectest"
+	"github.com/helmfile/helmfile/pkg/filesystem"
+)
+
+// mockFetchHelm wraps exectest.Helm to count Fetch calls and create
+// a fake chart directory so findChartDirectory succeeds.
+type mockFetchHelm struct {
+	*exectest.Helm
+	fetchCount atomic.Int32
+}
+
+func (m *mockFetchHelm) Fetch(chart string, flags ...string) error {
+	// Extract the --untardir path from flags and create a fake Chart.yaml
+	untarDir := ""
+	for i, f := range flags {
+		if f == "--untardir" && i+1 < len(flags) {
+			untarDir = flags[i+1]
+			break
+		}
+	}
+	if untarDir != "" {
+		chartDir := filepath.Join(untarDir, chart)
+		_ = os.MkdirAll(chartDir, 0755)
+		chartYaml := filepath.Join(chartDir, "Chart.yaml")
+		_ = os.WriteFile(chartYaml, []byte("apiVersion: v2\nname: test\nversion: 1.0.0\n"), 0644)
+	}
+	m.fetchCount.Add(1)
+	// Simulate download time to widen the race window
+	time.Sleep(50 * time.Millisecond)
+	return nil
+}
+
+// TestForcedDownloadChartSerializesSameChart verifies that concurrent calls
+// to forcedDownloadChart with the same chart+version but different release
+// names are serialized so helm.Fetch is called exactly once.
+// This is the core fix for issue #768.
+func TestForcedDownloadChartSerializesSameChart(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+
+	// Use unique chart name to avoid polluting global cache across tests
+	chartName := fmt.Sprintf("testrepo-768/unique-chart-%d", time.Now().UnixNano())
+
+	st := &HelmState{
+		logger:   logger.Sugar(),
+		fs:       filesystem.DefaultFileSystem(),
+		basePath: tempDir,
+	}
+
+	mockHelm := &mockFetchHelm{Helm: &exectest.Helm{}}
+
+	numReleases := 5
+	var wg sync.WaitGroup
+
+	for i := 0; i < numReleases; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			release := &ReleaseSpec{
+				Name:    fmt.Sprintf("release-%d", idx),
+				Chart:   chartName,
+				Version: "1.0.0",
+			}
+			opts := ChartPrepareOptions{
+				SkipRefresh: true,
+				SkipDeps:    true,
+			}
+			_, err := st.forcedDownloadChart(chartName, tempDir, release, mockHelm, opts)
+			assert.NoError(t, err)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// helm.Fetch should be called exactly once despite 5 concurrent releases
+	assert.Equal(t, int32(1), mockHelm.fetchCount.Load(),
+		"helm.Fetch must be called exactly once for concurrent releases with the same chart+version")
+}
+
+// TestForcedDownloadChartAllowsDifferentCharts verifies that downloads of
+// different charts are NOT serialized against each other (only same-chart
+// downloads are serialized).
+func TestForcedDownloadChartAllowsDifferentCharts(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+	ts := time.Now().UnixNano()
+
+	st := &HelmState{
+		logger:   logger.Sugar(),
+		fs:       filesystem.DefaultFileSystem(),
+		basePath: tempDir,
+	}
+
+	mockHelm := &mockFetchHelm{Helm: &exectest.Helm{}}
+
+	// Two different charts
+	charts := []string{
+		fmt.Sprintf("testrepo-768/chart-a-%d", ts),
+		fmt.Sprintf("testrepo-768/chart-b-%d", ts),
+	}
+
+	var wg sync.WaitGroup
+	for _, chartName := range charts {
+		wg.Add(1)
+		go func(cn string) {
+			defer wg.Done()
+			release := &ReleaseSpec{
+				Name:    "release-" + cn,
+				Chart:   cn,
+				Version: "1.0.0",
+			}
+			opts := ChartPrepareOptions{
+				SkipRefresh: true,
+				SkipDeps:    true,
+			}
+			_, e := st.forcedDownloadChart(cn, tempDir, release, mockHelm, opts)
+			assert.NoError(t, e)
+		}(chartName)
+	}
+
+	wg.Wait()
+
+	// Both different charts should be fetched
+	assert.Equal(t, int32(2), mockHelm.fetchCount.Load(),
+		"different charts should not block each other")
+}
+
+// TestWithChartOperationLockSerializesSameChart verifies that
+// withChartOperationLock serializes concurrent helm operations for
+// releases using the same remote chart (issue #768).
+func TestWithChartOperationLockSerializesSameChart(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	ts := time.Now().UnixNano()
+	chartName := fmt.Sprintf("testrepo-768/op-chart-%d", ts)
+
+	st := &HelmState{
+		logger: logger.Sugar(),
+	}
+
+	var concurrentCount atomic.Int32
+	var maxConcurrent atomic.Int32
+
+	numReleases := 5
+	var wg sync.WaitGroup
+
+	for i := 0; i < numReleases; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			release := &ReleaseSpec{
+				Name:    fmt.Sprintf("release-%d", idx),
+				Chart:   chartName,
+				Version: "1.0.0",
+				// ChartPath empty => remote chart => lock acquired
+			}
+			_ = st.withChartOperationLock(release, chartName, func() error {
+				cur := concurrentCount.Add(1)
+				for {
+					old := maxConcurrent.Load()
+					if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+						break
+					}
+				}
+				time.Sleep(20 * time.Millisecond)
+				concurrentCount.Add(-1)
+				return nil
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Same-chart operations must be serialized: max concurrency should be 1
+	assert.Equal(t, int32(1), maxConcurrent.Load(),
+		"concurrent helm operations for the same chart must be serialized")
+}
+
+// TestWithChartOperationLockNoLockForLocalChart verifies that
+// withChartOperationLock does NOT serialize operations when ChartPath
+// is set (local or pre-fetched charts).
+func TestWithChartOperationLockNoLockForLocalChart(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	ts := time.Now().UnixNano()
+	chartName := fmt.Sprintf("testrepo-768/local-chart-%d", ts)
+
+	st := &HelmState{
+		logger: logger.Sugar(),
+	}
+
+	var concurrentCount atomic.Int32
+	var maxConcurrent atomic.Int32
+
+	numReleases := 5
+	var wg sync.WaitGroup
+
+	for i := 0; i < numReleases; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			release := &ReleaseSpec{
+				Name:      fmt.Sprintf("release-%d", idx),
+				Chart:     chartName,
+				Version:   "1.0.0",
+				ChartPath: "/some/local/path", // ChartPath set => no lock
+			}
+			_ = st.withChartOperationLock(release, chartName, func() error {
+				cur := concurrentCount.Add(1)
+				for {
+					old := maxConcurrent.Load()
+					if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+						break
+					}
+				}
+				time.Sleep(20 * time.Millisecond)
+				concurrentCount.Add(-1)
+				return nil
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Local charts should NOT be serialized: all should run concurrently
+	assert.Greater(t, maxConcurrent.Load(), int32(1),
+		"local/pre-fetched charts should not be serialized")
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1237,7 +1237,9 @@ func (st *HelmState) SyncReleases(affectedReleases *AffectedReleases, helm helme
 					// active. When tracking isn't running it's the original
 					// helm — either path is safe to call directly.
 					releaseHelm := trackHandle.Helm
-					helmErr := releaseHelm.SyncRelease(context, release.Name, chart, release.Namespace, flags...)
+					helmErr := st.withChartOperationLock(release, chart, func() error {
+						return releaseHelm.SyncRelease(context, release.Name, chart, release.Namespace, flags...)
+					})
 					if helmErr != nil && trackStarted && trackHandle.WasHelmKilled() {
 						// The kubedog safety valve sent SIGINT to helm because
 						// the cluster confirmed convergence while helm was
@@ -1336,7 +1338,9 @@ func (st *HelmState) SyncReleases(affectedReleases *AffectedReleases, helm helme
 }
 
 func (st *HelmState) performSyncOrReinstallOfRelease(affectedReleases *AffectedReleases, helm helmexec.Interface, context helmexec.HelmContext, release *ReleaseSpec, chart string, m *sync.Mutex, flags ...string) *ReleaseError {
-	if err := helm.SyncRelease(context, release.Name, chart, release.Namespace, flags...); err != nil {
+	if err := st.withChartOperationLock(release, chart, func() error {
+		return helm.SyncRelease(context, release.Name, chart, release.Namespace, flags...)
+	}); err != nil {
 		st.logger.Debugf("update strategy - sync failed: %s", err.Error())
 		// Only fail if a different error than forbidden updates
 		if !strings.Contains(err.Error(), "Forbidden: updates") {
@@ -1387,7 +1391,9 @@ func (st *HelmState) performSyncOrReinstallOfRelease(affectedReleases *AffectedR
 		}
 		m.Unlock()
 	}
-	if err := helm.SyncRelease(context, release.Name, chart, release.Namespace, flags...); err != nil {
+	if err := st.withChartOperationLock(release, chart, func() error {
+		return helm.SyncRelease(context, release.Name, chart, release.Namespace, flags...)
+	}); err != nil {
 		m.Lock()
 		affectedReleases.Failed = append(affectedReleases.Failed, release)
 		m.Unlock()
@@ -1550,6 +1556,33 @@ func (st *HelmState) getNamedRWMutex(name string) *sync.RWMutex {
 	newMu := &sync.RWMutex{}
 	actualMu, _ := rwMutexMap.LoadOrStore(name, newMu)
 	return actualMu.(*sync.RWMutex)
+}
+
+// withChartOperationLock serializes helm operations (upgrade, diff) per
+// chart+version for remote charts to prevent concurrent download races on
+// helm's repository cache (issue #768). When multiple releases use the same
+// remote chart, concurrent `helm upgrade`/`helm diff` calls race on helm's
+// internal cache file rename, causing "Access is denied" errors on Windows.
+//
+// For local or pre-fetched charts (release.ChartPath is set), no lock is
+// acquired because the chart is already available locally and helm won't
+// download it.
+//
+// Trade-off: the lock wraps the entire helm operation (download + template +
+// deploy), not just the download. Same-chart releases are fully serialized.
+// This is unavoidable without pre-fetching because helm downloads and deploys
+// atomically. Releases with different charts are unaffected and remain fully
+// parallel. If kubedog tracking is enabled, note that it starts before this
+// lock is acquired, so a release waiting on the lock may have its kubedog
+// watcher active before helm begins.
+func (st *HelmState) withChartOperationLock(release *ReleaseSpec, chart string, fn func() error) error {
+	if release.ChartPath != "" {
+		return fn()
+	}
+	mu := st.getNamedRWMutex("helm-op:" + chart + ":" + release.Version)
+	mu.Lock()
+	defer mu.Unlock()
+	return fn()
 }
 
 type PrepareChartKey struct {
@@ -1947,14 +1980,34 @@ func (st *HelmState) processLocalChart(normalizedChart, dir string, release *Rel
 
 // forcedDownloadChart handles forced chart downloads.
 // Locks are acquired during download and released immediately after.
+// A per-chart+version mutex serializes downloads within the process so that
+// concurrent releases using the same chart don't race on helm's repository
+// cache (issue #768).
 func (st *HelmState) forcedDownloadChart(chartName, dir string, release *ReleaseSpec, helm helmexec.Interface, opts ChartPrepareOptions) (string, error) {
-	// Check global chart cache first for non-OCI charts
+	cacheKey := st.getChartCacheKey(release)
+
+	// Fast path: check in-process cache without acquiring any lock.
 	// If found, another worker in this process already downloaded the chart.
 	// We don't need to acquire a lock - the tempDir won't be deleted until
 	// after helm operations complete (cleanup is deferred in withPreparedCharts).
-	cacheKey := st.getChartCacheKey(release)
 	if cachedPath, exists := st.checkChartCache(cacheKey); exists && st.fs.DirectoryExistsAt(cachedPath) {
 		st.logger.Debugf("Chart %s:%s already downloaded, using cached version at %s", chartName, release.Version, cachedPath)
+		return cachedPath, nil
+	}
+
+	// Serialize downloads per chart+version within this process.
+	// The chartPath generated below includes the release name (see
+	// DefaultFetchOutputDirTemplate), so per-chartPath file locks do NOT
+	// prevent concurrent `helm fetch` of the same chart by different releases.
+	// Without this mutex, two workers downloading the same chart concurrently
+	// race on helm's repository cache on Windows (issue #768).
+	downloadMu := st.getNamedRWMutex("chart-download:" + cacheKey.Chart + ":" + cacheKey.Version)
+	downloadMu.Lock()
+	defer downloadMu.Unlock()
+
+	// Double-check: another worker may have completed the download while we waited.
+	if cachedPath, exists := st.checkChartCache(cacheKey); exists && st.fs.DirectoryExistsAt(cachedPath) {
+		st.logger.Debugf("Chart %s:%s downloaded by another worker, using cached version at %s", chartName, release.Version, cachedPath)
 		return cachedPath, nil
 	}
 
@@ -3056,7 +3109,9 @@ func (st *HelmState) DiffReleases(helm helmexec.Interface, additionalValues []st
 
 				if prep.upgradeDueToSkippedDiff {
 					results <- diffResult{release, &ReleaseError{ReleaseSpec: release, err: nil, Code: HelmDiffExitCodeChanged}, buf}
-				} else if err := helm.DiffRelease(st.createHelmContextWithWriter(release, buf), release.Name, chartPath, release.Namespace, releaseSuppressDiff, flags...); err != nil {
+				} else if err := st.withChartOperationLock(release, chartPath, func() error {
+					return helm.DiffRelease(st.createHelmContextWithWriter(release, buf), release.Name, chartPath, release.Namespace, releaseSuppressDiff, flags...)
+				}); err != nil {
 					switch e := err.(type) {
 					case helmexec.ExitError:
 						// Propagate any non-zero exit status from the external command like `helm` that is failed under the hood
@@ -5615,6 +5670,8 @@ func (st *HelmState) acquireExclusiveLock(result *chartLockResult, chartPath str
 
 // getOCIChart downloads or retrieves an OCI chart from cache.
 // Locks are acquired during download and released immediately after.
+// A per-chart+version mutex serializes downloads within the process so that
+// concurrent releases using the same OCI chart don't race (issue #768).
 func (st *HelmState) getOCIChart(release *ReleaseSpec, tempDir string, helm helmexec.Interface, opts ChartPrepareOptions) (*string, error) {
 	qualifiedChartName, chartName, chartVersion, err := st.getOCIQualifiedChartName(release)
 	if err != nil {
@@ -5625,13 +5682,22 @@ func (st *HelmState) getOCIChart(release *ReleaseSpec, tempDir string, helm helm
 		return nil, nil
 	}
 
-	// Check global chart cache first (in-memory cache)
-	// If found, another worker in this process already downloaded the chart.
-	// We don't need to acquire a lock - the tempDir won't be deleted until
-	// after helm operations complete (cleanup is deferred in withPreparedCharts).
 	cacheKey := st.getChartCacheKey(release)
+
+	// Fast path: check in-process cache without acquiring any lock.
 	if cachedPath, exists := st.checkChartCache(cacheKey); exists && st.fs.DirectoryExistsAt(cachedPath) {
 		st.logger.Debugf("OCI chart %s:%s already downloaded, using cached version at %s", chartName, chartVersion, cachedPath)
+		return &cachedPath, nil
+	}
+
+	// Serialize downloads per chart+version within this process (issue #768).
+	downloadMu := st.getNamedRWMutex("chart-download:" + cacheKey.Chart + ":" + cacheKey.Version)
+	downloadMu.Lock()
+	defer downloadMu.Unlock()
+
+	// Double-check: another worker may have completed the download while we waited.
+	if cachedPath, exists := st.checkChartCache(cacheKey); exists && st.fs.DirectoryExistsAt(cachedPath) {
+		st.logger.Debugf("OCI chart %s:%s downloaded by another worker, using cached version at %s", chartName, chartVersion, cachedPath)
 		return &cachedPath, nil
 	}
 


### PR DESCRIPTION
## Problem

When multiple releases in a helmfile use the same remote chart (e.g. deploying `platform/shell-ui` as both `admin-ui` and `agent-ui`), concurrent `helm upgrade`/`helm diff` calls race on helm's internal repository cache file rename. On Windows this causes intermittent:

```
Error: link error: cannot rename ...\Temp\helm\repository\shell-ui-13.16.0.tgz1033128112
to ...\Temp\helm\repository\shell-ui-13.16.0.tgz: Access is denied.
```

The user's only workaround was `--concurrency 1`.

Fixes #768

## Solution

Two layers of per-chart+version serialization:

### 1. Operation-level lock: `withChartOperationLock`
Wraps all `SyncRelease`/`DiffRelease` calls (4 call sites) with a mutex keyed by `chart+version`. Only applies to **remote charts** (`release.ChartPath == ""`); local, pre-fetched, OCI, and chartify charts bypass the lock entirely. Releases with **different charts remain fully parallel**.

### 2. Download-level lock: per-chart mutex in `forcedDownloadChart`/`getOCIChart`
Double-check locking pattern ensures only one `helm fetch` runs per unique chart+version within a process. Covers the ForceDownload path (lint/template/unittest/pull) and OCI charts.

## Key design decisions

- **No chart path changes** — helm still receives the original chart name, preserving all existing behavior and tests (zero test regressions).
- **No new flags** — the fix is automatic and transparent.
- **Minimal parallelism impact** — only releases sharing the *same* chart are serialized; different charts run fully concurrent.
- **Trade-off**: the entire helm operation (download + template + deploy) is serialized for same-chart releases. This is unavoidable without pre-fetching because helm downloads and deploys atomically.

## Testing

- `TestForcedDownloadChartSerializesSameChart` — 5 concurrent releases, same chart → 1 Fetch call
- `TestForcedDownloadChartAllowsDifferentCharts` — 2 different charts → 2 Fetch calls (not blocked)
- `TestWithChartOperationLockSerializesSameChart` — verifies max concurrency = 1 for same chart
- `TestWithChartOperationLockNoLockForLocalChart` — verifies local charts are NOT serialized
- All existing tests pass with `-race` (0 regressions)
- `golangci-lint`: 0 issues