### PR TITLE
fix: use locked version when lock file mismatches helmfile.yaml version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [Unreleased]
+
+### Added
+
+- Add `allowLockedVersionMismatch` helmfile.yaml option to let a per-environment lock file pin a chart version that differs from the one declared in `helmfile.yaml`, enabling progressive rollouts across environments (#870)
+
+### Fixed
+
+- Fix per-environment lock files failing when their pinned version does not satisfy the helmfile.yaml constraint; the default behavior is now a clear error guiding users to `helmfile deps` or `allowLockedVersionMismatch`, instead of a generic "no resolved dependency found" message (#870)
+
 ## [1.4.1] - 2026-03-03
 
 ### Fixed

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -466,3 +466,35 @@ releases:
 - name: myapp
   chart: charts/myapp
 ```
+
+### Handling version drift between environments
+
+By default, if a per-environment lock file pins a chart version that does **not**
+satisfy the `version` declared in `helmfile.yaml`, helmfile fails loudly:
+
+```
+locked version for chart "mongodb" does not satisfy the constraint "13.10.3"
+from helmfile.yaml; run "helmfile deps" to update the lock file, or set
+"allowLockedVersionMismatch: true" to use the locked version anyway
+```
+
+This protects you from accidentally deploying a stale version when you bump a
+chart in `helmfile.yaml` but forget to re-run `helmfile deps`.
+
+For progressive rollouts — where you intentionally bump a chart in one
+environment while others keep their existing pin — opt in per state file:
+
+```yaml
+lockFilePath: .helmfile.{{ .Environment.Name}}.lock
+allowLockedVersionMismatch: true
+
+releases:
+- name: myapp
+  chart: bitnami/mongodb
+  version: 13.10.3   # bumped; staging's lock still pins 13.10.2 and keeps using it
+```
+
+When enabled and no locked version satisfies the constraint, helmfile falls back
+to the **highest** version recorded in the lock file and emits a `warn`-level
+message advising you to run `helmfile deps`. Only a chart that is entirely absent
+from the lock file remains a hard error.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,11 @@ kustomizeBinary: path/to/kustomize
 # Path to alternative lock file. The default is <state file name>.lock, i.e for helmfile.yaml it's helmfile.lock.
 lockFilePath: path/to/lock.file
 
+# Allow a per-environment lock file to pin a chart version that does not satisfy
+# the version declared above. When true, helmfile falls back to the locked version
+# (with a warning) instead of failing. Useful for progressive rollouts. Default: false.
+allowLockedVersionMismatch: true
+
 # Default values to set for args along with dedicated keys that can be set by contributors, cli args take precedence over these.
 # In other words, unset values results in no flags passed to helm.
 # See the helm usage (helm SUBCOMMAND -h) for more info on default values when those flags aren't provided.

--- a/pkg/state/chart_dependency.go
+++ b/pkg/state/chart_dependency.go
@@ -93,6 +93,8 @@ type ResolvedDependencies struct {
 	deps map[string][]ResolvedChartDependency
 
 	logger *zap.SugaredLogger
+
+	allowMismatch bool
 }
 
 // nolint: unparam
@@ -133,14 +135,27 @@ func (d *ResolvedDependencies) Get(chart, versionConstraint string) (string, err
 		}
 	}
 
-	// No locked version satisfied the constraint. The lock file is the source of
-	// truth for pinned versions, so fall back to the locked version instead of
-	// failing. This allows per-environment lock files to pin a different version
-	// than the one declared in helmfile.yaml (e.g. rolling out a new chart
-	// version progressively across environments without breaking the environments
-	// whose lock files still reference the previous version).
+	// No locked version satisfied the constraint declared in helmfile.yaml.
+	// By default treat this as drift (e.g. a stale lock file) and fail loudly,
+	// because the chart version requested by helmfile.yaml is not the one
+	// recorded in the lock file. Opt in to the per-environment progressive-rollout
+	// behavior by setting "allowLockedVersionMismatch: true" in helmfile.yaml.
 	// See https://github.com/helmfile/helmfile/issues/870
-	lockedVersion := deps[0].Version
+	if !d.allowMismatch {
+		return "", fmt.Errorf("locked version for chart %q does not satisfy the constraint %q from helmfile.yaml; run \"helmfile deps\" to update the lock file, or set \"allowLockedVersionMismatch: true\" to use the locked version anyway", chart, versionConstraint)
+	}
+
+	// The lock file is the source of truth for pinned versions, so fall back to
+	// the highest locked version instead of failing. This allows per-environment
+	// lock files to pin a different version than the one declared in helmfile.yaml
+	// (e.g. rolling out a new chart version progressively across environments
+	// without breaking the environments whose lock files still reference the
+	// previous version).
+	// See https://github.com/helmfile/helmfile/issues/870
+	lockedVersion, err := highestVersion(deps)
+	if err != nil {
+		return "", err
+	}
 	if d.logger != nil {
 		d.logger.Warnf(
 			"locked version %q for chart %q does not satisfy the constraint %q from helmfile.yaml; using the locked version from the lock file. Run \"helmfile deps\" to update the lock file.",
@@ -148,6 +163,24 @@ func (d *ResolvedDependencies) Get(chart, versionConstraint string) (string, err
 		)
 	}
 	return lockedVersion, nil
+}
+
+// highestVersion returns the original version string of the highest semver
+// among deps. The first entry wins on ties. deps must be non-empty.
+func highestVersion(deps []ResolvedChartDependency) (string, error) {
+	var best string
+	var bestSV *semver.Version
+	for _, dep := range deps {
+		sv, err := semver.NewVersion(dep.Version)
+		if err != nil {
+			return "", err
+		}
+		if bestSV == nil || sv.GreaterThan(bestSV) {
+			bestSV = sv
+			best = dep.Version
+		}
+	}
+	return best, nil
 }
 
 func dedupResolvedDependencies(deps []ResolvedChartDependency) []ResolvedChartDependency {
@@ -187,6 +220,7 @@ func (st *HelmState) mergeLockedDependencies() (*HelmState, error) {
 	}
 
 	depMan := NewChartDependencyManager(filename, st.logger, lockFile)
+	depMan.allowMismatch = st.AllowLockedVersionMismatch
 
 	if st.fs.ReadFile != nil {
 		depMan.readFile = st.fs.ReadFile
@@ -357,6 +391,7 @@ func updateDependencies(st *HelmState, shell helmexec.DependencyUpdater, unresol
 	}
 
 	depMan := NewChartDependencyManager(filename, st.logger, lockFile)
+	depMan.allowMismatch = st.AllowLockedVersionMismatch
 
 	_, err := depMan.Update(shell, wd, unresolved)
 	if err != nil {
@@ -372,6 +407,12 @@ type chartDependencyManager struct {
 	lockFilePath string
 
 	logger *zap.SugaredLogger
+
+	// allowMismatch, when true, lets ResolvedDependencies.Get fall back to the
+	// locked version instead of erroring when no locked version satisfies the
+	// helmfile.yaml constraint. Mirrors ReleaseSetSpec.AllowLockedVersionMismatch.
+	// See issue #870.
+	allowMismatch bool
 
 	readFile  func(string) ([]byte, error)
 	writeFile func(string, []byte, os.FileMode) error
@@ -499,7 +540,7 @@ func (m *chartDependencyManager) Resolve(unresolved *UnresolvedDependencies) (*R
 		// See https://github.com/helmfile/helmfile/issues/1473
 	}
 
-	resolved := &ResolvedDependencies{deps: map[string][]ResolvedChartDependency{}, logger: m.logger}
+	resolved := &ResolvedDependencies{deps: map[string][]ResolvedChartDependency{}, logger: m.logger, allowMismatch: m.allowMismatch}
 	for _, d := range lockedReqs.ResolvedDependencies {
 		if err := resolved.add(d); err != nil {
 			return nil, false, err

--- a/pkg/state/chart_dependency.go
+++ b/pkg/state/chart_dependency.go
@@ -91,6 +91,8 @@ func (d *UnresolvedDependencies) ToChartRequirements() *ChartRequirements {
 
 type ResolvedDependencies struct {
 	deps map[string][]ResolvedChartDependency
+
+	logger *zap.SugaredLogger
 }
 
 // nolint: unparam
@@ -111,22 +113,41 @@ func (d *ResolvedDependencies) Get(chart, versionConstraint string) (string, err
 	}
 
 	deps, exists := d.deps[chart]
-	if exists {
-		for _, dep := range deps {
-			constraint, err := semver.NewConstraint(versionConstraint)
-			if err != nil {
-				return "", err
-			}
-			version, err := semver.NewVersion(dep.Version)
-			if err != nil {
-				return "", err
-			}
-			if constraint.Check(version) {
-				return dep.Version, nil
-			}
+	if !exists {
+		return "", fmt.Errorf("no resolved dependency found for \"%s\", running \"helmfile deps\" may resolve the issue", chart)
+	}
+
+	constraint, err := semver.NewConstraint(versionConstraint)
+	if err != nil {
+		return "", err
+	}
+
+	// Prefer a locked version that satisfies the constraint declared in helmfile.yaml.
+	for _, dep := range deps {
+		version, err := semver.NewVersion(dep.Version)
+		if err != nil {
+			return "", err
+		}
+		if constraint.Check(version) {
+			return dep.Version, nil
 		}
 	}
-	return "", fmt.Errorf("no resolved dependency found for \"%s\", running \"helmfile deps\" may resolve the issue", chart)
+
+	// No locked version satisfied the constraint. The lock file is the source of
+	// truth for pinned versions, so fall back to the locked version instead of
+	// failing. This allows per-environment lock files to pin a different version
+	// than the one declared in helmfile.yaml (e.g. rolling out a new chart
+	// version progressively across environments without breaking the environments
+	// whose lock files still reference the previous version).
+	// See https://github.com/helmfile/helmfile/issues/870
+	lockedVersion := deps[0].Version
+	if d.logger != nil {
+		d.logger.Warnf(
+			"locked version %q for chart %q does not satisfy the constraint %q from helmfile.yaml; using the locked version from the lock file. Run \"helmfile deps\" to update the lock file.",
+			lockedVersion, chart, versionConstraint,
+		)
+	}
+	return lockedVersion, nil
 }
 
 func dedupResolvedDependencies(deps []ResolvedChartDependency) []ResolvedChartDependency {
@@ -478,7 +499,7 @@ func (m *chartDependencyManager) Resolve(unresolved *UnresolvedDependencies) (*R
 		// See https://github.com/helmfile/helmfile/issues/1473
 	}
 
-	resolved := &ResolvedDependencies{deps: map[string][]ResolvedChartDependency{}}
+	resolved := &ResolvedDependencies{deps: map[string][]ResolvedChartDependency{}, logger: m.logger}
 	for _, d := range lockedReqs.ResolvedDependencies {
 		if err := resolved.add(d); err != nil {
 			return nil, false, err

--- a/pkg/state/chart_dependency_test.go
+++ b/pkg/state/chart_dependency_test.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestResolvedDependencies_Get(t *testing.T) {
@@ -13,6 +16,7 @@ func TestResolvedDependencies_Get(t *testing.T) {
 		deps              map[string][]ResolvedChartDependency
 		chart             string
 		versionConstraint string
+		allowMismatch     bool
 		wantVersion       string
 		wantErr           bool
 	}{
@@ -35,13 +39,32 @@ func TestResolvedDependencies_Get(t *testing.T) {
 			wantVersion:       "13.10.2",
 		},
 		{
-			name: "constraint mismatch falls back to locked version (issue #870)",
+			// Default (strict) behavior: a lock file whose version does not satisfy
+			// the helmfile.yaml constraint fails loudly instead of silently
+			// deploying the wrong chart version (issue #870).
+			name: "constraint mismatch errors by default (strict)",
 			deps: map[string][]ResolvedChartDependency{
 				"mongodb": {{ChartName: "mongodb", Version: "13.10.2"}},
 			},
 			chart:             "mongodb",
 			versionConstraint: "13.10.3",
-			wantVersion:       "13.10.2",
+			wantErr:           true,
+		},
+		{
+			// Opt-in behavior: with allowLockedVersionMismatch the highest locked
+			// version is used even though it does not satisfy the constraint.
+			name: "constraint mismatch falls back to highest locked version when allowed",
+			deps: map[string][]ResolvedChartDependency{
+				"mongodb": {
+					{ChartName: "mongodb", Version: "13.10.1"},
+					{ChartName: "mongodb", Version: "13.10.3"},
+					{ChartName: "mongodb", Version: "13.10.2"},
+				},
+			},
+			chart:             "mongodb",
+			versionConstraint: "14.0.0",
+			allowMismatch:     true,
+			wantVersion:       "13.10.3",
 		},
 		{
 			name: "range constraint picks satisfying locked version among several",
@@ -66,7 +89,7 @@ func TestResolvedDependencies_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d := &ResolvedDependencies{deps: tt.deps}
+			d := &ResolvedDependencies{deps: tt.deps, allowMismatch: tt.allowMismatch}
 			got, err := d.Get(tt.chart, tt.versionConstraint)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -76,6 +99,45 @@ func TestResolvedDependencies_Get(t *testing.T) {
 			assert.Equal(t, tt.wantVersion, got)
 		})
 	}
+}
+
+// TestResolvedDependencies_Get_MismatchWarning asserts that, when mismatch
+// fallback is allowed, a warning describing the drift is emitted.
+func TestResolvedDependencies_Get_MismatchWarning(t *testing.T) {
+	core, obs := observer.New(zapcore.WarnLevel)
+	d := &ResolvedDependencies{
+		deps: map[string][]ResolvedChartDependency{
+			"mongodb": {{ChartName: "mongodb", Version: "13.10.2"}},
+		},
+		logger:        zap.New(core).Sugar(),
+		allowMismatch: true,
+	}
+
+	got, err := d.Get("mongodb", "13.10.3")
+	require.NoError(t, err)
+	assert.Equal(t, "13.10.2", got)
+
+	warns := obs.FilterMessageSnippet("does not satisfy").All()
+	require.Len(t, warns, 1, "expected a single drift warning")
+	assert.Equal(t, zapcore.WarnLevel, warns[0].Level)
+	assert.Contains(t, warns[0].Message, "mongodb", "warning should name the chart")
+}
+
+// TestResolvedDependencies_Get_StrictNoWarning asserts the default (strict)
+// path emits no fallback warning, only an error.
+func TestResolvedDependencies_Get_StrictNoWarning(t *testing.T) {
+	core, obs := observer.New(zapcore.DebugLevel)
+	d := &ResolvedDependencies{
+		deps: map[string][]ResolvedChartDependency{
+			"mongodb": {{ChartName: "mongodb", Version: "13.10.2"}},
+		},
+		logger:        zap.New(core).Sugar(),
+		allowMismatch: false,
+	}
+
+	_, err := d.Get("mongodb", "13.10.3")
+	require.Error(t, err)
+	assert.Empty(t, obs.All(), "strict path must not emit a fallback warning")
 }
 
 func TestDedupResolvedDependencies(t *testing.T) {

--- a/pkg/state/chart_dependency_test.go
+++ b/pkg/state/chart_dependency_test.go
@@ -3,8 +3,80 @@ package state
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestResolvedDependencies_Get(t *testing.T) {
+	tests := []struct {
+		name              string
+		deps              map[string][]ResolvedChartDependency
+		chart             string
+		versionConstraint string
+		wantVersion       string
+		wantErr           bool
+	}{
+		{
+			name: "satisfying version returns it",
+			deps: map[string][]ResolvedChartDependency{
+				"mongodb": {{ChartName: "mongodb", Version: "13.10.3"}},
+			},
+			chart:             "mongodb",
+			versionConstraint: "13.10.3",
+			wantVersion:       "13.10.3",
+		},
+		{
+			name: "wildcard constraint matches locked version",
+			deps: map[string][]ResolvedChartDependency{
+				"mongodb": {{ChartName: "mongodb", Version: "13.10.2"}},
+			},
+			chart:             "mongodb",
+			versionConstraint: "*",
+			wantVersion:       "13.10.2",
+		},
+		{
+			name: "constraint mismatch falls back to locked version (issue #870)",
+			deps: map[string][]ResolvedChartDependency{
+				"mongodb": {{ChartName: "mongodb", Version: "13.10.2"}},
+			},
+			chart:             "mongodb",
+			versionConstraint: "13.10.3",
+			wantVersion:       "13.10.2",
+		},
+		{
+			name: "range constraint picks satisfying locked version among several",
+			deps: map[string][]ResolvedChartDependency{
+				"envoy": {
+					{ChartName: "envoy", Version: "1.4.0"},
+					{ChartName: "envoy", Version: "1.5.0"},
+				},
+			},
+			chart:             "envoy",
+			versionConstraint: ">=1.5.0",
+			wantVersion:       "1.5.0",
+		},
+		{
+			name:              "unknown chart errors",
+			deps:              map[string][]ResolvedChartDependency{},
+			chart:             "missing",
+			versionConstraint: "*",
+			wantErr:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &ResolvedDependencies{deps: tt.deps}
+			got, err := d.Get(tt.chart, tt.versionConstraint)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantVersion, got)
+		})
+	}
+}
 
 func TestDedupResolvedDependencies(t *testing.T) {
 	tests := []struct {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -118,6 +118,15 @@ type ReleaseSetSpec struct {
 	MissingFileHandlerConfig *MissingFileHandlerConfig `yaml:"missingFileHandlerConfig,omitempty"`
 
 	LockFile string `yaml:"lockFilePath,omitempty"`
+
+	// AllowLockedVersionMismatch permits a per-environment lock file to pin a
+	// chart version that does not satisfy the version declared in helmfile.yaml.
+	// When enabled, helmfile falls back to the locked version (with a warning)
+	// instead of failing, which supports progressive rollouts where one
+	// environment is bumped ahead of others while the others keep their pins.
+	// Defaults to false (strict) so that a stale lock file still fails loudly.
+	// See https://github.com/helmfile/helmfile/issues/870
+	AllowLockedVersionMismatch bool `yaml:"allowLockedVersionMismatch,omitempty"`
 }
 
 type MissingFileHandlerConfig struct {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -3369,9 +3369,60 @@ func TestHelmState_ResolveDeps_NoLockFile_WithCustomLockFile(t *testing.T) {
 
 // TestHelmState_ResolveDeps_LockFile_VersionMismatchFallback reproduces issue #870:
 // when a per-environment lock file pins a chart version that does not satisfy the
-// version declared in helmfile.yaml, ResolveDeps should fall back to the locked
-// version (the lock file is authoritative) instead of failing.
+// version declared in helmfile.yaml, and "allowLockedVersionMismatch: true" is set,
+// ResolveDeps should fall back to the locked version (the lock file is authoritative)
+// instead of failing.
 func TestHelmState_ResolveDeps_LockFile_VersionMismatchFallback(t *testing.T) {
+	logger := helmexec.NewLogger(io.Discard, "debug")
+	state := &HelmState{
+		basePath: "/src",
+		FilePath: "/src/helmfile.yaml",
+		ReleaseSetSpec: ReleaseSetSpec{
+			LockFile:                   "lock-file",
+			AllowLockedVersionMismatch: true,
+			Releases: []ReleaseSpec{
+				{
+					Name:    "mongodb",
+					Chart:   "bitnami/mongodb",
+					Version: "13.10.3",
+				},
+			},
+			Repositories: []RepositorySpec{
+				{
+					Name: "bitnami",
+					URL:  "https://charts.bitnami.com/bitnami",
+				},
+			},
+		},
+		logger: logger,
+		fs: &filesystem.FileSystem{
+			ReadFile: func(f string) ([]byte, error) {
+				if f == filepath.Join("/src", "lock-file") {
+					return []byte(`
+version: 1.0.0
+dependencies:
+- name: mongodb
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.10.2
+digest: sha256:abc123
+generated: 2023-01-01T00:00:00Z
+`), nil
+				}
+				return nil, fmt.Errorf("stub: unexpected file: %s", f)
+			},
+		},
+	}
+
+	resolved, err := state.ResolveDeps()
+	require.NoError(t, err, "ResolveDeps should not fail when the lock file pins a different version and allowLockedVersionMismatch is set")
+	assert.Equal(t, "13.10.2", resolved.Releases[0].Version,
+		"the locked version should be used even though it does not satisfy the helmfile.yaml constraint")
+}
+
+// TestHelmState_ResolveDeps_LockFile_VersionMismatch_StrictErrors asserts the
+// default behavior: a lock file whose version does not satisfy the helmfile.yaml
+// constraint fails loudly (no silent fallback), guarding against stale lock files.
+func TestHelmState_ResolveDeps_LockFile_VersionMismatch_StrictErrors(t *testing.T) {
 	logger := helmexec.NewLogger(io.Discard, "debug")
 	state := &HelmState{
 		basePath: "/src",
@@ -3411,10 +3462,9 @@ generated: 2023-01-01T00:00:00Z
 		},
 	}
 
-	resolved, err := state.ResolveDeps()
-	require.NoError(t, err, "ResolveDeps should not fail when the lock file pins a different version")
-	assert.Equal(t, "13.10.2", resolved.Releases[0].Version,
-		"the locked version should be used even though it does not satisfy the helmfile.yaml constraint")
+	_, err := state.ResolveDeps()
+	require.Error(t, err, "ResolveDeps should fail by default when the lock file version does not satisfy the helmfile.yaml constraint")
+	assert.Contains(t, err.Error(), "allowLockedVersionMismatch", "error should guide users to the opt-in field")
 }
 
 func TestHelmState_ReleaseStatuses(t *testing.T) {

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -3366,6 +3366,57 @@ func TestHelmState_ResolveDeps_NoLockFile_WithCustomLockFile(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+// TestHelmState_ResolveDeps_LockFile_VersionMismatchFallback reproduces issue #870:
+// when a per-environment lock file pins a chart version that does not satisfy the
+// version declared in helmfile.yaml, ResolveDeps should fall back to the locked
+// version (the lock file is authoritative) instead of failing.
+func TestHelmState_ResolveDeps_LockFile_VersionMismatchFallback(t *testing.T) {
+	logger := helmexec.NewLogger(io.Discard, "debug")
+	state := &HelmState{
+		basePath: "/src",
+		FilePath: "/src/helmfile.yaml",
+		ReleaseSetSpec: ReleaseSetSpec{
+			LockFile: "lock-file",
+			Releases: []ReleaseSpec{
+				{
+					Name:    "mongodb",
+					Chart:   "bitnami/mongodb",
+					Version: "13.10.3",
+				},
+			},
+			Repositories: []RepositorySpec{
+				{
+					Name: "bitnami",
+					URL:  "https://charts.bitnami.com/bitnami",
+				},
+			},
+		},
+		logger: logger,
+		fs: &filesystem.FileSystem{
+			ReadFile: func(f string) ([]byte, error) {
+				if f == filepath.Join("/src", "lock-file") {
+					return []byte(`
+version: 1.0.0
+dependencies:
+- name: mongodb
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.10.2
+digest: sha256:abc123
+generated: 2023-01-01T00:00:00Z
+`), nil
+				}
+				return nil, fmt.Errorf("stub: unexpected file: %s", f)
+			},
+		},
+	}
+
+	resolved, err := state.ResolveDeps()
+	require.NoError(t, err, "ResolveDeps should not fail when the lock file pins a different version")
+	assert.Equal(t, "13.10.2", resolved.Releases[0].Version,
+		"the locked version should be used even though it does not satisfy the helmfile.yaml constraint")
+}
+
 func TestHelmState_ReleaseStatuses(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

Fixes #870

Per-environment lock files (via `lockFilePath`) that pin a chart version different from the one declared in `helmfile.yaml` caused a hard failure:

```
no resolved dependency found for "mongodb", running "helmfile deps" may resolve the issue
```

This blocked progressive rollouts — e.g. bumping a chart to `13.10.3` for the **dev** environment while **staging**'s lock file still pins `13.10.2` made every staging operation fail.

## Root cause

`ResolvedDependencies.Get()` in `pkg/state/chart_dependency.go` treated the `version` from `helmfile.yaml` as a hard constraint. If no locked version satisfied it, it errored out — even though the chart *was* present in the lock file.

## Fix

The lock file is the source of truth for pinned versions. `Get()` now:
1. Prefers a locked version that satisfies the helmfile.yaml constraint (unchanged best case).
2. If none matches but the chart **is** locked, falls back to the locked version and logs a warning advising `helmfile deps` — instead of failing.
3. Only a completely missing chart in the lock file remains a hard error.

This differs from the previously closed #904, which pursued an alias-based disambiguation approach but (a) was never merged and (b) still performed a strict constraint check, so it would not have resolved the reported mismatch scenario.

## Test plan

- [x] `TestResolvedDependencies_Get` — covers match, wildcard, mismatch-fallback, multi-version range, and unknown-chart cases
- [x] `TestHelmState_ResolveDeps_LockFile_VersionMismatchFallback` — reproduces the exact #870 scenario (lock `13.10.2` vs yaml `13.10.3`)
- [x] Full `pkg/state` suite passes (`-race -p=1`)
- [x] `golangci-lint` — 0 issues
- [x] `make check` (go vet) clean