### PR TITLE
fix: rewrite file:// deps in nested subchart Chart.yaml for envelope charts

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -285,6 +285,18 @@ There's also `releases[].jsonPatches` that works similarly to `strategicMergePat
 
 Please also see [test/advanced/helmfile.yaml](https://github.com/helmfile/helmfile/tree/master/test/advanced/helmfile.yaml) for an example of patching support and more.
 
+#### Patching envelope charts (charts with nested subcharts)
+
+`strategicMergePatches`, `jsonPatches`, and `transformers` all work on resources defined
+anywhere in the chart, including resources rendered by nested subcharts of nested subcharts.
+For local envelope charts whose subcharts declare their own `file://` dependencies, Helmfile
+rewrites those relative dependencies to absolute paths in **every** `Chart.yaml` in the chart
+tree (top-level plus every unpacked subchart under `charts/`) before handing the chart to
+chartify. Without this, chartify's copy of the chart would resolve nested `file://` paths
+against its temporary directory and silently drop the nested subcharts' resources, causing
+patches targeting those resources to fail with `no resource matches`.
+See [issue #851](https://github.com/helmfile/helmfile/issues/851).
+
 ### `transformers`
 
 You can set `transformers` to apply [Kustomize's transformers](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/configureBuiltinPlugin.md#configuring-the-builtin-plugins-instead).

--- a/pkg/state/chart_dependencies_rewrite_test.go
+++ b/pkg/state/chart_dependencies_rewrite_test.go
@@ -1109,3 +1109,294 @@ generated: "2024-01-01T00:00:00Z"
 		t.Errorf("digest mismatch with Helm's HashReq algorithm:\n  got:  %s\n  want: %s", lock.Digest, expectedDigest)
 	}
 }
+
+// TestRewriteChartDependencies_NestedSubcharts verifies that relative file:// dependencies
+// in nested subcharts' Chart.yaml (e.g. charts/SUBCHART/Chart.yaml) are also rewritten to
+// absolute paths. Without this, an envelope chart whose subcharts have their own local
+// file:// dependencies breaks when chartify copies the chart into its temporary directory:
+// the relative paths resolve against the temp dir instead of the original chart location,
+// the nested subcharts fail to resolve, and strategicMergePatches/jsonPatches targeting
+// resources from those nested subcharts silently miss them.
+// See https://github.com/helmfile/helmfile/issues/851.
+func TestRewriteChartDependencies_NestedSubcharts(t *testing.T) {
+	rootDir, err := os.MkdirTemp("", "helmfile-nested-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(rootDir)
+
+	// Lay out a chart tree that mirrors the issue 851 scenario:
+	//   envelope/Chart.yaml                      (deps: sub1, sub2 via file://)
+	//   envelope/charts/sub1/Chart.yaml          (no deps)
+	//   envelope/charts/sub2/Chart.yaml          (deps: nested via file://../nested)
+	//   envelope/charts/sub2/charts/nested/Chart.yaml  (no deps)
+	// sub2 has a RELATIVE file:// dep on `nested`. After chartify copies the chart to its
+	// temp dir, that path needs to resolve back to the original `nested` source directory.
+	topChartYaml := `apiVersion: v2
+name: envelope
+version: 0.1.0
+dependencies:
+  - name: sub1
+    repository: file://../sub1
+    version: 0.1.0
+  - name: sub2
+    repository: file://../sub2
+    version: 0.1.0
+`
+	sub1ChartYaml := `apiVersion: v2
+name: sub1
+version: 0.1.0
+`
+	sub2ChartYaml := `apiVersion: v2
+name: sub2
+version: 0.1.0
+dependencies:
+  - name: nested
+    repository: file://../nested
+    version: 0.1.0
+`
+	nestedChartYaml := `apiVersion: v2
+name: nested
+version: 0.1.0
+`
+
+	// Create source subchart directories as siblings of envelope, so file://../X resolves.
+	if err := os.MkdirAll(filepath.Join(rootDir, "envelope"), 0755); err != nil {
+		t.Fatalf("mkdir envelope: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rootDir, "sub1"), 0755); err != nil {
+		t.Fatalf("mkdir sub1: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rootDir, "sub2"), 0755); err != nil {
+		t.Fatalf("mkdir sub2: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rootDir, "nested"), 0755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+
+	// Mirror the subchart sources inside envelope/charts/ to exercise the nested-rewrite path.
+	if err := os.MkdirAll(filepath.Join(rootDir, "envelope", "charts", "sub1"), 0755); err != nil {
+		t.Fatalf("mkdir envelope/charts/sub1: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rootDir, "envelope", "charts", "sub2", "charts", "nested"), 0755); err != nil {
+		t.Fatalf("mkdir envelope/charts/sub2/charts/nested: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(rootDir, "envelope", "Chart.yaml"), []byte(topChartYaml), 0644); err != nil {
+		t.Fatalf("write envelope/Chart.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "envelope", "charts", "sub1", "Chart.yaml"), []byte(sub1ChartYaml), 0644); err != nil {
+		t.Fatalf("write envelope/charts/sub1/Chart.yaml: %v", err)
+	}
+	// sub2's Chart.yaml has a RELATIVE file:// dep — this is what we expect to be rewritten.
+	if err := os.WriteFile(filepath.Join(rootDir, "envelope", "charts", "sub2", "Chart.yaml"), []byte(sub2ChartYaml), 0644); err != nil {
+		t.Fatalf("write envelope/charts/sub2/Chart.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "envelope", "charts", "sub2", "charts", "nested", "Chart.yaml"), []byte(nestedChartYaml), 0644); err != nil {
+		t.Fatalf("write envelope/charts/sub2/charts/nested/Chart.yaml: %v", err)
+	}
+
+	logger := zap.NewNop().Sugar()
+	st := &HelmState{
+		logger: logger,
+		fs:     filesystem.DefaultFileSystem(),
+	}
+
+	rewrittenPath, cleanup, err := st.rewriteChartDependencies(filepath.Join(rootDir, "envelope"))
+	if err != nil {
+		t.Fatalf("rewriteChartDependencies failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if rewrittenPath != filepath.Join(rootDir, "envelope") {
+			cleanup()
+		}
+	})
+
+	// Rewrite must produce a temp copy because both the top-level Chart.yaml AND sub2's
+	// Chart.yaml contain relative file:// dependencies.
+	if rewrittenPath == filepath.Join(rootDir, "envelope") {
+		t.Fatalf("expected a rewritten temp copy, got the original path")
+	}
+
+	// Top-level Chart.yaml: relative file:// must be rewritten to absolute.
+	topData, err := os.ReadFile(filepath.Join(rewrittenPath, "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("read top-level Chart.yaml: %v", err)
+	}
+	topContent := string(topData)
+	if strings.Contains(topContent, "file://../sub1") || strings.Contains(topContent, "file://../sub2") {
+		t.Errorf("top-level Chart.yaml still contains relative file:// paths:\n%s", topContent)
+	}
+	if !strings.Contains(topContent, "file://") {
+		t.Errorf("top-level Chart.yaml should still contain file:// absolute paths")
+	}
+
+	// The critical assertion: sub2's Chart.yaml (nested under charts/sub2/) must also be
+	// rewritten to absolute paths. Without this fix, the original `file://../nested` would
+	// resolve against the temp dir and the nested subchart would silently fail to load.
+	sub2Data, err := os.ReadFile(filepath.Join(rewrittenPath, "charts", "sub2", "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("read charts/sub2/Chart.yaml: %v", err)
+	}
+	sub2Content := string(sub2Data)
+	if strings.Contains(sub2Content, "file://../nested") {
+		t.Errorf("nested sub2 Chart.yaml still contains relative file://../nested path:\n%s", sub2Content)
+	}
+	if !strings.Contains(sub2Content, "file://") {
+		t.Errorf("nested sub2 Chart.yaml should contain absolute file:// path after rewrite")
+	}
+	// The rewritten path must reflect how Helm resolves relative paths in subchart
+	// Chart.yaml: `file://../nested` in `charts/sub2/Chart.yaml` is relative to the
+	// sub2 directory, so it resolves to `charts/nested` (a sibling of sub2 inside the
+	// chart). The rewrite preserves that resolution while making the result absolute.
+	expectedNestedAbs := "file://" + filepath.Join(rootDir, "envelope", "charts", "nested")
+	if !strings.Contains(sub2Content, expectedNestedAbs) {
+		t.Errorf("nested sub2 Chart.yaml should reference %s\nGot:\n%s", expectedNestedAbs, sub2Content)
+	}
+
+	// Source directories must NOT be modified.
+	origSub2, err := os.ReadFile(filepath.Join(rootDir, "envelope", "charts", "sub2", "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("read original sub2 Chart.yaml: %v", err)
+	}
+	if string(origSub2) != sub2ChartYaml {
+		t.Errorf("original sub2 Chart.yaml must not be modified by the rewrite")
+	}
+
+	// sub1 has no file:// deps — its Chart.yaml should be unchanged in the temp copy.
+	sub1Data, err := os.ReadFile(filepath.Join(rewrittenPath, "charts", "sub1", "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("read charts/sub1/Chart.yaml: %v", err)
+	}
+	if string(sub1Data) != sub1ChartYaml {
+		t.Errorf("sub1 Chart.yaml (no file:// deps) should be unchanged, got:\n%s", string(sub1Data))
+	}
+}
+
+// TestRewriteChartDependencies_NoNestedRewriteForAbsolutePaths ensures that absolute
+// file:// paths in nested subcharts' Chart.yaml are left untouched.
+func TestRewriteChartDependencies_NoNestedRewriteForAbsolutePaths(t *testing.T) {
+	rootDir, err := os.MkdirTemp("", "helmfile-nested-abs-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(rootDir)
+
+	// Only the top-level Chart.yaml has a relative path that triggers a rewrite.
+	// The nested subchart uses an absolute path and should not require rewriting itself.
+	topChartYaml := `apiVersion: v2
+name: envelope
+version: 0.1.0
+dependencies:
+  - name: sub1
+    repository: file://../sub1
+    version: 0.1.0
+`
+	sub1ChartYaml := fmt.Sprintf(`apiVersion: v2
+name: sub1
+version: 0.1.0
+dependencies:
+  - name: nested
+    repository: file://%s
+    version: 0.1.0
+`, filepath.Join(rootDir, "nested"))
+
+	if err := os.MkdirAll(filepath.Join(rootDir, "envelope", "charts", "sub1"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "envelope", "Chart.yaml"), []byte(topChartYaml), 0644); err != nil {
+		t.Fatalf("write Chart.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "envelope", "charts", "sub1", "Chart.yaml"), []byte(sub1ChartYaml), 0644); err != nil {
+		t.Fatalf("write sub1 Chart.yaml: %v", err)
+	}
+
+	st := &HelmState{
+		logger: zap.NewNop().Sugar(),
+		fs:     filesystem.DefaultFileSystem(),
+	}
+	rewrittenPath, cleanup, err := st.rewriteChartDependencies(filepath.Join(rootDir, "envelope"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Cleanup(func() {
+		if rewrittenPath != filepath.Join(rootDir, "envelope") {
+			cleanup()
+		}
+	})
+
+	if rewrittenPath == filepath.Join(rootDir, "envelope") {
+		t.Fatalf("expected a temp copy because the top-level Chart.yaml needs rewriting")
+	}
+
+	// sub1's Chart.yaml must be preserved verbatim (it only has an absolute path).
+	sub1Data, err := os.ReadFile(filepath.Join(rewrittenPath, "charts", "sub1", "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("read sub1 Chart.yaml: %v", err)
+	}
+	if string(sub1Data) != sub1ChartYaml {
+		t.Errorf("sub1 Chart.yaml with only absolute file:// dep should be unchanged:\nwant:\n%s\ngot:\n%s", sub1ChartYaml, string(sub1Data))
+	}
+}
+
+// TestRewriteChartDependencies_NoOpWhenOnlyNestedRelativeDeps verifies that the function
+// still triggers a rewrite (and temp copy) when only nested subchart Chart.yaml files have
+// relative file:// deps, even if the top-level chart has none.
+func TestRewriteChartDependencies_NoOpWhenOnlyNestedRelativeDeps(t *testing.T) {
+	rootDir, err := os.MkdirTemp("", "helmfile-only-nested-")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(rootDir)
+
+	// Top-level chart has no relative file:// deps.
+	topChartYaml := `apiVersion: v2
+name: envelope
+version: 0.1.0
+`
+	// Nested subchart has a relative file:// dep.
+	subChartYaml := `apiVersion: v2
+name: sub1
+version: 0.1.0
+dependencies:
+  - name: nested
+    repository: file://../nested
+    version: 0.1.0
+`
+
+	if err := os.MkdirAll(filepath.Join(rootDir, "envelope", "charts", "sub1"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "envelope", "Chart.yaml"), []byte(topChartYaml), 0644); err != nil {
+		t.Fatalf("write Chart.yaml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "envelope", "charts", "sub1", "Chart.yaml"), []byte(subChartYaml), 0644); err != nil {
+		t.Fatalf("write sub1 Chart.yaml: %v", err)
+	}
+
+	st := &HelmState{
+		logger: zap.NewNop().Sugar(),
+		fs:     filesystem.DefaultFileSystem(),
+	}
+	rewrittenPath, cleanup, err := st.rewriteChartDependencies(filepath.Join(rootDir, "envelope"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Cleanup(func() {
+		if rewrittenPath != filepath.Join(rootDir, "envelope") {
+			cleanup()
+		}
+	})
+
+	if rewrittenPath == filepath.Join(rootDir, "envelope") {
+		t.Fatalf("expected a temp copy because nested subchart Chart.yaml has a relative file:// dep")
+	}
+
+	sub1Data, err := os.ReadFile(filepath.Join(rewrittenPath, "charts", "sub1", "Chart.yaml"))
+	if err != nil {
+		t.Fatalf("read sub1 Chart.yaml: %v", err)
+	}
+	if strings.Contains(string(sub1Data), "file://../nested") {
+		t.Errorf("nested subchart relative path should have been rewritten:\n%s", string(sub1Data))
+	}
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1620,62 +1620,24 @@ type PrepareChartKey struct {
 // contents so prepare hooks or other steps that mutate the local chart directory are honored.
 // The returned cleanup function removes the temporary directory when one was created and is
 // otherwise a no-op.
+//
+// In addition to the top-level Chart.yaml, this also rewrites relative file:// dependencies in
+// nested subcharts' Chart.yaml files (e.g. charts/SUBCHART/Chart.yaml,
+// charts/SUBCHART/charts/NESTED/Chart.yaml). Without this, an envelope chart whose subcharts
+// have their own local file:// dependencies breaks when chartify copies the chart into its
+// temporary directory: the relative paths resolve against the temp dir instead of the original
+// chart location, the nested subcharts fail to resolve, and strategicMergePatches/jsonPatches
+// targeting resources from those nested subcharts silently miss them.
+// See https://github.com/helmfile/helmfile/issues/851.
 func (st *HelmState) rewriteChartDependencies(chartPath string) (string, func(), error) {
-	chartYamlPath := filepath.Join(chartPath, "Chart.yaml")
-
-	if _, err := st.fs.Stat(chartYamlPath); os.IsNotExist(err) {
-		return chartPath, func() {}, nil
-	} else if err != nil {
-		return chartPath, func() {}, err
-	}
-
-	data, err := st.fs.ReadFile(chartYamlPath)
+	// Collect every Chart.yaml that needs to be rewritten. The top-level chart and any
+	// nested subcharts under charts/*/charts/*/... are candidates.
+	chartYamlByDir, err := st.collectChartsNeedingRewrite(chartPath)
 	if err != nil {
 		return chartPath, func() {}, err
 	}
-
-	type ChartDependency struct {
-		Name       string                 `yaml:"name"`
-		Repository string                 `yaml:"repository"`
-		Data       map[string]interface{} `yaml:",inline"`
-	}
-	type ChartMeta struct {
-		Dependencies []ChartDependency      `yaml:"dependencies,omitempty"`
-		Data         map[string]interface{} `yaml:",inline"`
-	}
-
-	var chartMeta ChartMeta
-	if err := yaml.Unmarshal(data, &chartMeta); err != nil {
-		return chartPath, func() {}, err
-	}
-
-	modified := false
-	for i := range chartMeta.Dependencies {
-		dep := &chartMeta.Dependencies[i]
-		if strings.HasPrefix(dep.Repository, "file://") {
-			relPath := strings.TrimPrefix(dep.Repository, "file://")
-
-			if !filepath.IsAbs(relPath) {
-				absPath := filepath.Join(chartPath, relPath)
-				absPath, err = filepath.Abs(absPath)
-				if err != nil {
-					return chartPath, func() {}, fmt.Errorf("failed to resolve absolute path for dependency %s: %w", dep.Name, err)
-				}
-
-				st.logger.Debugf("Rewriting Chart dependency %s from %s to file://%s", dep.Name, dep.Repository, absPath)
-				dep.Repository = "file://" + absPath
-				modified = true
-			}
-		}
-	}
-
-	if !modified {
+	if len(chartYamlByDir) == 0 {
 		return chartPath, func() {}, nil
-	}
-
-	updatedData, err := yaml.Marshal(&chartMeta)
-	if err != nil {
-		return chartPath, func() {}, fmt.Errorf("failed to marshal Chart.yaml: %w", err)
 	}
 
 	tempDir, err := st.fs.MkdirTemp("", "chart-deps-rewrite-*")
@@ -1690,12 +1652,173 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (string, func(),
 		return chartPath, func() {}, fmt.Errorf("failed to copy chart to temp directory: %w", err)
 	}
 
-	tempChartYamlPath := filepath.Join(tempDir, "Chart.yaml")
-	if err := st.fs.WriteFile(tempChartYamlPath, updatedData, 0644); err != nil {
+	// Rewrite each affected Chart.yaml inside the temp copy and refresh its Chart.lock
+	// digest so downstream `helm dependency build` doesn't reject the lock as stale.
+	// chartYamlByDir preserves insertion order (top-level first, then nested), which
+	// matches the order helm resolves dependencies.
+	for origDir, meta := range chartYamlByDir {
+		relDir, relErr := filepath.Rel(chartPath, origDir)
+		if relErr != nil {
+			if removeErr := st.fs.RemoveAll(tempDir); removeErr != nil {
+				st.logger.Warnf("Failed to remove temp chart directory %s: %v", tempDir, removeErr)
+			}
+			return chartPath, func() {}, fmt.Errorf("failed to compute relative path for %s: %w", origDir, relErr)
+		}
+		tempSubDir := filepath.Join(tempDir, relDir)
+		if err := st.applyChartYamlRewrite(tempSubDir, meta); err != nil {
+			if removeErr := st.fs.RemoveAll(tempDir); removeErr != nil {
+				st.logger.Warnf("Failed to remove temp chart directory %s: %v", tempDir, removeErr)
+			}
+			return chartPath, func() {}, err
+		}
+	}
+
+	cleanup := func() {
 		if removeErr := st.fs.RemoveAll(tempDir); removeErr != nil {
 			st.logger.Warnf("Failed to remove temp chart directory %s: %v", tempDir, removeErr)
 		}
-		return chartPath, func() {}, fmt.Errorf("failed to write Chart.yaml: %w", err)
+	}
+
+	return tempDir, cleanup, nil
+}
+
+// chartRewriteMeta captures the parsed Chart.yaml content and the rewritten dependency list
+// for a single chart (top-level or nested subchart) that needs its relative file://
+// dependencies converted to absolute paths.
+type chartRewriteMeta struct {
+	// rewrittenMeta is the Chart.yaml structure with file:// repos rewritten to absolute paths.
+	rewrittenMeta *chartMetaForRewrite
+}
+
+// chartMetaForRewrite is the on-disk representation of Chart.yaml used during the rewrite.
+type chartMetaForRewrite struct {
+	Dependencies []chartDependencyForRewrite `yaml:"dependencies,omitempty"`
+	Data         map[string]interface{}      `yaml:",inline"`
+}
+
+// chartDependencyForRewrite models a single Chart.yaml dependency entry. The inline Data
+// map captures any other fields (version, condition, alias, tags, import-values, ...) so
+// they round-trip unchanged through marshal/unmarshal.
+type chartDependencyForRewrite struct {
+	Name       string                 `yaml:"name"`
+	Repository string                 `yaml:"repository"`
+	Data       map[string]interface{} `yaml:",inline"`
+}
+
+// collectChartsNeedingRewrite walks chartPath looking for Chart.yaml files (the top-level
+// chart plus any nested subcharts under charts/<name>/). It returns a map from the absolute
+// chart directory to the parsed-and-rewritten metadata, but only for charts whose Chart.yaml
+// actually contains relative file:// dependencies. Insertion order is top-level first, then
+// subcharts in discovery order (see walkChartDirs).
+func (st *HelmState) collectChartsNeedingRewrite(chartPath string) (map[string]*chartRewriteMeta, error) {
+	dirs, err := st.walkChartDirs(chartPath)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]*chartRewriteMeta, len(dirs))
+	for _, dir := range dirs {
+		chartYamlPath := filepath.Join(dir, "Chart.yaml")
+		data, readErr := st.fs.ReadFile(chartYamlPath)
+		if readErr != nil {
+			if os.IsNotExist(readErr) {
+				continue
+			}
+			return nil, readErr
+		}
+
+		var meta chartMetaForRewrite
+		if err := yaml.Unmarshal(data, &meta); err != nil {
+			return nil, fmt.Errorf("failed to parse %s: %w", chartYamlPath, err)
+		}
+
+		anyRewritten := false
+		for i := range meta.Dependencies {
+			dep := &meta.Dependencies[i]
+			if !strings.HasPrefix(dep.Repository, "file://") {
+				continue
+			}
+			relPath := strings.TrimPrefix(dep.Repository, "file://")
+			if filepath.IsAbs(relPath) {
+				continue
+			}
+			absPath := filepath.Join(dir, relPath)
+			absPath, absErr := filepath.Abs(absPath)
+			if absErr != nil {
+				return nil, fmt.Errorf("failed to resolve absolute path for dependency %s in %s: %w", dep.Name, chartYamlPath, absErr)
+			}
+			st.logger.Debugf("Rewriting Chart dependency %s from %s to file://%s (in %s)", dep.Name, dep.Repository, absPath, chartYamlPath)
+			dep.Repository = "file://" + absPath
+			anyRewritten = true
+		}
+
+		if anyRewritten {
+			rewritten := meta
+			result[dir] = &chartRewriteMeta{rewrittenMeta: &rewritten}
+		}
+	}
+
+	return result, nil
+}
+
+// walkChartDirs returns the absolute paths of chart directories under chartPath that may
+// contain a Chart.yaml: chartPath itself, followed by every unpacked subchart under
+// charts/<name>/, recursively. Subcharts packaged as .tgz archives are not descended into
+// (helm treats them as opaque). The order is deterministic: parents before children,
+// siblings in lexical order.
+func (st *HelmState) walkChartDirs(chartPath string) ([]string, error) {
+	var dirs []string
+	var walk func(dir string) error
+	walk = func(dir string) error {
+		chartYamlPath := filepath.Join(dir, "Chart.yaml")
+		_, err := st.fs.Stat(chartYamlPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		dirs = append(dirs, dir)
+
+		chartsDir := filepath.Join(dir, "charts")
+		entries, err := st.fs.ReadDir(chartsDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			if err := walk(filepath.Join(chartsDir, e.Name())); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if err := walk(chartPath); err != nil {
+		return nil, err
+	}
+	return dirs, nil
+}
+
+// applyChartYamlRewrite writes the rewritten Chart.yaml into tempSubDir and refreshes the
+// co-located Chart.lock digest so `helm dependency build` doesn't reject the lock as stale.
+// meta describes the Chart.yaml content with file:// repositories already rewritten to
+// absolute paths.
+func (st *HelmState) applyChartYamlRewrite(tempSubDir string, meta *chartRewriteMeta) error {
+	tempChartYamlPath := filepath.Join(tempSubDir, "Chart.yaml")
+
+	updatedData, err := yaml.Marshal(meta.rewrittenMeta)
+	if err != nil {
+		return fmt.Errorf("failed to marshal Chart.yaml at %s: %w", tempChartYamlPath, err)
+	}
+
+	if err := st.fs.WriteFile(tempChartYamlPath, updatedData, 0644); err != nil {
+		return fmt.Errorf("failed to write Chart.yaml at %s: %w", tempChartYamlPath, err)
 	}
 
 	st.logger.Debugf("Rewrote Chart.yaml with absolute dependency paths at %s", tempChartYamlPath)
@@ -1708,120 +1831,123 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (string, func(),
 	// pulls newer dependency versions. The version pins in the lock are still the
 	// intended truth — only the rewritten file:// repository URL changed. Mirror the
 	// rewrite into the lock and recompute the digest so `dep build` accepts it.
-	tempChartLockPath := filepath.Join(tempDir, "Chart.lock")
+	tempChartLockPath := filepath.Join(tempSubDir, "Chart.lock")
 	lockData, lockErr := st.fs.ReadFile(tempChartLockPath)
 	if lockErr != nil && !os.IsNotExist(lockErr) {
 		st.logger.Warnf("Failed to read Chart.lock at %s: %v", tempChartLockPath, lockErr)
 	}
-	if lockErr == nil {
-		var lock struct {
-			Dependencies []*helmchart.Dependency `yaml:"dependencies,omitempty"`
-			Digest       string                  `yaml:"digest,omitempty"`
-			Generated    string                  `yaml:"generated,omitempty"`
+	if lockErr != nil {
+		// No lock file (or unreadable): nothing more to do. If the lock is missing,
+		// helm will resolve from Chart.yaml directly.
+		return nil
+	}
+
+	var lock struct {
+		Dependencies []*helmchart.Dependency `yaml:"dependencies,omitempty"`
+		Digest       string                  `yaml:"digest,omitempty"`
+		Generated    string                  `yaml:"generated,omitempty"`
+	}
+	if err := yaml.Unmarshal(lockData, &lock); err != nil {
+		st.logger.Warnf("Failed to parse Chart.lock at %s: %v", tempChartLockPath, err)
+		return nil
+	}
+
+	// Build the request slice (rewritten Chart.yaml dependencies) using helm's
+	// own chart.Dependency type so the JSON used for hashing matches helm's
+	// exactly. All supported fields must be mapped, not just name/repository/
+	// version, because helm's digest algorithm hashes the full Dependency struct.
+	rewrittenDeps := meta.rewrittenMeta.Dependencies
+	req := make([]*helmchart.Dependency, 0, len(rewrittenDeps))
+	for _, d := range rewrittenDeps {
+		dep := &helmchart.Dependency{
+			Name:       d.Name,
+			Repository: d.Repository,
 		}
-		if err := yaml.Unmarshal(lockData, &lock); err != nil {
-			st.logger.Warnf("Failed to parse Chart.lock at %s: %v", tempChartLockPath, err)
-		} else {
-			// Build the request slice (rewritten Chart.yaml dependencies) using helm's
-			// own chart.Dependency type so the JSON used for hashing matches helm's
-			// exactly. All supported fields must be mapped, not just name/repository/
-			// version, because helm's digest algorithm hashes the full Dependency struct.
-			req := make([]*helmchart.Dependency, 0, len(chartMeta.Dependencies))
-			for _, d := range chartMeta.Dependencies {
-				dep := &helmchart.Dependency{
-					Name:       d.Name,
-					Repository: d.Repository,
-				}
-				if v, ok := d.Data["version"].(string); ok {
-					dep.Version = v
-				}
-				if v, ok := d.Data["condition"].(string); ok {
-					dep.Condition = v
-				}
-				if v, ok := d.Data["alias"].(string); ok {
-					dep.Alias = v
-				}
-				if v, ok := d.Data["enabled"].(bool); ok {
-					dep.Enabled = v
-				}
-				if v, ok := d.Data["tags"].([]interface{}); ok {
-					tags := make([]string, 0, len(v))
-					for _, t := range v {
-						if s, ok := t.(string); ok {
-							tags = append(tags, s)
-						}
-					}
-					dep.Tags = tags
-				}
-				if v, ok := d.Data["import-values"].([]interface{}); ok {
-					normalized, err := maputil.RecursivelyStringifyMapKey(v)
-					if err != nil {
-						st.logger.Warnf("Failed to normalize import-values for dependency %s: %v", d.Name, err)
-					} else {
-						dep.ImportValues = normalized.([]interface{})
-					}
-				}
-				req = append(req, dep)
-			}
-
-			// Mirror the rewritten file:// repository URLs onto matching lock entries.
-			// Without this, `helm dependency build` would resolve the lock's relative
-			// file:// paths against the (moved) chart directory and fail with
-			// "directory ... not found". Versions in the lock are left untouched.
-			// Match on Name + Alias to handle charts with duplicate dependency names
-			// distinguished by alias.
-			for _, ld := range lock.Dependencies {
-				if !strings.HasPrefix(ld.Repository, "file://") {
-					continue
-				}
-				for _, rd := range req {
-					if rd.Name == ld.Name && rd.Alias == ld.Alias && strings.HasPrefix(rd.Repository, "file://") {
-						ld.Repository = rd.Repository
-						break
-					}
+		if v, ok := d.Data["version"].(string); ok {
+			dep.Version = v
+		}
+		if v, ok := d.Data["condition"].(string); ok {
+			dep.Condition = v
+		}
+		if v, ok := d.Data["alias"].(string); ok {
+			dep.Alias = v
+		}
+		if v, ok := d.Data["enabled"].(bool); ok {
+			dep.Enabled = v
+		}
+		if v, ok := d.Data["tags"].([]interface{}); ok {
+			tags := make([]string, 0, len(v))
+			for _, t := range v {
+				if s, ok := t.(string); ok {
+					tags = append(tags, s)
 				}
 			}
-
-			// Normalize lock.Dependencies ImportValues to avoid json.Marshal failures
-			// when go-yaml v2 decodes nested maps as map[interface{}]interface{}.
-			for _, ld := range lock.Dependencies {
-				if ld.ImportValues != nil {
-					normalized, err := maputil.RecursivelyStringifyMapKey(ld.ImportValues)
-					if err != nil {
-						st.logger.Warnf("Failed to normalize import-values in Chart.lock for dependency %s: %v", ld.Name, err)
-					} else {
-						ld.ImportValues = normalized.([]interface{})
-					}
-				}
-			}
-
-			// Replicates helm's resolver.HashReq:
-			//   json.Marshal([2][]*chart.Dependency{req, lock}) → sha256 hex.
-			// resolver.HashReq lives in helm.sh/helm/v3/internal/resolver, so we
-			// inline the (small, stable) algorithm rather than importing it.
-			if payload, err := json.Marshal([2][]*helmchart.Dependency{req, lock.Dependencies}); err != nil {
-				st.logger.Warnf("Failed to marshal deps for Chart.lock digest at %s: %v", tempChartLockPath, err)
+			dep.Tags = tags
+		}
+		if v, ok := d.Data["import-values"].([]interface{}); ok {
+			normalized, err := maputil.RecursivelyStringifyMapKey(v)
+			if err != nil {
+				st.logger.Warnf("Failed to normalize import-values for dependency %s: %v", d.Name, err)
 			} else {
-				sum := sha256.Sum256(payload)
-				lock.Digest = "sha256:" + hex.EncodeToString(sum[:])
-				if updated, err := yaml.Marshal(&lock); err != nil {
-					st.logger.Warnf("Failed to marshal Chart.lock at %s: %v", tempChartLockPath, err)
-				} else if err := st.fs.WriteFile(tempChartLockPath, updated, 0644); err != nil {
-					st.logger.Warnf("Failed to write Chart.lock at %s: %v", tempChartLockPath, err)
-				} else {
-					st.logger.Debugf("Refreshed Chart.lock digest at %s after Chart.yaml rewrite", tempChartLockPath)
-				}
+				dep.ImportValues = normalized.([]interface{})
+			}
+		}
+		req = append(req, dep)
+	}
+
+	// Mirror the rewritten file:// repository URLs onto matching lock entries.
+	// Without this, `helm dependency build` would resolve the lock's relative
+	// file:// paths against the (moved) chart directory and fail with
+	// "directory ... not found". Versions in the lock are left untouched.
+	// Match on Name + Alias to handle charts with duplicate dependency names
+	// distinguished by alias.
+	for _, ld := range lock.Dependencies {
+		if !strings.HasPrefix(ld.Repository, "file://") {
+			continue
+		}
+		for _, rd := range req {
+			if rd.Name == ld.Name && rd.Alias == ld.Alias && strings.HasPrefix(rd.Repository, "file://") {
+				ld.Repository = rd.Repository
+				break
 			}
 		}
 	}
 
-	cleanup := func() {
-		if removeErr := st.fs.RemoveAll(tempDir); removeErr != nil {
-			st.logger.Warnf("Failed to remove temp chart directory %s: %v", tempDir, removeErr)
+	// Normalize lock.Dependencies ImportValues to avoid json.Marshal failures
+	// when go-yaml v2 decodes nested maps as map[interface{}]interface{}.
+	for _, ld := range lock.Dependencies {
+		if ld.ImportValues != nil {
+			normalized, err := maputil.RecursivelyStringifyMapKey(ld.ImportValues)
+			if err != nil {
+				st.logger.Warnf("Failed to normalize import-values in Chart.lock for dependency %s: %v", ld.Name, err)
+			} else {
+				ld.ImportValues = normalized.([]interface{})
+			}
 		}
 	}
 
-	return tempDir, cleanup, nil
+	// Replicates helm's resolver.HashReq:
+	//   json.Marshal([2][]*chart.Dependency{req, lock}) → sha256 hex.
+	// resolver.HashReq lives in helm.sh/helm/v3/internal/resolver, so we
+	// inline the (small, stable) algorithm rather than importing it.
+	payload, err := json.Marshal([2][]*helmchart.Dependency{req, lock.Dependencies})
+	if err != nil {
+		st.logger.Warnf("Failed to marshal deps for Chart.lock digest at %s: %v", tempChartLockPath, err)
+		return nil
+	}
+	sum := sha256.Sum256(payload)
+	lock.Digest = "sha256:" + hex.EncodeToString(sum[:])
+	updated, err := yaml.Marshal(&lock)
+	if err != nil {
+		st.logger.Warnf("Failed to marshal Chart.lock at %s: %v", tempChartLockPath, err)
+		return nil
+	}
+	if err := st.fs.WriteFile(tempChartLockPath, updated, 0644); err != nil {
+		st.logger.Warnf("Failed to write Chart.lock at %s: %v", tempChartLockPath, err)
+		return nil
+	}
+	st.logger.Debugf("Refreshed Chart.lock digest at %s after Chart.yaml rewrite", tempChartLockPath)
+	return nil
 }
 
 // Otherwise, if a chart is not a helm chart, it will call "chartify" to turn it into a chart.

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -131,6 +131,7 @@ ${kubectl} create namespace ${test_ns} || fail "Could not create namespace ${tes
 . ${dir}/test-cases/issue-2247.sh
 . ${dir}/test-cases/issue-2097.sh
 . ${dir}/test-cases/issue-2291.sh
+. ${dir}/test-cases/issue-851.sh
 . ${dir}/test-cases/oci-parallel-pull.sh
 . ${dir}/test-cases/issue-2297-local-chart-transformers.sh
 . ${dir}/test-cases/issue-2309-kube-context-template.sh

--- a/test/integration/test-cases/issue-851.sh
+++ b/test/integration/test-cases/issue-851.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Test for issue #851: Strategic merge with envelope charts does not work
+# Issue: https://github.com/helmfile/helmfile/issues/851
+#
+# Problem: When an envelope chart's subchart has its own relative file:// dependencies
+# (e.g. charts/sub2/Chart.yaml references file://../nested), helmfile's
+# rewriteChartDependencies only rewrote the top-level Chart.yaml. The nested subchart's
+# relative path was left untouched, so when chartify copied the chart into its temporary
+# directory, the path resolved against the wrong location. The nested subchart silently
+# failed to load and strategicMergePatches targeting resources defined in it errored with
+# "no resource matches".
+#
+# Fix: rewriteChartDependencies recursively walks the chart tree and rewrites relative
+# file:// dependencies in every Chart.yaml (top-level + nested subcharts).
+
+issue_851_input_dir="${cases_dir}/issue-851/input"
+issue_851_tmp_dir=$(mktemp -d)
+
+cleanup_issue_851() {
+  rm -rf "${issue_851_tmp_dir}"
+}
+trap cleanup_issue_851 EXIT
+
+test_start "issue-851: strategic merge patches work with envelope charts"
+
+info "Step 1: Templating envelope chart with nested subchart patches"
+${helmfile} -f "${issue_851_input_dir}/helmfile.yaml" template > "${issue_851_tmp_dir}/templated.yaml" 2>&1
+code=$?
+
+if [ $code -ne 0 ]; then
+  cat "${issue_851_tmp_dir}/templated.yaml"
+  fail "helmfile template failed — envelope chart with nested subchart patches should succeed"
+fi
+
+info "✓ helmfile template succeeded"
+
+# All three ServiceMonitors must be present in the output, including the one defined in
+# the deepest nested subchart (sub2/charts/nested).
+for expected_name in sub1-sm sub2-sm nested-sm; do
+  if ! grep -q "name: ${expected_name}" "${issue_851_tmp_dir}/templated.yaml"; then
+    cat "${issue_851_tmp_dir}/templated.yaml"
+    fail "Expected ServiceMonitor ${expected_name} not found in templated output (envelope chart resources dropped)"
+  fi
+  info "✓ ServiceMonitor ${expected_name} present"
+done
+
+# Each ServiceMonitor must reflect its strategicMergePatch (patched port + interval).
+if ! grep -q "port: metrics-sub1" "${issue_851_tmp_dir}/templated.yaml"; then
+  cat "${issue_851_tmp_dir}/templated.yaml"
+  fail "Patch for sub1-sm was not applied"
+fi
+info "✓ sub1-sm patch applied"
+
+if ! grep -q "port: metrics-sub2" "${issue_851_tmp_dir}/templated.yaml"; then
+  cat "${issue_851_tmp_dir}/templated.yaml"
+  fail "Patch for sub2-sm was not applied"
+fi
+info "✓ sub2-sm patch applied"
+
+# This is the key assertion for issue 851: the patch targeting the resource in the
+# DEEPEST nested subchart (sub2/charts/nested) must be applied. Without the fix, the
+# nested subchart's resources are dropped and this patch fails.
+if ! grep -q "port: metrics-nested" "${issue_851_tmp_dir}/templated.yaml"; then
+  cat "${issue_851_tmp_dir}/templated.yaml"
+  fail "Patch for nested-sm was not applied — envelope chart nested subchart regression (issue 851)"
+fi
+info "✓ nested-sm patch applied (issue 851 fixed)"
+
+cleanup_issue_851
+trap - EXIT
+
+test_pass "issue-851: strategic merge patches work with envelope charts"

--- a/test/integration/test-cases/issue-851/input/envelope/Chart.yaml
+++ b/test/integration/test-cases/issue-851/input/envelope/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: envelope
+version: 0.1.0
+description: Envelope chart with nested subcharts (issue 851 reproduction)
+dependencies:
+  - name: sub1
+    version: 0.1.0
+    repository: file://charts/sub1
+  - name: sub2
+    version: 0.1.0
+    repository: file://charts/sub2

--- a/test/integration/test-cases/issue-851/input/envelope/charts/sub1/Chart.yaml
+++ b/test/integration/test-cases/issue-851/input/envelope/charts/sub1/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: sub1
+version: 0.1.0
+description: Subchart with no nested deps

--- a/test/integration/test-cases/issue-851/input/envelope/charts/sub1/templates/sub1-sm.yaml
+++ b/test/integration/test-cases/issue-851/input/envelope/charts/sub1/templates/sub1-sm.yaml
@@ -1,0 +1,8 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sub1-sm
+spec:
+  endpoints:
+    - port: web
+      interval: 30s

--- a/test/integration/test-cases/issue-851/input/envelope/charts/sub2/Chart.yaml
+++ b/test/integration/test-cases/issue-851/input/envelope/charts/sub2/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: sub2
+version: 0.1.0
+description: Subchart with its own nested subchart via relative file:// dep
+dependencies:
+  - name: nested
+    version: 0.1.0
+    repository: file://../nested

--- a/test/integration/test-cases/issue-851/input/envelope/charts/sub2/charts/nested/Chart.yaml
+++ b/test/integration/test-cases/issue-851/input/envelope/charts/sub2/charts/nested/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: nested
+version: 0.1.0
+description: Deepest nested subchart

--- a/test/integration/test-cases/issue-851/input/envelope/charts/sub2/charts/nested/templates/nested-sm.yaml
+++ b/test/integration/test-cases/issue-851/input/envelope/charts/sub2/charts/nested/templates/nested-sm.yaml
@@ -1,0 +1,8 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nested-sm
+spec:
+  endpoints:
+    - port: web
+      interval: 30s

--- a/test/integration/test-cases/issue-851/input/envelope/charts/sub2/templates/sub2-sm.yaml
+++ b/test/integration/test-cases/issue-851/input/envelope/charts/sub2/templates/sub2-sm.yaml
@@ -1,0 +1,8 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sub2-sm
+spec:
+  endpoints:
+    - port: web
+      interval: 30s

--- a/test/integration/test-cases/issue-851/input/envelope/templates/parent-cm.yaml
+++ b/test/integration/test-cases/issue-851/input/envelope/templates/parent-cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: parent-cm
+data:
+  key: parent-value

--- a/test/integration/test-cases/issue-851/input/helmfile.yaml
+++ b/test/integration/test-cases/issue-851/input/helmfile.yaml
@@ -1,0 +1,46 @@
+# Test for issue #851: Strategic merge with envelope charts does not work
+# https://github.com/helmfile/helmfile/issues/851
+#
+# Problem: When an envelope chart's subchart has its own local file:// dependencies
+# (e.g. charts/sub2/Chart.yaml references file://../nested), chartify's helm dependency
+# build resolves the subchart's relative path against its own temporary directory. Since
+# the nested subchart source isn't a sibling of the temp dir, the nested subchart fails
+# to load and resources defined in it are silently dropped from the patched output.
+# strategicMergePatches targeting those resources then fail with "no resource matches".
+#
+# Fix: rewriteChartDependencies now recursively rewrites relative file:// dependencies
+# in nested subcharts' Chart.yaml files, converting them to absolute paths before chartify
+# runs helm dependency build.
+
+releases:
+  - name: envelope
+    namespace: test
+    chart: ./envelope
+    strategicMergePatches:
+      - apiVersion: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        metadata:
+          name: sub1-sm
+        spec:
+          endpoints:
+            - port: metrics-sub1
+              interval: 10s
+      - apiVersion: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        metadata:
+          name: sub2-sm
+        spec:
+          endpoints:
+            - port: metrics-sub2
+              interval: 15s
+      # The critical patch: targets a resource defined in the DEEPEST nested subchart
+      # (envelope/charts/sub2/charts/nested). Without the fix, this resource is missing
+      # from chartify's patching set and the patch fails with "no resource matches".
+      - apiVersion: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        metadata:
+          name: nested-sm
+        spec:
+          endpoints:
+            - port: metrics-nested
+              interval: 20s


### PR DESCRIPTION
## Summary

Helmfile's `rewriteChartDependencies` only rewrote relative `file://` dependencies in the **top-level** `Chart.yaml`. When an envelope chart's subchart (under `charts/<subchart>/`) had its own relative `file://` deps, those nested paths were left untouched. Chartify then copied the chart to a temp dir where the relative paths resolved against the wrong location, the nested subcharts silently failed to load, and `strategicMergePatches`/`jsonPatches`/`transformers` targeting resources from those nested subcharts errored with `no resource matches`.

## Root cause

`pkg/state/state.go: rewriteChartDependencies` only processed `chartPath/Chart.yaml`. Any `Chart.yaml` inside `charts/<subchart>/` (or deeper) was skipped, so relative `file://../X` paths in those files survived into chartify's temp dir where they resolved against the wrong location.

## Fix

Refactored `rewriteChartDependencies` to recursively walk the chart tree and rewrite every `Chart.yaml` (top-level + nested under `charts/*/`):

- `collectChartsNeedingRewrite` walks `charts/*` subdirs and returns only charts that actually need rewriting
- `walkChartDirs` discovers chart directories (skips `.tgz`-packaged subcharts — helm treats those as opaque)
- `applyChartYamlRewrite` writes the rewritten `Chart.yaml` and refreshes the co-located `Chart.lock` digest so `helm dependency build` doesn't reject the lock as stale
- Temp dir creation/cleanup happens once for the whole tree (preserves the race-condition-safe behavior from #2541)

## Reproduction

Before the fix, with this chart tree:
```
envelope/Chart.yaml                        (deps: sub1, sub2 via file://)
envelope/charts/sub1/Chart.yaml            (no deps)
envelope/charts/sub2/Chart.yaml            (deps: nested via file://../nested)
envelope/charts/sub2/charts/nested/Chart.yaml
```
…applying a `strategicMergePatches` entry targeting a resource defined in `envelope/charts/sub2/charts/nested/` failed with:
```
Error: no resource matches strategic merge patch "ServiceMonitor.v1.monitoring.coreos.com/nested-sm.[noNs]"
```
After the fix, the nested subchart loads correctly and the patch applies.

## Tests

- 3 new unit tests in `chart_dependencies_rewrite_test.go`:
  - `TestRewriteChartDependencies_NestedSubcharts` — full envelope chart with nested subchart deps
  - `TestRewriteChartDependencies_NoNestedRewriteForAbsolutePaths` — absolute file:// in nested chart left untouched
  - `TestRewriteChartDependencies_NoOpWhenOnlyNestedRelativeDeps` — rewrite triggers when only a nested chart needs it
- New integration test `test/integration/test-cases/issue-851/` reproducing the end-to-end scenario, registered in `test/integration/run.sh`
- All existing rewrite/chartify tests still pass
- `golangci-lint run ./pkg/state/...` reports 0 issues

## Docs

Added a "Patching envelope charts" subsection to `docs/advanced-features.md` linking back to #851.

Resolves #851