### PR TITLE
fix: pre-build transitive subchart deps for envelope charts (#851)

### DIFF
--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -285,6 +285,24 @@ There's also `releases[].jsonPatches` that works similarly to `strategicMergePat
 
 Please also see [test/advanced/helmfile.yaml](https://github.com/helmfile/helmfile/tree/master/test/advanced/helmfile.yaml) for an example of patching support and more.
 
+#### Patching envelope charts (charts whose subcharts have local dependencies)
+
+`strategicMergePatches`, `jsonPatches`, and `transformers` all work on resources defined
+anywhere in the chart, including resources rendered by transitive subcharts (a subchart's
+own dependencies).
+
+For local envelope charts whose subcharts declare their own `file://` dependencies, Helmfile
+runs `helm dependency build` bottom-up across the transitive dependency tree before chartify
+runs. Without this, helm's `dependency build` on the parent chart would fetch each file://
+subchart and package it as a `.tgz` **without** recursively building the subchart's own deps
+first. The resulting `.tgz` would lack the nested subchart's resources, chartify's
+`helm template` would silently drop them, and patches targeting those resources would fail
+with `no resource matches`.
+See [issue #851](https://github.com/helmfile/helmfile/issues/851).
+
+To opt out of dependency building (e.g. for read-only `template` invocations), use
+`--skip-deps` or set `helmDefaults.skipDeps: true` / `releases[].skipDeps: true`.
+
 ### `transformers`
 
 You can set `transformers` to apply [Kustomize's transformers](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/configureBuiltinPlugin.md#configuring-the-builtin-plugins-instead).

--- a/pkg/state/prebuild_subchart_deps_test.go
+++ b/pkg/state/prebuild_subchart_deps_test.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,16 +13,53 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/helmfile/helmfile/pkg/filesystem"
+	"github.com/helmfile/helmfile/pkg/helmexec"
 )
 
 // skipIfNoHelm skips the calling test when the helm binary is not available on
-// PATH. Tests that exercise runHelmDepBuild need helm installed to produce
-// meaningful results.
+// PATH. Tests that exercise runHelmDepBuild through a real helmexec need helm
+// installed to produce meaningful results.
 func skipIfNoHelm(t *testing.T) {
 	t.Helper()
 	if _, err := exec.LookPath("helm"); err != nil {
 		t.Skipf("skipping: helm binary not found in PATH (%v)", err)
 	}
+}
+
+// newRealHelmExec builds a helmexec.Interface backed by the real helm binary on
+// PATH, for tests that assert actual `helm dependency build` side effects.
+func newRealHelmExec(t *testing.T) helmexec.Interface {
+	t.Helper()
+	logger := zap.NewNop().Sugar()
+	runner := &helmexec.ShellRunner{Ctx: context.Background(), Logger: logger}
+	helm, err := helmexec.New("helm", helmexec.HelmExecOptions{}, logger, "", "", runner)
+	if err != nil {
+		t.Fatalf("helmexec.New: %v", err)
+	}
+	return helm
+}
+
+// stubHelm is a minimal helmexec.Interface for prebuild tests that should NOT
+// invoke a real helm binary (avoids network I/O and the helm dependency). It
+// records BuildDeps/UpdateDeps calls so tests can assert which charts were
+// visited. Only BuildDeps/UpdateDeps are exercised by the prebuild path, so the
+// embedded nil Interface satisfies the rest of the contract without being
+// dereferenced.
+type stubHelm struct {
+	helmexec.Interface
+	buildErr error
+	builds   []string
+	updates  []string
+}
+
+func (s *stubHelm) BuildDeps(name, chart string, flags ...string) error {
+	s.builds = append(s.builds, chart)
+	return s.buildErr
+}
+
+func (s *stubHelm) UpdateDeps(chart string) error {
+	s.updates = append(s.updates, chart)
+	return s.buildErr
 }
 
 // writeChart creates a chart directory with Chart.yaml and the given templates.
@@ -97,7 +136,7 @@ func TestPreBuildTransitiveSubchartDeps_VisitsAllTransitiveDeps(t *testing.T) {
 		},
 	}
 
-	st.preBuildTransitiveSubchartDeps(filepath.Join(rootDir, "envelope"))
+	st.preBuildTransitiveSubchartDeps(filepath.Join(rootDir, "envelope"), newRealHelmExec(t))
 
 	// The critical assertion: sub2/charts/ should now contain nested (as
 	// .tgz or unpacked). Without the fix, helm dep build on the parent chart
@@ -138,7 +177,8 @@ func hasNestedTgzPrefix(name string) bool {
 }
 
 // TestPreBuildTransitiveSubchartDeps_HandlesMissingChartYaml verifies the
-// function is a no-op (no panic) when the chart dir has no Chart.yaml.
+// function is a no-op (no panic) when the chart dir has no Chart.yaml. A stub
+// helm is used since the missing Chart.yaml short-circuits before any helm call.
 func TestPreBuildTransitiveSubchartDeps_HandlesMissingChartYaml(t *testing.T) {
 	rootDir, err := os.MkdirTemp("", "helmfile-prebuild-noyaml-")
 	if err != nil {
@@ -155,7 +195,7 @@ func TestPreBuildTransitiveSubchartDeps_HandlesMissingChartYaml(t *testing.T) {
 	}
 
 	// Should not panic.
-	st.preBuildTransitiveSubchartDeps(rootDir)
+	st.preBuildTransitiveSubchartDeps(rootDir, &stubHelm{})
 }
 
 // TestPreBuildTransitiveSubchartDeps_HandlesCircularDeps verifies the function
@@ -190,7 +230,7 @@ func TestPreBuildTransitiveSubchartDeps_HandlesCircularDeps(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		st.preBuildTransitiveSubchartDeps(aDir)
+		st.preBuildTransitiveSubchartDeps(aDir, newRealHelmExec(t))
 	}()
 	select {
 	case <-done:
@@ -202,8 +242,12 @@ func TestPreBuildTransitiveSubchartDeps_HandlesCircularDeps(t *testing.T) {
 
 // TestPreBuildTransitiveSubchartDeps_DoesNotRecurseIntoRemoteDeps verifies the
 // function does not recurse into dependencies declared with non-file://
-// repositories (https://, oci://). It still runs helm dep build on the chart
-// dir itself, but the failure to resolve the remote is logged and swallowed.
+// repositories (https://, oci://). It still runs helm dep build on the chart dir
+// itself, but does not follow the remote dependency.
+//
+// A stub helm whose BuildDeps returns an error is used so the test fails fast
+// and deterministically without performing any network I/O (a real helm would
+// try to fetch https://charts.example.com).
 func TestPreBuildTransitiveSubchartDeps_DoesNotRecurseIntoRemoteDeps(t *testing.T) {
 	rootDir, err := os.MkdirTemp("", "helmfile-prebuild-remote-")
 	if err != nil {
@@ -212,9 +256,9 @@ func TestPreBuildTransitiveSubchartDeps_DoesNotRecurseIntoRemoteDeps(t *testing.
 	defer os.RemoveAll(rootDir)
 
 	// Chart with only a remote dep. preBuildTransitiveSubchartDeps should not
-	// recurse into anything (no file:// deps to follow) and should not panic
-	// when helm dep build can't resolve the remote dep in the test environment.
-	writeChart(t, filepath.Join(rootDir, "chart"), "chart",
+	// recurse into anything (no file:// deps to follow).
+	chartDir := filepath.Join(rootDir, "chart")
+	writeChart(t, chartDir, "chart",
 		map[string]string{"remote": "https://charts.example.com"},
 		nil,
 	)
@@ -227,6 +271,20 @@ func TestPreBuildTransitiveSubchartDeps_DoesNotRecurseIntoRemoteDeps(t *testing.
 		},
 	}
 
-	// Should not panic; helm dep build failure is logged and swallowed.
-	st.preBuildTransitiveSubchartDeps(filepath.Join(rootDir, "chart"))
+	helm := &stubHelm{buildErr: errors.New("stub: dependency build unavailable")}
+	st.preBuildTransitiveSubchartDeps(chartDir, helm)
+
+	// BuildDeps must be called exactly once, on the chart dir itself — proving
+	// the function did not recurse into the remote dep.
+	if len(helm.builds) != 1 {
+		t.Fatalf("expected exactly one BuildDeps call (chart dir, no recursion into remote), got %v", helm.builds)
+	}
+	if got, want := filepath.Base(helm.builds[0]), "chart"; got != want {
+		t.Fatalf("BuildDeps called on %q, want chart dir %q", helm.builds[0], want)
+	}
+	// The stub error is not a lock-out-of-sync signal, so there must be no
+	// fallback to UpdateDeps.
+	if len(helm.updates) != 0 {
+		t.Fatalf("expected no UpdateDeps fallback, got %v", helm.updates)
+	}
 }

--- a/pkg/state/prebuild_subchart_deps_test.go
+++ b/pkg/state/prebuild_subchart_deps_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,6 +12,16 @@ import (
 
 	"github.com/helmfile/helmfile/pkg/filesystem"
 )
+
+// skipIfNoHelm skips the calling test when the helm binary is not available on
+// PATH. Tests that exercise runHelmDepBuild need helm installed to produce
+// meaningful results.
+func skipIfNoHelm(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skipf("skipping: helm binary not found in PATH (%v)", err)
+	}
+}
 
 // writeChart creates a chart directory with Chart.yaml and the given templates.
 // deps maps dependency name → repository URL (skipped if empty).
@@ -53,6 +64,7 @@ func TestPreBuildTransitiveSubchartDeps_VisitsAllTransitiveDeps(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode (requires helm)")
 	}
+	skipIfNoHelm(t)
 
 	rootDir, err := os.MkdirTemp("", "helmfile-prebuild-")
 	if err != nil {
@@ -152,6 +164,7 @@ func TestPreBuildTransitiveSubchartDeps_HandlesCircularDeps(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode (requires helm)")
 	}
+	skipIfNoHelm(t)
 
 	rootDir, err := os.MkdirTemp("", "helmfile-prebuild-cycle-")
 	if err != nil {
@@ -187,9 +200,11 @@ func TestPreBuildTransitiveSubchartDeps_HandlesCircularDeps(t *testing.T) {
 	}
 }
 
-// TestPreBuildTransitiveSubchartDeps_NoOpOnRemoteDeps verifies the function
-// skips dependencies declared with non-file:// repositories (https://, oci://).
-func TestPreBuildTransitiveSubchartDeps_NoOpOnRemoteDeps(t *testing.T) {
+// TestPreBuildTransitiveSubchartDeps_DoesNotRecurseIntoRemoteDeps verifies the
+// function does not recurse into dependencies declared with non-file://
+// repositories (https://, oci://). It still runs helm dep build on the chart
+// dir itself, but the failure to resolve the remote is logged and swallowed.
+func TestPreBuildTransitiveSubchartDeps_DoesNotRecurseIntoRemoteDeps(t *testing.T) {
 	rootDir, err := os.MkdirTemp("", "helmfile-prebuild-remote-")
 	if err != nil {
 		t.Fatalf("mkdtemp: %v", err)

--- a/pkg/state/prebuild_subchart_deps_test.go
+++ b/pkg/state/prebuild_subchart_deps_test.go
@@ -1,0 +1,216 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/helmfile/helmfile/pkg/filesystem"
+)
+
+// writeChart creates a chart directory with Chart.yaml and the given templates.
+// deps maps dependency name → repository URL (skipped if empty).
+func writeChart(t *testing.T, dir, name string, deps map[string]string, templates map[string]string) {
+	t.Helper()
+	chartYaml := "apiVersion: v2\nname: " + name + "\nversion: 0.1.0\n"
+	if len(deps) > 0 {
+		chartYaml += "dependencies:\n"
+		for depName, repo := range deps {
+			chartYaml += "  - name: " + depName + "\n    repository: " + repo + "\n    version: 0.1.0\n"
+		}
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte(chartYaml), 0644); err != nil {
+		t.Fatalf("write Chart.yaml in %s: %v", dir, err)
+	}
+	if len(templates) > 0 {
+		tmplDir := filepath.Join(dir, "templates")
+		if err := os.MkdirAll(tmplDir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", tmplDir, err)
+		}
+		for filename, content := range templates {
+			if err := os.WriteFile(filepath.Join(tmplDir, filename), []byte(content), 0644); err != nil {
+				t.Fatalf("write %s: %v", filename, err)
+			}
+		}
+	}
+}
+
+// TestPreBuildTransitiveSubchartDeps_VisitsAllTransitiveDeps verifies that
+// preBuildTransitiveSubchartDeps walks the full transitive file:// dependency
+// tree by checking that helm dep build runs on every chart dir.
+//
+// We assert this by checking that sub2/charts/nested-* exists after the call —
+// that's the exact artifact that helm's non-recursive dep build fails to
+// produce for envelope charts (issue #851).
+func TestPreBuildTransitiveSubchartDeps_VisitsAllTransitiveDeps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode (requires helm)")
+	}
+
+	rootDir, err := os.MkdirTemp("", "helmfile-prebuild-")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	defer os.RemoveAll(rootDir)
+
+	// envelope → sub1, sub2
+	// sub2 → nested
+	writeChart(t, filepath.Join(rootDir, "envelope"), "envelope",
+		map[string]string{"sub1": "file://../sub1", "sub2": "file://../sub2"},
+		map[string]string{"cm.yaml": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: parent-cm\n"},
+	)
+	writeChart(t, filepath.Join(rootDir, "sub1"), "sub1", nil,
+		map[string]string{"sm.yaml": "apiVersion: monitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: sub1-sm\n"},
+	)
+	writeChart(t, filepath.Join(rootDir, "sub2"), "sub2",
+		map[string]string{"nested": "file://../nested"},
+		map[string]string{"sm.yaml": "apiVersion: monitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: sub2-sm\n"},
+	)
+	writeChart(t, filepath.Join(rootDir, "nested"), "nested", nil,
+		map[string]string{"sm.yaml": "apiVersion: monitoring.coreos.com/v1\nkind: ServiceMonitor\nmetadata:\n  name: nested-sm\n"},
+	)
+
+	st := &HelmState{
+		logger: zap.NewNop().Sugar(),
+		fs:     filesystem.DefaultFileSystem(),
+		ReleaseSetSpec: ReleaseSetSpec{
+			DefaultHelmBinary: "helm",
+		},
+	}
+
+	st.preBuildTransitiveSubchartDeps(filepath.Join(rootDir, "envelope"))
+
+	// The critical assertion: sub2/charts/ should now contain nested (as
+	// .tgz or unpacked). Without the fix, helm dep build on the parent chart
+	// produces sub2.tgz WITHOUT nested, and the nested ServiceMonitor is
+	// silently dropped from the chartify output.
+	sub2Charts := filepath.Join(rootDir, "sub2", "charts")
+	entries, err := os.ReadDir(sub2Charts)
+	if err != nil {
+		t.Fatalf("sub2/charts should exist after preBuildTransitiveSubchartDeps ran helm dep build on sub2: %v", err)
+	}
+	foundNested := false
+	for _, e := range entries {
+		name := e.Name()
+		if name == "nested" || hasNestedTgzPrefix(name) {
+			foundNested = true
+			break
+		}
+	}
+	if !foundNested {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("sub2/charts should contain nested after pre-build; got entries: %v", names)
+	}
+
+	// envelope/charts should contain sub1 and sub2.
+	envCharts := filepath.Join(rootDir, "envelope", "charts")
+	if entries, err := os.ReadDir(envCharts); err != nil {
+		t.Fatalf("envelope/charts should exist after pre-build: %v", err)
+	} else if len(entries) == 0 {
+		t.Fatalf("envelope/charts should contain sub1 and sub2 after pre-build")
+	}
+}
+
+func hasNestedTgzPrefix(name string) bool {
+	return len(name) > len("nested-") && name[:7] == "nested-"
+}
+
+// TestPreBuildTransitiveSubchartDeps_HandlesMissingChartYaml verifies the
+// function is a no-op (no panic) when the chart dir has no Chart.yaml.
+func TestPreBuildTransitiveSubchartDeps_HandlesMissingChartYaml(t *testing.T) {
+	rootDir, err := os.MkdirTemp("", "helmfile-prebuild-noyaml-")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	defer os.RemoveAll(rootDir)
+
+	st := &HelmState{
+		logger: zap.NewNop().Sugar(),
+		fs:     filesystem.DefaultFileSystem(),
+		ReleaseSetSpec: ReleaseSetSpec{
+			DefaultHelmBinary: "helm",
+		},
+	}
+
+	// Should not panic.
+	st.preBuildTransitiveSubchartDeps(rootDir)
+}
+
+// TestPreBuildTransitiveSubchartDeps_HandlesCircularDeps verifies the function
+// terminates when the file:// dependency graph has a cycle.
+func TestPreBuildTransitiveSubchartDeps_HandlesCircularDeps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode (requires helm)")
+	}
+
+	rootDir, err := os.MkdirTemp("", "helmfile-prebuild-cycle-")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	defer os.RemoveAll(rootDir)
+
+	// a → b → a (cycle). Use absolute file:// paths so each can resolve the other.
+	aDir := filepath.Join(rootDir, "a")
+	bDir := filepath.Join(rootDir, "b")
+	writeChart(t, aDir, "a", map[string]string{"b": "file://" + bDir}, nil)
+	writeChart(t, bDir, "b", map[string]string{"a": "file://" + aDir}, nil)
+
+	st := &HelmState{
+		logger: zap.NewNop().Sugar(),
+		fs:     filesystem.DefaultFileSystem(),
+		ReleaseSetSpec: ReleaseSetSpec{
+			DefaultHelmBinary: "helm",
+		},
+	}
+
+	// Should terminate, not infinite-loop.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		st.preBuildTransitiveSubchartDeps(aDir)
+	}()
+	select {
+	case <-done:
+		// success — terminated
+	case <-time.After(30 * time.Second):
+		t.Fatal("preBuildTransitiveSubchartDeps did not terminate on circular deps")
+	}
+}
+
+// TestPreBuildTransitiveSubchartDeps_NoOpOnRemoteDeps verifies the function
+// skips dependencies declared with non-file:// repositories (https://, oci://).
+func TestPreBuildTransitiveSubchartDeps_NoOpOnRemoteDeps(t *testing.T) {
+	rootDir, err := os.MkdirTemp("", "helmfile-prebuild-remote-")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	defer os.RemoveAll(rootDir)
+
+	// Chart with only a remote dep. preBuildTransitiveSubchartDeps should not
+	// recurse into anything (no file:// deps to follow) and should not panic
+	// when helm dep build can't resolve the remote dep in the test environment.
+	writeChart(t, filepath.Join(rootDir, "chart"), "chart",
+		map[string]string{"remote": "https://charts.example.com"},
+		nil,
+	)
+
+	st := &HelmState{
+		logger: zap.NewNop().Sugar(),
+		fs:     filesystem.DefaultFileSystem(),
+		ReleaseSetSpec: ReleaseSetSpec{
+			DefaultHelmBinary: "helm",
+		},
+	}
+
+	// Should not panic; helm dep build failure is logged and swallowed.
+	st.preBuildTransitiveSubchartDeps(filepath.Join(rootDir, "chart"))
+}

--- a/pkg/state/prebuild_subchart_deps_test.go
+++ b/pkg/state/prebuild_subchart_deps_test.go
@@ -3,6 +3,7 @@ package state
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -121,7 +122,7 @@ func TestPreBuildTransitiveSubchartDeps_VisitsAllTransitiveDeps(t *testing.T) {
 }
 
 func hasNestedTgzPrefix(name string) bool {
-	return len(name) > len("nested-") && name[:7] == "nested-"
+	return strings.HasPrefix(name, "nested-")
 }
 
 // TestPreBuildTransitiveSubchartDeps_HandlesMissingChartYaml verifies the

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1835,57 +1835,47 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (string, func(),
 }
 
 // preBuildTransitiveSubchartDeps walks the transitive tree of local file://
-// dependencies declared in chartPath/Chart.yaml (and recursively, each
-// dependency's own Chart.yaml), and runs `helm dependency build` on each
-// dependency's source directory in bottom-up order.
+// dependencies declared in chartPath/Chart.yaml and runs `helm dependency build`
+// on each chart's source directory bottom-up (dependencies before dependents).
 //
-// This is required for envelope charts (charts whose subcharts themselves have
-// local file:// dependencies). Helm's `helm dependency build` on the parent
-// chart fetches each file:// subchart and packages it as a .tgz archive, but
-// does NOT recursively build the subchart's own dependencies first. The
-// resulting .tgz therefore lacks the nested subchart's resources. When chartify
-// later runs helm template --output-dir on the chart, resources defined in the
-// nested subchart are silently absent, and strategicMergePatches/jsonPatches
-// targeting those resources fail with "no resource matches".
+// This fixes envelope charts whose subcharts declare their own file:// deps:
+// helm's `dependency build` on the parent packages each subchart as .tgz without
+// recursively building the subchart's own deps, so the nested subchart's
+// resources are silently absent and patches targeting them fail with
+// "no resource matches". See https://github.com/helmfile/helmfile/issues/851.
 //
-// By pre-building each subchart's dependencies bottom-up, the .tgz that helm
-// later produces for the parent includes the nested subchart's deps, so all
-// resources are rendered and patches resolve correctly.
-//
-// See https://github.com/helmfile/helmfile/issues/851.
-//
-// This function is best-effort: failures to read a Chart.yaml or run helm on a
-// subchart are logged at debug level and do not abort the top-level operation,
-// matching helmfile's behavior of not hard-failing on subchart dependency
-// issues when the chart may already have its deps pre-built.
+// Best-effort: errors are logged, not returned, so a single broken subchart
+// doesn't abort the entire release.
 func (st *HelmState) preBuildTransitiveSubchartDeps(chartPath string) {
-	visited := make(map[string]bool)
-	st.preBuildSubchartDepsRecursive(chartPath, visited)
+	st.prebuildChartDeps(chartPath, make(map[string]bool))
 }
 
-// preBuildSubchartDepsRecursive is the recursive worker for
-// preBuildTransitiveSubchartDeps. It visits each file:// dependency of chartDir
-// depth-first (so dependencies are built before the charts that depend on
-// them), then runs `helm dependency build` on chartDir itself.
-//
-// `visited` tracks absolute chart directory paths to prevent infinite recursion
-// on circular file:// dependency graphs.
-func (st *HelmState) preBuildSubchartDepsRecursive(chartDir string, visited map[string]bool) {
+// prebuildChartDeps is the recursive worker. It visits each file:// dependency
+// depth-first, then runs helm dependency build on chartDir itself.
+func (st *HelmState) prebuildChartDeps(chartDir string, visited map[string]bool) {
 	absChartDir, err := filepath.Abs(chartDir)
-	if err != nil {
-		st.logger.Debugf("preBuildSubchartDeps: failed to resolve abs path for %s: %v", chartDir, err)
-		return
-	}
-	if visited[absChartDir] {
+	if err != nil || visited[absChartDir] {
 		return
 	}
 	visited[absChartDir] = true
 
-	chartYamlPath := filepath.Join(absChartDir, "Chart.yaml")
-	data, err := st.fs.ReadFile(chartYamlPath)
-	if err != nil {
-		// No Chart.yaml or unreadable — nothing to pre-build.
+	deps, ok := st.parseLocalFileDeps(absChartDir)
+	if !ok {
 		return
+	}
+	for _, depDir := range deps {
+		st.prebuildChartDeps(depDir, visited)
+	}
+	st.runHelmDepBuild(absChartDir)
+}
+
+// parseLocalFileDeps reads chartDir/Chart.yaml and returns the absolute paths
+// of all local file:// dependencies that exist as directories. Returns ok=false
+// if Chart.yaml is missing, unreadable, or has no file:// deps.
+func (st *HelmState) parseLocalFileDeps(chartDir string) (depDirs []string, ok bool) {
+	data, err := st.fs.ReadFile(filepath.Join(chartDir, "Chart.yaml"))
+	if err != nil {
+		return nil, false
 	}
 
 	type chartDep struct {
@@ -1896,92 +1886,79 @@ func (st *HelmState) preBuildSubchartDepsRecursive(chartDir string, visited map[
 	}
 	var meta chartMeta
 	if err := yaml.Unmarshal(data, &meta); err != nil {
-		st.logger.Debugf("preBuildSubchartDeps: failed to parse %s: %v", chartYamlPath, err)
-		return
+		st.logger.Debugf("preBuildSubchartDeps: failed to parse %s/Chart.yaml: %v", chartDir, err)
+		return nil, false
 	}
 
-	// First, recurse into each local file:// dependency so its own deps are
-	// pre-built before we build this chart's deps.
 	for _, dep := range meta.Dependencies {
-		if !strings.HasPrefix(dep.Repository, "file://") {
-			continue
+		dir, found := st.resolveFileDep(dep.Repository, chartDir)
+		if found {
+			depDirs = append(depDirs, dir)
 		}
-		depPath := strings.TrimPrefix(dep.Repository, "file://")
-		if !filepath.IsAbs(depPath) {
-			depPath = filepath.Join(absChartDir, depPath)
-		}
-		// Only pre-build local directory dependencies (not archives, not remote).
-		if !st.fs.DirectoryExistsAt(depPath) {
-			continue
-		}
-		st.preBuildSubchartDepsRecursive(depPath, visited)
 	}
-
-	// Then run `helm dependency build` on this chart dir. If Chart.lock exists
-	// and is in sync, helm uses it (preserving pinned versions). If the lock is
-	// missing or stale, fall back to `helm dependency update`. Errors are logged
-	// but not propagated: the chart may already have its deps pre-built, in
-	// which case chartify's own helm dep build will succeed later.
-	st.runHelmDependencyBuild(absChartDir)
+	return depDirs, true
 }
 
-// runHelmDependencyBuild runs `helm dependency build` on chartDir, falling back
-// to `helm dependency update` if the lock file is missing or out of sync. It
-// acquires a per-chartDir mutex (via getNamedRWMutex) so that concurrent
-// releases referencing the same local chart don't race on helm's writes to the
-// chart's charts/ and Chart.lock (same pattern as forcedDownloadChart for #768).
+// resolveFileDep resolves a file:// repository URL to an absolute directory path.
+// Returns (dir, true) if the dependency is a local file:// URL pointing to an
+// existing directory; ("", false) otherwise.
+func (st *HelmState) resolveFileDep(repo, parentDir string) (string, bool) {
+	const fileScheme = "file://"
+	if !strings.HasPrefix(repo, fileScheme) {
+		return "", false
+	}
+	path := strings.TrimPrefix(repo, fileScheme)
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(parentDir, path)
+	}
+	if !st.fs.DirectoryExistsAt(path) {
+		return "", false
+	}
+	return path, true
+}
+
+// runHelmDepBuild runs `helm dependency build` on chartDir with a per-dir lock
+// to prevent concurrent releases from corrupting charts/*.tgz (same pattern as
+// forcedDownloadChart for #768). Falls back to `helm dependency update` when
+// Chart.lock is missing or stale.
 //
-// `--skip-refresh` is passed to avoid a slow `helm repo update` for every
-// subchart in the tree. This is safe for file://-only deps (the common case for
-// envelope charts). For subcharts that also declare https:// deps, users should
-// run `helm repo update` separately; chartify's own `helm dependency build`
-// (which does NOT skip refresh) runs afterwards and will catch stale repos.
-//
-// Errors from lock-out-of-sync are expected and logged at debug level; other
-// failures (helm missing, network errors for remote deps) are logged at warn
-// level so users can diagnose why patches later fail with "no resource matches".
-func (st *HelmState) runHelmDependencyBuild(chartDir string) {
+// --skip-refresh avoids a slow `helm repo update` per subchart; file:// deps
+// (the envelope-chart use case) don't need the repo cache. For mixed file:// +
+// https:// deps, chartify's own helm dep build (without --skip-refresh) runs
+// afterwards as a safety net.
+func (st *HelmState) runHelmDepBuild(chartDir string) {
+	mu := st.getNamedRWMutex("prebuild-deps:" + chartDir)
+	mu.Lock()
+	defer mu.Unlock()
+
 	helmBin := st.DefaultHelmBinary
 	if helmBin == "" {
 		helmBin = "helm"
 	}
 
-	// Serialize per-chart-dir so concurrent releases referencing the same local
-	// chart tree don't corrupt charts/*.tgz or Chart.lock. The mutex is
-	// process-wide (rwMutexMap), matching forcedDownloadChart's approach (#768).
-	mu := st.getNamedRWMutex("prebuild-deps:" + chartDir)
-	mu.Lock()
-	defer mu.Unlock()
-
-	// Prefer `dependency build` (honors Chart.lock) over `dependency update`
-	// (re-resolves version constraints against repos, which can silently pull
-	// newer versions). Same strategy chartify uses internally.
-	cmd := exec.Command(helmBin, "dependency", "build", chartDir, "--skip-refresh")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		// `dependency build` fails when Chart.lock is missing or out of sync
-		// with Chart.yaml. Fall back to `dependency update`, which re-resolves
-		// from Chart.yaml. This matches chartify's fallback behavior.
-		if isLockOutOfSync(output) {
-			st.logger.Debugf("preBuildSubchartDeps: `helm dependency build` failed for %s (lock out of sync), falling back to `dependency update`: %v", chartDir, err)
-			cmd = exec.Command(helmBin, "dependency", "update", chartDir, "--skip-refresh")
-			output, err = cmd.CombinedOutput()
-		}
+	// Try `dependency build` first (honors Chart.lock). Fall back to `update`
+	// (re-resolves from Chart.yaml) when the lock is missing or stale.
+	output, err := st.execHelmDep(helmBin, "build", chartDir)
+	if err != nil && isLockOutOfSync(output) {
+		st.logger.Debugf("preBuildSubchartDeps: falling back to `dependency update` for %s", chartDir)
+		_, _ = st.execHelmDep(helmBin, "update", chartDir)
 	}
-	if err != nil {
-		// Non-lock errors (helm missing, network failures, malformed Chart.yaml)
-		// surface as warnings so users can diagnose why strategicMergePatches
-		// later fail with "no resource matches". Lock-out-of-sync errors that
-		// also fail on `dependency update` are also warned here.
-		st.logger.Warnf("preBuildSubchartDeps: helm dependency command failed for %s: %v\n%s", chartDir, err, string(output))
-		return
-	}
-	st.logger.Debugf("preBuildSubchartDeps: built dependencies for %s", chartDir)
 }
 
-// isLockOutOfSync returns true when the helm output indicates the Chart.lock
-// is missing or out of sync with Chart.yaml — the case where falling back from
-// `dependency build` to `dependency update` is the right move.
+// execHelmDep executes `helm dependency <subcmd> <chartDir> --skip-refresh`,
+// logs the result, and returns the combined output and error.
+func (st *HelmState) execHelmDep(helmBin, subcmd, chartDir string) ([]byte, error) {
+	output, err := exec.Command(helmBin, "dependency", subcmd, chartDir, "--skip-refresh").CombinedOutput()
+	if err != nil {
+		st.logger.Warnf("preBuildSubchartDeps: helm dependency %s failed for %s: %v\n%s", subcmd, chartDir, err, string(output))
+	} else {
+		st.logger.Debugf("preBuildSubchartDeps: helm dependency %s succeeded for %s", subcmd, chartDir)
+	}
+	return output, err
+}
+
+// isLockOutOfSync returns true when helm's output indicates Chart.lock is
+// missing or stale — the signal to fall back from `build` to `update`.
 func isLockOutOfSync(output []byte) bool {
 	msg := string(output)
 	return strings.Contains(msg, "out of sync") ||

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1871,7 +1871,8 @@ func (st *HelmState) prebuildChartDeps(chartDir string, visited map[string]bool)
 
 // parseLocalFileDeps reads chartDir/Chart.yaml and returns the absolute paths
 // of all local file:// dependencies that exist as directories. Returns ok=false
-// if Chart.yaml is missing, unreadable, or has no file:// deps.
+// only when Chart.yaml is missing, unreadable, or unparseable. When ok=true the
+// returned slice may be empty (e.g. no file:// deps present).
 func (st *HelmState) parseLocalFileDeps(chartDir string) (depDirs []string, ok bool) {
 	data, err := st.fs.ReadFile(filepath.Join(chartDir, "Chart.yaml"))
 	if err != nil {
@@ -1886,7 +1887,7 @@ func (st *HelmState) parseLocalFileDeps(chartDir string) (depDirs []string, ok b
 	}
 	var meta chartMeta
 	if err := yaml.Unmarshal(data, &meta); err != nil {
-		st.logger.Debugf("preBuildSubchartDeps: failed to parse %s/Chart.yaml: %v", chartDir, err)
+		st.logger.Debugf("parseLocalFileDeps: failed to parse %s/Chart.yaml: %v", chartDir, err)
 		return nil, false
 	}
 
@@ -1940,7 +1941,7 @@ func (st *HelmState) runHelmDepBuild(chartDir string) {
 	// (re-resolves from Chart.yaml) when the lock is missing or stale.
 	output, err := st.execHelmDep(helmBin, "build", chartDir)
 	if err != nil && isLockOutOfSync(output) {
-		st.logger.Debugf("preBuildSubchartDeps: falling back to `dependency update` for %s", chartDir)
+		st.logger.Debugf("runHelmDepBuild: falling back to `dependency update` for %s", chartDir)
 		_, _ = st.execHelmDep(helmBin, "update", chartDir)
 	}
 }
@@ -1950,9 +1951,9 @@ func (st *HelmState) runHelmDepBuild(chartDir string) {
 func (st *HelmState) execHelmDep(helmBin, subcmd, chartDir string) ([]byte, error) {
 	output, err := exec.Command(helmBin, "dependency", subcmd, chartDir, "--skip-refresh").CombinedOutput()
 	if err != nil {
-		st.logger.Warnf("preBuildSubchartDeps: helm dependency %s failed for %s: %v\n%s", subcmd, chartDir, err, string(output))
+		st.logger.Debugf("execHelmDep: helm dependency %s failed for %s: %v\n%s", subcmd, chartDir, err, string(output))
 	} else {
-		st.logger.Debugf("preBuildSubchartDeps: helm dependency %s succeeded for %s", subcmd, chartDir)
+		st.logger.Debugf("execHelmDep: helm dependency %s succeeded for %s", subcmd, chartDir)
 	}
 	return output, err
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -1846,13 +1845,13 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (string, func(),
 //
 // Best-effort: errors are logged, not returned, so a single broken subchart
 // doesn't abort the entire release.
-func (st *HelmState) preBuildTransitiveSubchartDeps(chartPath string) {
-	st.prebuildChartDeps(chartPath, make(map[string]bool))
+func (st *HelmState) preBuildTransitiveSubchartDeps(chartPath string, helm helmexec.Interface) {
+	st.prebuildChartDeps(chartPath, make(map[string]bool), helm)
 }
 
 // prebuildChartDeps is the recursive worker. It visits each file:// dependency
 // depth-first, then runs helm dependency build on chartDir itself.
-func (st *HelmState) prebuildChartDeps(chartDir string, visited map[string]bool) {
+func (st *HelmState) prebuildChartDeps(chartDir string, visited map[string]bool, helm helmexec.Interface) {
 	absChartDir, err := filepath.Abs(chartDir)
 	if err != nil || visited[absChartDir] {
 		return
@@ -1864,9 +1863,9 @@ func (st *HelmState) prebuildChartDeps(chartDir string, visited map[string]bool)
 		return
 	}
 	for _, depDir := range deps {
-		st.prebuildChartDeps(depDir, visited)
+		st.prebuildChartDeps(depDir, visited, helm)
 	}
-	st.runHelmDepBuild(absChartDir)
+	st.runHelmDepBuild(absChartDir, helm)
 }
 
 // parseLocalFileDeps reads chartDir/Chart.yaml and returns the absolute paths
@@ -1920,48 +1919,34 @@ func (st *HelmState) resolveFileDep(repo, parentDir string) (string, bool) {
 
 // runHelmDepBuild runs `helm dependency build` on chartDir with a per-dir lock
 // to prevent concurrent releases from corrupting charts/*.tgz (same pattern as
-// forcedDownloadChart for #768). Falls back to `helm dependency update` when
-// Chart.lock is missing or stale.
+// forcedDownloadChart for #768). It dispatches through the shared helmexec
+// runner so the command inherits Helmfile's standard wiring (binary resolution,
+// logging, flag handling, context cancellation) instead of shelling out
+// directly. Falls back to `helm dependency update` when Chart.lock is missing or
+// stale.
 //
 // --skip-refresh avoids a slow `helm repo update` per subchart; file:// deps
 // (the envelope-chart use case) don't need the repo cache. For mixed file:// +
 // https:// deps, chartify's own helm dep build (without --skip-refresh) runs
 // afterwards as a safety net.
-func (st *HelmState) runHelmDepBuild(chartDir string) {
+func (st *HelmState) runHelmDepBuild(chartDir string, helm helmexec.Interface) {
 	mu := st.getNamedRWMutex("prebuild-deps:" + chartDir)
 	mu.Lock()
 	defer mu.Unlock()
 
-	helmBin := st.DefaultHelmBinary
-	if helmBin == "" {
-		helmBin = "helm"
-	}
-
 	// Try `dependency build` first (honors Chart.lock). Fall back to `update`
-	// (re-resolves from Chart.yaml) when the lock is missing or stale.
-	output, err := st.execHelmDep(helmBin, "build", chartDir)
-	if err != nil && isLockOutOfSync(output) {
+	// (re-resolves from Chart.yaml) when the lock is missing or stale. BuildDeps
+	// returns a helmexec.ExitError whose message embeds the combined output, so
+	// isLockOutOfSync can inspect err.Error() without a separate os/exec call.
+	if err := helm.BuildDeps(filepath.Base(chartDir), chartDir, "--skip-refresh"); err != nil && isLockOutOfSync(err.Error()) {
 		st.logger.Debugf("runHelmDepBuild: falling back to `dependency update` for %s", chartDir)
-		_, _ = st.execHelmDep(helmBin, "update", chartDir)
+		_ = helm.UpdateDeps(chartDir)
 	}
 }
 
-// execHelmDep executes `helm dependency <subcmd> <chartDir> --skip-refresh`,
-// logs the result, and returns the combined output and error.
-func (st *HelmState) execHelmDep(helmBin, subcmd, chartDir string) ([]byte, error) {
-	output, err := exec.Command(helmBin, "dependency", subcmd, chartDir, "--skip-refresh").CombinedOutput()
-	if err != nil {
-		st.logger.Debugf("execHelmDep: helm dependency %s failed for %s: %v\n%s", subcmd, chartDir, err, string(output))
-	} else {
-		st.logger.Debugf("execHelmDep: helm dependency %s succeeded for %s", subcmd, chartDir)
-	}
-	return output, err
-}
-
-// isLockOutOfSync returns true when helm's output indicates Chart.lock is
+// isLockOutOfSync returns true when helm's error/output indicates Chart.lock is
 // missing or stale — the signal to fall back from `build` to `update`.
-func isLockOutOfSync(output []byte) bool {
-	msg := string(output)
+func isLockOutOfSync(msg string) bool {
 	return strings.Contains(msg, "out of sync") ||
 		strings.Contains(msg, "lock file is out of date") ||
 		strings.Contains(msg, "no lock file") ||
@@ -1972,7 +1957,7 @@ func isLockOutOfSync(output []byte) bool {
 //
 // If exists, it will also patch resources by json patches, strategic-merge patches, and injectors.
 // processChartification handles the chartification process
-func (st *HelmState) processChartification(chartification *Chartify, release *ReleaseSpec, chartPath string, opts ChartPrepareOptions, skipDeps bool, helmfileCommand string) (string, bool, error) {
+func (st *HelmState) processChartification(chartification *Chartify, release *ReleaseSpec, chartPath string, helm helmexec.Interface, opts ChartPrepareOptions, skipDeps bool, helmfileCommand string) (string, bool, error) {
 	// Pre-build transitive local file:// subchart dependencies before chartify runs.
 	// helm's `dependency build` on the parent chart fetches each file:// subchart and
 	// packages it as .tgz, but does NOT recursively build the subchart's own deps.
@@ -1981,7 +1966,7 @@ func (st *HelmState) processChartification(chartification *Chartify, release *Re
 	// strategicMergePatches/jsonPatches targeting those resources fail with
 	// "no resource matches". See https://github.com/helmfile/helmfile/issues/851.
 	if !skipDeps && st.fs.DirectoryExistsAt(chartPath) {
-		st.preBuildTransitiveSubchartDeps(chartPath)
+		st.preBuildTransitiveSubchartDeps(chartPath, helm)
 	}
 
 	// Rewrite relative file:// dependencies in Chart.yaml to absolute paths before chartify processes them
@@ -2258,7 +2243,7 @@ func (st *HelmState) prepareChartForRelease(release *ReleaseSpec, helm helmexec.
 		if isLocal {
 			chartPath = normalizeChart(st.basePath, chartPath)
 		}
-		chartPath, buildDeps, err = st.processChartification(chartification, release, chartPath, opts, skipDeps, helmfileCommand)
+		chartPath, buildDeps, err = st.processChartification(chartification, release, chartPath, helm, opts, skipDeps, helmfileCommand)
 		if err != nil {
 			return &chartPrepareResult{err: err}
 		}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1921,9 +1921,16 @@ func (st *HelmState) resolveFileDep(repo, parentDir string) (string, bool) {
 // to prevent concurrent releases from corrupting charts/*.tgz (same pattern as
 // forcedDownloadChart for #768). It dispatches through the shared helmexec
 // runner so the command inherits Helmfile's standard wiring (binary resolution,
-// logging, flag handling, context cancellation) instead of shelling out
-// directly. Falls back to `helm dependency update` when Chart.lock is missing or
-// stale.
+// flag handling, context cancellation) instead of shelling out directly. Falls
+// back to `helm dependency update` when Chart.lock is missing or stale.
+//
+// The prebuild is best-effort and runs for every transitive subchart, so it must
+// stay user-silent: helmexec.BuildDeps emits "Building dependency release=..."
+// at Info, which would clutter output for envelope charts with many subcharts.
+// We therefore run on a shallow clone whose logger is raised above Info
+// (LoggerSwapper, same pattern as helmx.go). Command wiring is shared via the
+// clone; failures are surfaced at Debug through st.logger, and the helmexec
+// ExitError message embeds helm's combined output for diagnostics.
 //
 // --skip-refresh avoids a slow `helm repo update` per subchart; file:// deps
 // (the envelope-chart use case) don't need the repo cache. For mixed file:// +
@@ -1934,13 +1941,32 @@ func (st *HelmState) runHelmDepBuild(chartDir string, helm helmexec.Interface) {
 	mu.Lock()
 	defer mu.Unlock()
 
+	// Clone the runner with a quiet logger so the per-subchart
+	// "Building dependency release=..." Info line and helm stdout do not leak
+	// into user output. Live output is also disabled on the clone so helm stdout
+	// can't bypass the logger in --enable-live-output mode. The clone shares the
+	// runner and its options are a value copy, so this does not mutate the
+	// original execer. Mocks that don't implement LoggerSwapper fall back to the
+	// original interface (they don't emit that line anyway).
+	quietHelm := helm
+	if swapper, ok := helm.(helmexec.LoggerSwapper); ok {
+		quietHelm = swapper.WithLogger(helmexec.NewLogger(io.Discard, "warn"))
+		quietHelm.SetEnableLiveOutput(false)
+	}
+
 	// Try `dependency build` first (honors Chart.lock). Fall back to `update`
 	// (re-resolves from Chart.yaml) when the lock is missing or stale. BuildDeps
 	// returns a helmexec.ExitError whose message embeds the combined output, so
 	// isLockOutOfSync can inspect err.Error() without a separate os/exec call.
-	if err := helm.BuildDeps(filepath.Base(chartDir), chartDir, "--skip-refresh"); err != nil && isLockOutOfSync(err.Error()) {
-		st.logger.Debugf("runHelmDepBuild: falling back to `dependency update` for %s", chartDir)
-		_ = helm.UpdateDeps(chartDir)
+	if err := quietHelm.BuildDeps(filepath.Base(chartDir), chartDir, "--skip-refresh"); err != nil {
+		if isLockOutOfSync(err.Error()) {
+			st.logger.Debugf("runHelmDepBuild: falling back to `dependency update` for %s", chartDir)
+			if err := quietHelm.UpdateDeps(chartDir); err != nil {
+				st.logger.Debugf("runHelmDepBuild: helm dependency update failed for %s: %v", chartDir, err)
+			}
+		} else {
+			st.logger.Debugf("runHelmDepBuild: helm dependency build failed for %s: %v", chartDir, err)
+		}
 	}
 }
 

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -1833,11 +1834,157 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (string, func(),
 	return tempDir, cleanup, nil
 }
 
+// preBuildTransitiveSubchartDeps walks the transitive tree of local file://
+// dependencies declared in chartPath/Chart.yaml (and recursively, each
+// dependency's own Chart.yaml), and runs `helm dependency build` on each
+// dependency's source directory in bottom-up order.
+//
+// This is required for envelope charts (charts whose subcharts themselves have
+// local file:// dependencies). Helm's `helm dependency build` on the parent
+// chart fetches each file:// subchart and packages it as a .tgz archive, but
+// does NOT recursively build the subchart's own dependencies first. The
+// resulting .tgz therefore lacks the nested subchart's resources. When chartify
+// later runs helm template --output-dir on the chart, resources defined in the
+// nested subchart are silently absent, and strategicMergePatches/jsonPatches
+// targeting those resources fail with "no resource matches".
+//
+// By pre-building each subchart's dependencies bottom-up, the .tgz that helm
+// later produces for the parent includes the nested subchart's deps, so all
+// resources are rendered and patches resolve correctly.
+//
+// See https://github.com/helmfile/helmfile/issues/851.
+//
+// This function is best-effort: failures to read a Chart.yaml or run helm on a
+// subchart are logged at debug level and do not abort the top-level operation,
+// matching helmfile's behavior of not hard-failing on subchart dependency
+// issues when the chart may already have its deps pre-built.
+func (st *HelmState) preBuildTransitiveSubchartDeps(chartPath string) {
+	visited := make(map[string]bool)
+	st.preBuildSubchartDepsRecursive(chartPath, visited)
+}
+
+// preBuildSubchartDepsRecursive is the recursive worker for
+// preBuildTransitiveSubchartDeps. It visits each file:// dependency of chartDir
+// depth-first (so dependencies are built before the charts that depend on
+// them), then runs `helm dependency build` on chartDir itself.
+//
+// `visited` tracks absolute chart directory paths to prevent infinite recursion
+// on circular file:// dependency graphs.
+func (st *HelmState) preBuildSubchartDepsRecursive(chartDir string, visited map[string]bool) {
+	absChartDir, err := filepath.Abs(chartDir)
+	if err != nil {
+		st.logger.Debugf("preBuildSubchartDeps: failed to resolve abs path for %s: %v", chartDir, err)
+		return
+	}
+	if visited[absChartDir] {
+		return
+	}
+	visited[absChartDir] = true
+
+	chartYamlPath := filepath.Join(absChartDir, "Chart.yaml")
+	data, err := st.fs.ReadFile(chartYamlPath)
+	if err != nil {
+		// No Chart.yaml or unreadable — nothing to pre-build.
+		return
+	}
+
+	type chartDep struct {
+		Repository string `yaml:"repository"`
+	}
+	type chartMeta struct {
+		Dependencies []chartDep `yaml:"dependencies,omitempty"`
+	}
+	var meta chartMeta
+	if err := yaml.Unmarshal(data, &meta); err != nil {
+		st.logger.Debugf("preBuildSubchartDeps: failed to parse %s: %v", chartYamlPath, err)
+		return
+	}
+
+	// First, recurse into each local file:// dependency so its own deps are
+	// pre-built before we build this chart's deps.
+	for _, dep := range meta.Dependencies {
+		if !strings.HasPrefix(dep.Repository, "file://") {
+			continue
+		}
+		depPath := strings.TrimPrefix(dep.Repository, "file://")
+		if !filepath.IsAbs(depPath) {
+			depPath = filepath.Join(absChartDir, depPath)
+		}
+		// Only pre-build local directory dependencies (not archives, not remote).
+		if !st.fs.DirectoryExistsAt(depPath) {
+			continue
+		}
+		st.preBuildSubchartDepsRecursive(depPath, visited)
+	}
+
+	// Then run `helm dependency build` on this chart dir. If Chart.lock exists
+	// and is in sync, helm uses it (preserving pinned versions). If the lock is
+	// missing or stale, fall back to `helm dependency update`. Errors are logged
+	// but not propagated: the chart may already have its deps pre-built, in
+	// which case chartify's own helm dep build will succeed later.
+	st.runHelmDependencyBuild(absChartDir)
+}
+
+// runHelmDependencyBuild runs `helm dependency build` on chartDir, falling back
+// to `helm dependency update` if the lock file is missing or out of sync. It
+// uses --skip-refresh to avoid hitting the network for local file:// deps (the
+// only kind preBuildSubchartDepsRecursive descends into). Errors are logged at
+// debug level and otherwise discarded.
+func (st *HelmState) runHelmDependencyBuild(chartDir string) {
+	helmBin := st.DefaultHelmBinary
+	if helmBin == "" {
+		helmBin = "helm"
+	}
+
+	// Prefer `dependency build` (honors Chart.lock) over `dependency update`
+	// (re-resolves version constraints against repos, which can silently pull
+	// newer versions). Same strategy chartify uses internally.
+	cmd := exec.Command(helmBin, "dependency", "build", chartDir, "--skip-refresh")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// `dependency build` fails when Chart.lock is missing or out of sync
+		// with Chart.yaml. Fall back to `dependency update`, which re-resolves
+		// from Chart.yaml. This matches chartify's fallback behavior.
+		if isLockOutOfSync(output) {
+			st.logger.Debugf("preBuildSubchartDeps: `helm dependency build` failed for %s (lock out of sync), falling back to `dependency update`: %v", chartDir, err)
+			cmd = exec.Command(helmBin, "dependency", "update", chartDir, "--skip-refresh")
+			output, err = cmd.CombinedOutput()
+		}
+	}
+	if err != nil {
+		st.logger.Debugf("preBuildSubchartDeps: helm dependency command failed for %s: %v\n%s", chartDir, err, string(output))
+		return
+	}
+	st.logger.Debugf("preBuildSubchartDeps: built dependencies for %s", chartDir)
+}
+
+// isLockOutOfSync returns true when the helm output indicates the Chart.lock
+// is missing or out of sync with Chart.yaml — the case where falling back from
+// `dependency build` to `dependency update` is the right move.
+func isLockOutOfSync(output []byte) bool {
+	msg := string(output)
+	return strings.Contains(msg, "out of sync") ||
+		strings.Contains(msg, "lock file is out of date") ||
+		strings.Contains(msg, "no lock file") ||
+		strings.Contains(msg, "Chart.lock not found")
+}
+
 // Otherwise, if a chart is not a helm chart, it will call "chartify" to turn it into a chart.
 //
 // If exists, it will also patch resources by json patches, strategic-merge patches, and injectors.
 // processChartification handles the chartification process
 func (st *HelmState) processChartification(chartification *Chartify, release *ReleaseSpec, chartPath string, opts ChartPrepareOptions, skipDeps bool, helmfileCommand string) (string, bool, error) {
+	// Pre-build transitive local file:// subchart dependencies before chartify runs.
+	// helm's `dependency build` on the parent chart fetches each file:// subchart and
+	// packages it as .tgz, but does NOT recursively build the subchart's own deps.
+	// Without this pre-build step, envelope charts whose subcharts have their own
+	// local file:// dependencies silently drop the nested subcharts' resources, and
+	// strategicMergePatches/jsonPatches targeting those resources fail with
+	// "no resource matches". See https://github.com/helmfile/helmfile/issues/851.
+	if !skipDeps && st.fs.DirectoryExistsAt(chartPath) {
+		st.preBuildTransitiveSubchartDeps(chartPath)
+	}
+
 	// Rewrite relative file:// dependencies in Chart.yaml to absolute paths before chartify processes them
 	// This prevents errors like "Error: directory /tmp/chartify.../argocd-application not found"
 	// when Chart.yaml contains dependencies like "file://../argocd-application"

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1927,14 +1927,31 @@ func (st *HelmState) preBuildSubchartDepsRecursive(chartDir string, visited map[
 
 // runHelmDependencyBuild runs `helm dependency build` on chartDir, falling back
 // to `helm dependency update` if the lock file is missing or out of sync. It
-// uses --skip-refresh to avoid hitting the network for local file:// deps (the
-// only kind preBuildSubchartDepsRecursive descends into). Errors are logged at
-// debug level and otherwise discarded.
+// acquires a per-chartDir mutex (via getNamedRWMutex) so that concurrent
+// releases referencing the same local chart don't race on helm's writes to the
+// chart's charts/ and Chart.lock (same pattern as forcedDownloadChart for #768).
+//
+// `--skip-refresh` is passed to avoid a slow `helm repo update` for every
+// subchart in the tree. This is safe for file://-only deps (the common case for
+// envelope charts). For subcharts that also declare https:// deps, users should
+// run `helm repo update` separately; chartify's own `helm dependency build`
+// (which does NOT skip refresh) runs afterwards and will catch stale repos.
+//
+// Errors from lock-out-of-sync are expected and logged at debug level; other
+// failures (helm missing, network errors for remote deps) are logged at warn
+// level so users can diagnose why patches later fail with "no resource matches".
 func (st *HelmState) runHelmDependencyBuild(chartDir string) {
 	helmBin := st.DefaultHelmBinary
 	if helmBin == "" {
 		helmBin = "helm"
 	}
+
+	// Serialize per-chart-dir so concurrent releases referencing the same local
+	// chart tree don't corrupt charts/*.tgz or Chart.lock. The mutex is
+	// process-wide (rwMutexMap), matching forcedDownloadChart's approach (#768).
+	mu := st.getNamedRWMutex("prebuild-deps:" + chartDir)
+	mu.Lock()
+	defer mu.Unlock()
 
 	// Prefer `dependency build` (honors Chart.lock) over `dependency update`
 	// (re-resolves version constraints against repos, which can silently pull
@@ -1952,7 +1969,11 @@ func (st *HelmState) runHelmDependencyBuild(chartDir string) {
 		}
 	}
 	if err != nil {
-		st.logger.Debugf("preBuildSubchartDeps: helm dependency command failed for %s: %v\n%s", chartDir, err, string(output))
+		// Non-lock errors (helm missing, network failures, malformed Chart.yaml)
+		// surface as warnings so users can diagnose why strategicMergePatches
+		// later fail with "no resource matches". Lock-out-of-sync errors that
+		// also fail on `dependency update` are also warned here.
+		st.logger.Warnf("preBuildSubchartDeps: helm dependency command failed for %s: %v\n%s", chartDir, err, string(output))
 		return
 	}
 	st.logger.Debugf("preBuildSubchartDeps: built dependencies for %s", chartDir)

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -132,6 +132,7 @@ ${kubectl} create namespace ${test_ns} || fail "Could not create namespace ${tes
 . ${dir}/test-cases/issue-2247.sh
 . ${dir}/test-cases/issue-2097.sh
 . ${dir}/test-cases/issue-2291.sh
+. ${dir}/test-cases/issue-851.sh
 . ${dir}/test-cases/oci-parallel-pull.sh
 . ${dir}/test-cases/issue-2297-local-chart-transformers.sh
 . ${dir}/test-cases/issue-2309-kube-context-template.sh

--- a/test/integration/test-cases/issue-851.sh
+++ b/test/integration/test-cases/issue-851.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Test for issue #851: Strategic merge with envelope charts does not work
+# Issue: https://github.com/helmfile/helmfile/issues/851
+#
+# Problem: When an envelope chart's subchart declares its own local file://
+# dependency, helm's `dependency build` on the parent chart fetches the subchart
+# and packages it as .tgz, but does NOT recursively build the subchart's own
+# deps first. The resulting .tgz lacks the nested subchart's resources. chartify's
+# helm template silently drops those resources, and strategicMergePatches/jsonPatches
+# targeting them fail with "no resource matches".
+#
+# Fix: preBuildTransitiveSubchartDeps walks the transitive file:// dep tree and
+# runs `helm dependency build` bottom-up on each subchart source dir before
+# chartify runs, so every subchart .tgz includes its own nested deps.
+
+issue_851_input_dir="${cases_dir}/issue-851/input"
+
+# Copy the chart tree to a temp dir so the test doesn't leave generated
+# Chart.lock / charts/*.tgz files in the repo. preBuildTransitiveSubchartDeps
+# runs `helm dependency build` on subchart source directories, which creates
+# those artifacts. The test must not pollute the source tree.
+issue_851_tmp_dir=$(mktemp -d)
+cp -r "${issue_851_input_dir}/." "${issue_851_tmp_dir}/"
+
+cleanup_issue_851() {
+  rm -rf "${issue_851_tmp_dir}"
+}
+trap cleanup_issue_851 EXIT
+
+test_start "issue-851: strategic merge patches work with envelope charts"
+
+info "Step 1: Templating envelope chart whose subchart has its own file:// dep"
+${helmfile} -f "${issue_851_tmp_dir}/helmfile.yaml" template > "${issue_851_tmp_dir}/templated.yaml" 2>&1
+code=$?
+
+if [ $code -ne 0 ]; then
+  cat "${issue_851_tmp_dir}/templated.yaml"
+  fail "helmfile template failed — envelope chart with nested subchart patches should succeed"
+fi
+
+info "✓ helmfile template succeeded"
+
+# All three ServiceMonitors must be present, including the one defined in sub2's
+# OWN dependency (nested). Without the fix, nested-sm is silently dropped.
+for expected_name in sub1-sm sub2-sm nested-sm; do
+  if ! grep -q "name: ${expected_name}" "${issue_851_tmp_dir}/templated.yaml"; then
+    cat "${issue_851_tmp_dir}/templated.yaml"
+    fail "Expected ServiceMonitor ${expected_name} not found (envelope chart nested subchart resources dropped)"
+  fi
+  info "✓ ServiceMonitor ${expected_name} present"
+done
+
+# Each ServiceMonitor must reflect its strategicMergePatch.
+for expected_port in metrics-sub1 metrics-sub2 metrics-nested; do
+  if ! grep -q "port: ${expected_port}" "${issue_851_tmp_dir}/templated.yaml"; then
+    cat "${issue_851_tmp_dir}/templated.yaml"
+    fail "Patch targeting ${expected_port} was not applied (issue 851 regression)"
+  fi
+done
+info "✓ all strategicMergePatches applied (sub1-sm, sub2-sm, nested-sm)"
+
+# The critical assertion: nested-sm's patch applied. Without the fix, the nested
+# subchart's resources are missing and this patch fails with "no resource matches".
+if ! grep -q "port: metrics-nested" "${issue_851_tmp_dir}/templated.yaml"; then
+  cat "${issue_851_tmp_dir}/templated.yaml"
+  fail "Patch for nested-sm was not applied — envelope chart regression (issue 851)"
+fi
+info "✓ nested-sm patch applied (issue 851 fixed)"
+
+cleanup_issue_851
+trap - EXIT
+
+test_pass "issue-851: strategic merge patches work with envelope charts"

--- a/test/integration/test-cases/issue-851/input/envelope/Chart.yaml
+++ b/test/integration/test-cases/issue-851/input/envelope/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: envelope
+version: 0.1.0
+description: Envelope chart whose subchart has its own local file:// dep (issue 851)
+dependencies:
+  - name: sub1
+    version: 0.1.0
+    repository: file://../sub1
+  - name: sub2
+    version: 0.1.0
+    repository: file://../sub2

--- a/test/integration/test-cases/issue-851/input/envelope/templates/parent-cm.yaml
+++ b/test/integration/test-cases/issue-851/input/envelope/templates/parent-cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: parent-cm
+data:
+  key: parent-value

--- a/test/integration/test-cases/issue-851/input/helmfile.yaml
+++ b/test/integration/test-cases/issue-851/input/helmfile.yaml
@@ -1,0 +1,46 @@
+# Test for issue #851: Strategic merge with envelope charts does not work
+# https://github.com/helmfile/helmfile/issues/851
+#
+# Problem: When an envelope chart's subchart declares its own local file://
+# dependency, helm's `dependency build` on the parent chart fetches the subchart
+# and packages it as .tgz, but does NOT recursively build the subchart's own deps
+# first. The resulting .tgz lacks the nested subchart's resources. When chartify
+# runs helm template, resources from the nested subchart are silently absent,
+# and strategicMergePatches targeting them fail with "no resource matches".
+#
+# Fix: preBuildTransitiveSubchartDeps walks the transitive file:// dep tree and
+# runs `helm dependency build` bottom-up on each subchart source dir before
+# chartify runs, so every subchart .tgz includes its own nested deps.
+
+releases:
+  - name: envelope
+    namespace: test
+    chart: ./envelope
+    strategicMergePatches:
+      - apiVersion: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        metadata:
+          name: sub1-sm
+        spec:
+          endpoints:
+            - port: metrics-sub1
+              interval: 10s
+      - apiVersion: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        metadata:
+          name: sub2-sm
+        spec:
+          endpoints:
+            - port: metrics-sub2
+              interval: 15s
+      # The critical patch: targets a resource defined in sub2's OWN dependency
+      # (nested). Without the fix, this resource is dropped from chartify's
+      # patching set and the patch fails with "no resource matches".
+      - apiVersion: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        metadata:
+          name: nested-sm
+        spec:
+          endpoints:
+            - port: metrics-nested
+              interval: 20s

--- a/test/integration/test-cases/issue-851/input/nested/Chart.yaml
+++ b/test/integration/test-cases/issue-851/input/nested/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: nested
+version: 0.1.0
+description: Deepest nested subchart — its resources are silently dropped without the fix

--- a/test/integration/test-cases/issue-851/input/nested/templates/nested-sm.yaml
+++ b/test/integration/test-cases/issue-851/input/nested/templates/nested-sm.yaml
@@ -1,0 +1,8 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nested-sm
+spec:
+  endpoints:
+    - port: web
+      interval: 30s

--- a/test/integration/test-cases/issue-851/input/sub1/Chart.yaml
+++ b/test/integration/test-cases/issue-851/input/sub1/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: sub1
+version: 0.1.0
+description: Leaf subchart (no deps)

--- a/test/integration/test-cases/issue-851/input/sub1/templates/sub1-sm.yaml
+++ b/test/integration/test-cases/issue-851/input/sub1/templates/sub1-sm.yaml
@@ -1,0 +1,8 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sub1-sm
+spec:
+  endpoints:
+    - port: web
+      interval: 30s

--- a/test/integration/test-cases/issue-851/input/sub2/Chart.yaml
+++ b/test/integration/test-cases/issue-851/input/sub2/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: sub2
+version: 0.1.0
+description: Subchart with its own local file:// dep (the envelope chart scenario)
+dependencies:
+  - name: nested
+    version: 0.1.0
+    repository: file://../nested

--- a/test/integration/test-cases/issue-851/input/sub2/templates/sub2-sm.yaml
+++ b/test/integration/test-cases/issue-851/input/sub2/templates/sub2-sm.yaml
@@ -1,0 +1,8 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sub2-sm
+spec:
+  endpoints:
+    - port: web
+      interval: 30s


### PR DESCRIPTION
## Summary

Fixes the root cause of `strategicMergePatches`/`jsonPatches`/`transformers` failing with `no resource matches` on envelope charts (charts whose subcharts have their own local `file://` dependencies).

## Root cause

Helm's `dependency build` on the parent chart fetches each `file://` subchart and packages it as `.tgz`, but does **NOT** recursively build the subchart's own dependencies first. For envelope charts whose subcharts declare their own local `file://` dependencies (e.g. `gitlab` chart → `gitlab` subchart → `gitaly`/`webservice`/... nested subcharts), the resulting `.tgz` lacks the nested subchart's resources. Chartify's `helm template --output-dir` then silently drops those resources, and patches targeting them fail.

## Reproduction (verified)

Before the fix:
```
Error: no resource matches strategic merge patch "ServiceMonitor.v1.monitoring.coreos.com/nested-sm.[noNs]"
```

After the fix: all three ServiceMonitors render, all patches apply.

## Fix

Add `preBuildTransitiveSubchartDeps` in `pkg/state/state.go`, called from `processChartification` before chartify runs (gated on `!skipDeps`):
1. Walks the transitive `file://` dependency tree depth-first
2. Runs `helm dependency build` bottom-up on each subchart source directory
3. Each subchart's deps get pre-built into its `charts/` before the parent packages it
4. Errors are logged at debug level and swallowed (best-effort — the chart may already have deps pre-built)

This is the same operation users do manually with `helm dependency build`. It runs only when `!skipDeps` (the existing flag users already use to opt out of dep building).

## What changed

- **`pkg/state/state.go`**: Added `preBuildTransitiveSubchartDeps`, `preBuildSubchartDepsRecursive`, `runHelmDependencyBuild`, `isLockOutOfSync`. Called from `processChartification`.
- **`pkg/state/prebuild_subchart_deps_test.go`** (new): 4 unit tests covering the happy path, missing Chart.yaml, circular deps, and remote-only deps.
- **`test/integration/test-cases/issue-851/`** (new): End-to-end integration test with an envelope chart whose subchart has its own `file://` dep, and `strategicMergePatches` targeting resources in the deepest nested subchart. **This test fails on `main` and passes with the fix.**
- **`docs/advanced-features.md`**: New "Patching envelope charts" subsection.

## Design notes

- **Source dir modification**: `preBuildTransitiveSubchartDeps` runs `helm dependency build` on subchart source directories, which creates `Chart.lock` and `charts/*.tgz` files. This is the same side-effect users get from running `helm dep build` manually and these files are typically `.gitignore`d. Users who want to avoid it can use `--skip-deps` / `helmDefaults.skipDeps`.
- **Best-effort**: failures are logged and swallowed, matching helmfile's tolerance for subcharts that already have their deps pre-built.
- **Circular dep safety**: depth-first walk tracks visited directories to prevent infinite recursion.

## Test plan

- [x] `go test -run "TestPreBuild|TestRewriteChart" ./pkg/state/...` — passes
- [x] `golangci-lint run ./pkg/state/...` — 0 issues
- [x] `go test ./pkg/app/...` — passes
- [x] Integration test reproduces the bug on `main` (exit 1 with `no resource matches`) and passes on this branch
- [x] Existing chartify/strategicMergePatches integration tests still pass

Resolves #851
