### PR TITLE
test: add integration test for issue #1880 transformers with file:// deps

### DIFF
--- a/pkg/state/issue923_test.go
+++ b/pkg/state/issue923_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -12,11 +13,26 @@ import (
 	"github.com/helmfile/helmfile/pkg/exectest"
 )
 
+// cleanupLeakedChartDirs removes chart directories and lock files that
+// PrepareCharts may leak into the CWD when OutputDirTemplate does not include
+// {{ .OutputDir }}. This is a safety net; the proper fix is to always
+// include {{ .OutputDir }}.
+func cleanupLeakedChartDirs(t *testing.T, dirs ...string) {
+	t.Helper()
+	t.Cleanup(func() {
+		for _, d := range dirs {
+			_ = os.RemoveAll(d)
+			_ = os.Remove(d + ".lock")
+		}
+	})
+}
+
 // TestIssue923_OCIChartPreparedForNeededRelease verifies that OCI charts are
 // prepared (pulled) for releases that are included via --include-needs.
 // See https://github.com/helmfile/helmfile/issues/923
 func TestIssue923_OCIChartPreparedForNeededRelease(t *testing.T) {
 	resetChartCacheForTest()
+	cleanupLeakedChartDirs(t, "argocd", "argocd-secrets")
 	helmfileContent := []byte(`
 repositories:
   - name: huma
@@ -61,12 +77,13 @@ releases:
 	// PrepareCharts uses opts.IncludeTransitiveNeeds to determine which releases
 	// to prepare charts for. When --include-needs is set, this should be true,
 	// matching c.IncludeNeeds() in the app layer.
-	// OutputDirTemplate is set to force charts into tempDir (not the global cache).
+	// OutputDirTemplate includes .OutputDir so charts go into tempDir (auto-cleaned
+	// by t.TempDir), not the global cache or CWD.
 	opts := ChartPrepareOptions{
 		SkipResolve:            true,
 		IncludeTransitiveNeeds: true,
 		Concurrency:            1,
-		OutputDirTemplate:      "{{ .Release.Name }}",
+		OutputDirTemplate:      "{{ .OutputDir }}/{{ .Release.Name }}",
 	}
 
 	releaseToChart, errs := st.PrepareCharts(helm, tempDir, 1, "apply", opts)
@@ -89,6 +106,7 @@ releases:
 // --include-needs, the OCI chart for the needed release is NOT prepared.
 func TestIssue923_OCIChartNotPreparedWithoutIncludeNeeds(t *testing.T) {
 	resetChartCacheForTest()
+	cleanupLeakedChartDirs(t, "argocd", "argocd-secrets")
 	helmfileContent := []byte(`
 repositories:
   - name: huma
@@ -131,7 +149,7 @@ releases:
 		SkipResolve:            true,
 		IncludeTransitiveNeeds: false,
 		Concurrency:            1,
-		OutputDirTemplate:      "{{ .Release.Name }}",
+		OutputDirTemplate:      "{{ .OutputDir }}/{{ .Release.Name }}",
 	}
 
 	releaseToChart, errs := st.PrepareCharts(helm, tempDir, 1, "apply", opts)

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -144,6 +144,7 @@ ${kubectl} create namespace ${test_ns} || fail "Could not create namespace ${tes
 . ${dir}/test-cases/issue-2431.sh
 . ${dir}/test-cases/issue-2544.sh
 . ${dir}/test-cases/issue-2596-local-deps-multiple-files.sh
+. ${dir}/test-cases/issue-1880-transformers-with-file-deps.sh
 . ${dir}/test-cases/issue-821-adhoc-dep-go-getter.sh
 . ${dir}/test-cases/issue-2599-default-inherit.sh
 . ${dir}/test-cases/kubedog-tracking.sh

--- a/test/integration/test-cases/chart-needs.sh
+++ b/test/integration/test-cases/chart-needs.sh
@@ -59,27 +59,27 @@ for i in $(seq 10); do
 done
 
 info "Applying ${chart_need_case_input_dir}/${config_file}"
-${helmfile} -f ${chart_need_case_input_dir}/${config_file}  apply --include-needs
-code=$?
+code=0
+${helmfile} -f ${chart_need_case_input_dir}/${config_file}  apply --include-needs || code=$?
 [ ${code} -eq 0 ] || fail "unexpected exit code returned by helmfile apply: want 0, got ${code}"
 
 ${kubectl} get storageclass managed-csi -o yaml | grep -q "provisioner: disk.csi.azure.com" || fail "storageclass managed-csi should be created when applying helmfile.yaml"
 
 info "Destroying ${chart_need_case_input_dir}/${config_file}"
-${helmfile} -f ${chart_need_case_input_dir}/${config_file} destroy
-code=$?
+code=0
+${helmfile} -f ${chart_need_case_input_dir}/${config_file} destroy || code=$?
 [ ${code} -eq 0 ] || fail "unexpected exit code returned by helmfile destroy: want 0, got ${code}"
 
 info "Syncing ${chart_need_case_input_dir}/${config_file}"
-${helmfile} -f ${chart_need_case_input_dir}/${config_file}  sync --include-needs
-code=$?
+code=0
+${helmfile} -f ${chart_need_case_input_dir}/${config_file}  sync --include-needs || code=$?
 [ ${code} -eq 0 ] || fail "unexpected exit code returned by helmfile apply: want 0, got ${code}"
 
 ${kubectl} get storageclass managed-csi -o yaml | grep -q "provisioner: disk.csi.azure.com" || fail "storageclass managed-csi should be created when syncing helmfile.yaml"
 
 info "Destroying ${chart_need_case_input_dir}/${config_file}"
-${helmfile} -f ${chart_need_case_input_dir}/${config_file} destroy
-code=$?
+code=0
+${helmfile} -f ${chart_need_case_input_dir}/${config_file} destroy || code=$?
 [ ${code} -eq 0 ] || fail "unexpected exit code returned by helmfile destroy: want 0, got ${code}"
 
 # Clean up: remove azuredisk-csi-driver repo to avoid conflicts with subsequent tests

--- a/test/integration/test-cases/happypath.sh
+++ b/test/integration/test-cases/happypath.sh
@@ -18,8 +18,8 @@ bash -c "${helmfile} -f ${happypath_case_input_dir}/${config_file} diff --output
 
 info "Templating ${happypath_case_input_dir}/${config_file}"
 rm -rf ${dir}/tmp
-${helmfile} -f ${happypath_case_input_dir}/${config_file} --debug template --output-dir tmp
-code=$?
+code=0
+${helmfile} -f ${happypath_case_input_dir}/${config_file} --debug template --output-dir tmp || code=$?
 [ ${code} -eq 0 ] || fail "unexpected exit code returned by helmfile template: ${code}"
 for output in $(ls -d ${dir}/tmp/*); do
     # e.g. test/integration/tmp/happypath-877c0dd4-helmx/helmx
@@ -53,18 +53,18 @@ done
 [ ${retry_result} -eq 0 ] || fail "httpbin failed to return 200 OK"
 
 info "Applying ${happypath_case_input_dir}/${config_file}"
-${helmfile} -f ${happypath_case_input_dir}/${config_file} apply --detailed-exitcode
-code=$?
+code=0
+${helmfile} -f ${happypath_case_input_dir}/${config_file} apply --detailed-exitcode || code=$?
 [ ${code} -eq 0 ] || fail "unexpected exit code returned by helmfile apply: want 0, got ${code}"
 
 info "Locking dependencies"
-${helmfile} -f ${happypath_case_input_dir}/${config_file} deps
-code=$?
+code=0
+${helmfile} -f ${happypath_case_input_dir}/${config_file} deps || code=$?
 [ ${code} -eq 0 ] || fail "unexpected exit code returned by helmfile deps: ${code}"
 
 info "Applying ${happypath_case_input_dir}/${config_file} with locked dependencies"
-${helmfile} -f ${happypath_case_input_dir}/${config_file} apply
-code=$?
+code=0
+${helmfile} -f ${happypath_case_input_dir}/${config_file} apply || code=$?
 [ ${code} -eq 0 ] || fail "unexpected exit code returned by helmfile apply: ${code}"
 ${helm} list --namespace=${test_ns} || fail "unable to list releases"
 
@@ -76,8 +76,8 @@ info "Ensuring \"helmfile destroy\" doesn't fail when no releases installed"
 ${helmfile} -f ${happypath_case_input_dir}/${config_file} destroy || fail "\"helmfile delete\" shouldn't fail when there are no installed releases"
 
 info "Re-applying ${happypath_case_input_dir}/${config_file} with locked dependencies"
-${helmfile} -f ${happypath_case_input_dir}/${config_file} apply
-code=$?
+code=0
+${helmfile} -f ${happypath_case_input_dir}/${config_file} apply || code=$?
 [ ${code} -eq 0 ] || fail "unexpected exit code returned by helmfile apply: ${code}"
 ${helm} list --namespace=${test_ns} || fail "unable to list releases"
 

--- a/test/integration/test-cases/issue-1880-transformers-with-file-deps.sh
+++ b/test/integration/test-cases/issue-1880-transformers-with-file-deps.sh
@@ -27,8 +27,8 @@ info "Testing helmfile template with transformers and file:// dependency"
 
 cd "${issue_1880_input_dir}"
 
-${helmfile_real} template > "${issue_1880_tmp}/output.yaml" 2>&1
-result=$?
+result=0
+${helmfile_real} template > "${issue_1880_tmp}/output.yaml" 2>&1 || result=$?
 
 cd - > /dev/null
 

--- a/test/integration/test-cases/issue-1880-transformers-with-file-deps.sh
+++ b/test/integration/test-cases/issue-1880-transformers-with-file-deps.sh
@@ -1,0 +1,51 @@
+# Integration test for issue #1880: Kustomize transformers preventing dependency update
+# https://github.com/helmfile/helmfile/issues/1880
+#
+# This test verifies that a local chart with a relative file:// dependency
+# (file://../library) works correctly when transformers are used.
+#
+# Before the fix, chartify copied the chart to a temp directory, breaking the
+# relative file:// path. helm dependency up then failed with:
+#   Error: directory /tmp/chartify.../monitoring/library not found
+
+issue_1880_input_dir="${cases_dir}/issue-1880-transformers-with-file-deps/input"
+issue_1880_tmp=""
+
+cleanup_issue_1880() {
+  if [ -n "${issue_1880_tmp}" ] && [ -d "${issue_1880_tmp}" ]; then
+    rm -rf "${issue_1880_tmp}"
+  fi
+}
+trap cleanup_issue_1880 EXIT
+
+issue_1880_tmp=$(mktemp -d)
+helmfile_real="$(pwd)/${helmfile}"
+
+test_start "issue #1880: transformers with relative file:// chart dependencies"
+
+info "Testing helmfile template with transformers and file:// dependency"
+
+cd "${issue_1880_input_dir}"
+
+${helmfile_real} template > "${issue_1880_tmp}/output.yaml" 2>&1
+result=$?
+
+cd - > /dev/null
+
+if [ $result -ne 0 ]; then
+    cat "${issue_1880_tmp}/output.yaml"
+    fail "helmfile template should not fail (issue #1880 regression)"
+fi
+
+# Verify the transformer was applied (LabelTransformer adds component=abc)
+if ! grep -q "component: abc" "${issue_1880_tmp}/output.yaml"; then
+    cat "${issue_1880_tmp}/output.yaml"
+    fail "Output should contain the transformer label 'component: abc'"
+fi
+
+info "Transformers with relative file:// dependencies work correctly"
+
+cleanup_issue_1880
+trap - EXIT
+
+test_pass "issue #1880: transformers with relative file:// chart dependencies"

--- a/test/integration/test-cases/issue-1880-transformers-with-file-deps/input/charts/library/Chart.yaml
+++ b/test/integration/test-cases/issue-1880-transformers-with-file-deps/input/charts/library/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: library
+version: 0.1.0
+description: A library chart dependency for issue #1880
+type: library

--- a/test/integration/test-cases/issue-1880-transformers-with-file-deps/input/charts/library/templates/_helpers.tpl
+++ b/test/integration/test-cases/issue-1880-transformers-with-file-deps/input/charts/library/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "library.getLabel" -}}
+{{ .Chart.Name }}-label
+{{- end -}}

--- a/test/integration/test-cases/issue-1880-transformers-with-file-deps/input/charts/service/Chart.yaml
+++ b/test/integration/test-cases/issue-1880-transformers-with-file-deps/input/charts/service/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: service
+version: 0.1.0
+description: A test chart for issue #1880 - has a relative file:// dependency
+dependencies:
+  - name: library
+    version: 0.1.0
+    repository: file://../library

--- a/test/integration/test-cases/issue-1880-transformers-with-file-deps/input/charts/service/templates/configmap.yaml
+++ b/test/integration/test-cases/issue-1880-transformers-with-file-deps/input/charts/service/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+data:
+  key: value

--- a/test/integration/test-cases/issue-1880-transformers-with-file-deps/input/helmfile.yaml
+++ b/test/integration/test-cases/issue-1880-transformers-with-file-deps/input/helmfile.yaml
@@ -1,0 +1,23 @@
+# Issue #1880: Kustomize transformers preventing dependency update
+# https://github.com/helmfile/helmfile/issues/1880
+#
+# When a local chart has a relative file:// dependency (e.g. file://../library)
+# and the release uses transformers, chartify copies the chart to a temp directory.
+# This breaks the relative file:// path, causing:
+#   Error: directory /tmp/chartify.../monitoring/library not found
+#
+# The fix rewrites relative file:// paths to absolute before chartify processes them.
+releases:
+  - name: sentry
+    namespace: monitoring
+    chart: ./charts/service
+    transformers:
+      - apiVersion: builtin
+        kind: LabelTransformer
+        metadata:
+          name: label-enforcer
+        labels:
+          component: abc
+        fieldSpecs:
+          - path: metadata/labels
+            create: true

--- a/test/integration/test-cases/issue-2269.sh
+++ b/test/integration/test-cases/issue-2269.sh
@@ -17,8 +17,8 @@ test_start "issue-2269: helmDefaults.skipDeps and skipRefresh prevent repo opera
 # The helmDefaults in helmfile.yaml should be sufficient to skip repo operations.
 # We use a fake repo URL that would fail if helmfile tried to contact it.
 info "Running helmfile template with helmDefaults.skipDeps=true and skipRefresh=true"
-${helmfile} -f "${issue_2269_input_dir}/helmfile.yaml" template > "${issue_2269_output}" 2>&1
-code=$?
+code=0
+${helmfile} -f "${issue_2269_input_dir}/helmfile.yaml" template > "${issue_2269_output}" 2>&1 || code=$?
 
 if [ $code -ne 0 ]; then
   cat "${issue_2269_output}"

--- a/test/integration/test-cases/issue-2271.sh
+++ b/test/integration/test-cases/issue-2271.sh
@@ -12,8 +12,8 @@ test_start "issue-2271: lookup function with strategicMergePatches and jsonPatch
 
 # Test 1: Install chart without kustomize patches
 info "Installing chart without kustomize patches"
-${helmfile} -f helmfile-no-kustomize.yaml apply --suppress-diff > "${issue_2271_tmp_dir}/test-2271-install.txt" 2>&1
-code=$?
+code=0
+${helmfile} -f helmfile-no-kustomize.yaml apply --suppress-diff > "${issue_2271_tmp_dir}/test-2271-install.txt" 2>&1 || code=$?
 
 if [ $code -ne 0 ]; then
   cat "${issue_2271_tmp_dir}/test-2271-install.txt"
@@ -44,8 +44,8 @@ assert_lookup_preserved() {
 
   info "Testing diff with ${label} - lookup should preserve value"
 
-  ${helmfile} -f "${helmfile_path}" diff > "${output_path}" 2>&1
-  code=$?
+  code=0
+  ${helmfile} -f "${helmfile_path}" diff > "${output_path}" 2>&1 || code=$?
 
   if [ $code -ne 0 ] && [ $code -ne 2 ]; then
     cat "${output_path}"

--- a/test/integration/test-cases/issue-2275.sh
+++ b/test/integration/test-cases/issue-2275.sh
@@ -14,8 +14,8 @@ info "Testing helmfile apply with chart requiring Kubernetes >=1.25.0"
 info "Expected: Success with auto-detected cluster version"
 
 # Test 1: Apply should succeed with auto-detected cluster version
-${helmfile} apply --skip-diff-on-install --suppress-diff > "${issue_2275_tmp_dir}/test-2275-output.txt" 2>&1
-code=$?
+code=0
+${helmfile} apply --skip-diff-on-install --suppress-diff > "${issue_2275_tmp_dir}/test-2275-output.txt" 2>&1 || code=$?
 
 if [ $code -ne 0 ]; then
   if grep -q "incompatible with Kubernetes v1.20.0" "${issue_2275_tmp_dir}/test-2275-output.txt"; then
@@ -34,8 +34,8 @@ info "Chart installed successfully with auto-detected version"
 # Test 2: Diff should work with auto-detected version
 info "Testing helmfile diff with auto-detected cluster version"
 
-${helmfile} diff > "${issue_2275_tmp_dir}/test-2275-diff-output.txt" 2>&1
-code=$?
+code=0
+${helmfile} diff > "${issue_2275_tmp_dir}/test-2275-diff-output.txt" 2>&1 || code=$?
 
 if [ $code -ne 0 ] && [ $code -ne 2 ]; then
   if grep -q "incompatible with Kubernetes v1.20.0" "${issue_2275_tmp_dir}/test-2275-diff-output.txt"; then
@@ -62,8 +62,8 @@ sed -i.bak 's/version: 1.0.0/version: 1.0.1/' test-chart/Chart.yaml
 info "Running helmfile apply to upgrade chart (this will run diff)"
 info "This would fail with 'incompatible with Kubernetes v1.20.0' before the fix"
 
-${helmfile} apply --suppress-diff > "${issue_2275_tmp_dir}/test-2275-apply2-output.txt" 2>&1
-code=$?
+code=0
+${helmfile} apply --suppress-diff > "${issue_2275_tmp_dir}/test-2275-apply2-output.txt" 2>&1 || code=$?
 
 # Restore original chart version
 mv test-chart/Chart.yaml.bak test-chart/Chart.yaml

--- a/test/integration/test-cases/issue-2280.sh
+++ b/test/integration/test-cases/issue-2280.sh
@@ -19,8 +19,8 @@ test_start "issue-2280: --color flag with Helm 4"
 
 # Test 1: Install the chart first
 info "Installing chart for issue #2280 test"
-${helmfile} -f helmfile.yaml apply --suppress-diff > "${issue_2280_tmp_dir}/install.txt" 2>&1
-code=$?
+code=0
+${helmfile} -f helmfile.yaml apply --suppress-diff > "${issue_2280_tmp_dir}/install.txt" 2>&1 || code=$?
 
 if [ $code -ne 0 ]; then
   cat "${issue_2280_tmp_dir}/install.txt"
@@ -37,8 +37,8 @@ info "Chart installed successfully"
 # After the fix, --color is removed and HELM_DIFF_COLOR env var is set instead
 info "Running diff with --color and --context flags"
 
-${helmfile} -f helmfile.yaml diff --color --context 3 > "${issue_2280_tmp_dir}/diff-color.txt" 2>&1
-code=$?
+code=0
+${helmfile} -f helmfile.yaml diff --color --context 3 > "${issue_2280_tmp_dir}/diff-color.txt" 2>&1 || code=$?
 
 # Check for the error from issue #2280
 if grep -q "invalid color mode" "${issue_2280_tmp_dir}/diff-color.txt"; then
@@ -62,8 +62,8 @@ info "SUCCESS: --color flag did not interfere with --context flag"
 # Test 3: Also test with --no-color
 info "Running diff with --no-color and --context flags"
 
-${helmfile} -f helmfile.yaml diff --no-color --context 3 > "${issue_2280_tmp_dir}/diff-no-color.txt" 2>&1
-code=$?
+code=0
+${helmfile} -f helmfile.yaml diff --no-color --context 3 > "${issue_2280_tmp_dir}/diff-no-color.txt" 2>&1 || code=$?
 
 if grep -q "invalid color mode" "${issue_2280_tmp_dir}/diff-no-color.txt"; then
   cat "${issue_2280_tmp_dir}/diff-no-color.txt"

--- a/test/integration/test-cases/issue-2291.sh
+++ b/test/integration/test-cases/issue-2291.sh
@@ -24,8 +24,8 @@ test_start "issue-2291: CRDs preserved with strategicMergePatches"
 
 # Test 1: Template the chart to verify CRDs are included
 info "Step 1: Templating chart to verify CRD structure"
-${helmfile} -f "${issue_2291_input_dir}/helmfile.yaml" template > "${issue_2291_tmp_dir}/templated.yaml" 2>&1
-code=$?
+code=0
+${helmfile} -f "${issue_2291_input_dir}/helmfile.yaml" template > "${issue_2291_tmp_dir}/templated.yaml" 2>&1 || code=$?
 
 if [ $code -ne 0 ]; then
   cat "${issue_2291_tmp_dir}/templated.yaml"
@@ -50,8 +50,8 @@ info "✓ CRD testresources.test.io found"
 
 # Test 2: Apply the chart with strategicMergePatches
 info "Step 2: Applying chart with strategicMergePatches"
-${helmfile} -f "${issue_2291_input_dir}/helmfile.yaml" apply --suppress-diff > "${issue_2291_tmp_dir}/apply.txt" 2>&1
-code=$?
+code=0
+${helmfile} -f "${issue_2291_input_dir}/helmfile.yaml" apply --suppress-diff > "${issue_2291_tmp_dir}/apply.txt" 2>&1 || code=$?
 
 if [ $code -ne 0 ]; then
   cat "${issue_2291_tmp_dir}/apply.txt"

--- a/test/integration/test-cases/issue-2297-local-chart-transformers.sh
+++ b/test/integration/test-cases/issue-2297-local-chart-transformers.sh
@@ -31,8 +31,8 @@ cd "${issue_2297_input_dir}"
 
 # This should succeed - before the fix it would fail with:
 # "helm pull ../chart --untar" fails with "repo .. not found"
-${helmfile_real} template > "${issue_2297_tmp}/output.yaml" 2>&1
-result=$?
+result=0
+${helmfile_real} template > "${issue_2297_tmp}/output.yaml" 2>&1 || result=$?
 
 cd - > /dev/null
 

--- a/test/integration/test-cases/issue-2596-local-deps-multiple-files.sh
+++ b/test/integration/test-cases/issue-2596-local-deps-multiple-files.sh
@@ -31,8 +31,8 @@ info "Testing helmfile template with local chart dependencies across multiple re
 
 cd "${issue_2596_input_dir}"
 
-${helmfile_real} template > "${issue_2596_tmp}/output.yaml" 2>&1
-result=$?
+result=0
+${helmfile_real} template > "${issue_2596_tmp}/output.yaml" 2>&1 || result=$?
 
 cd - > /dev/null
 

--- a/test/integration/test-cases/kubedog-tracking.sh
+++ b/test/integration/test-cases/kubedog-tracking.sh
@@ -9,8 +9,8 @@ info "Testing kubedog integration with httpbin chart"
 
 # Test 1: Basic sync with kubedog tracking
 info "Syncing release with basic kubedog tracking"
-${helmfile} -f "${kubedog_case_dir}/${config_file}" -l name=httpbin-basic sync
-code=$?
+code=0
+${helmfile} -f "${kubedog_case_dir}/${config_file}" -l name=httpbin-basic sync || code=$?
 [ "${code}" -eq 0 ] || fail "unexpected exit code returned by helmfile sync: ${code}"
 
 wait_deploy_ready httpbin-basic-httpbin
@@ -19,8 +19,8 @@ ${kubectl} get deployment httpbin-basic-httpbin -n "${test_ns}" || fail "httpbin
 
 # Test 2: Sync with whitelist filtering
 info "Syncing release with whitelist filtering"
-${helmfile} -f "${kubedog_case_dir}/${config_file}" -l name=httpbin-with-whitelist sync
-code=$?
+code=0
+${helmfile} -f "${kubedog_case_dir}/${config_file}" -l name=httpbin-with-whitelist sync || code=$?
 [ "${code}" -eq 0 ] || fail "unexpected exit code returned by helmfile sync with whitelist: ${code}"
 
 wait_deploy_ready httpbin-with-whitelist-httpbin
@@ -29,8 +29,8 @@ ${kubectl} get deployment httpbin-with-whitelist-httpbin -n "${test_ns}" || fail
 
 # Test 3: Sync with specific resource tracking
 info "Syncing release with specific resource tracking"
-${helmfile} -f "${kubedog_case_dir}/${config_file}" -l name=httpbin-with-resources sync
-code=$?
+code=0
+${helmfile} -f "${kubedog_case_dir}/${config_file}" -l name=httpbin-with-resources sync || code=$?
 [ "${code}" -eq 0 ] || fail "unexpected exit code returned by helmfile sync with resource tracking: ${code}"
 
 wait_deploy_ready httpbin-with-resources-httpbin
@@ -39,14 +39,14 @@ ${kubectl} get deployment httpbin-with-resources-httpbin -n "${test_ns}" || fail
 
 # Test 4: Apply all releases with kubedog via CLI flag
 info "Testing apply with kubedog CLI flag"
-${helmfile} -f "${kubedog_case_dir}/${config_file}" apply --track-mode kubedog --track-timeout 60
-code=$?
+code=0
+${helmfile} -f "${kubedog_case_dir}/${config_file}" apply --track-mode kubedog --track-timeout 60 || code=$?
 [ "${code}" -eq 0 ] || fail "unexpected exit code returned by helmfile apply: ${code}"
 
 # Test 5: Cleanup
 info "Destroying all releases"
-${helmfile} -f "${kubedog_case_dir}/${config_file}" destroy
-code=$?
+code=0
+${helmfile} -f "${kubedog_case_dir}/${config_file}" destroy || code=$?
 [ "${code}" -eq 0 ] || fail "unexpected exit code returned by helmfile destroy: ${code}"
 
 info "kubedog integration test completed successfully"

--- a/test/integration/test-cases/v1-subhelmfile-multi-bases-with-array-values.sh
+++ b/test/integration/test-cases/v1-subhelmfile-multi-bases-with-array-values.sh
@@ -15,8 +15,8 @@ for i in $(seq 10); do
     info "Comparing build/v1-subhelmfile-multi-bases-with-array-values #$i"
     # Remove incubator repo to ensure consistent output (repo addition message)
     ${helm} repo remove incubator 2>/dev/null || true
-    ${helmfile} -f ${v1_subhelmfile_multi_bases_with_array_values_input_dir}/helmfile.yaml.gotmpl template -e dev &> ${yaml_overwrite_reverse}
-    exit_code=$?
+    exit_code=0
+    ${helmfile} -f ${v1_subhelmfile_multi_bases_with_array_values_input_dir}/helmfile.yaml.gotmpl template -e dev &> ${yaml_overwrite_reverse} || exit_code=$?
     if [ $exit_code -ne 0 ]; then
         info "ERROR: helmfile template command failed with exit code $exit_code"
         info "ERROR: Output from failed command:"


### PR DESCRIPTION
## Summary

Add an integration test reproducing the exact scenario from issue #1880: a local chart with a relative `file://` dependency (`file://../library`) used together with kustomize transformers.

Before the fix (`rewriteChartDependencies` in PR #2334), chartify copied the chart to a temp directory, breaking the relative `file://` path and causing `helm dependency up` to fail with:
```
Error: directory /tmp/chartify.../monitoring/library not found
```

## Changes

- **New integration test** (`test/integration/test-cases/issue-1880-transformers-with-file-deps/`): Reproduces the demo from the issue — a local chart `./charts/service` with `file://../library` dependency + `LabelTransformer`. Verifies `helmfile template` succeeds and the transformer label is applied.
- **Fix test artifact leak** in `issue923_test.go`: `OutputDirTemplate` was `"{{ .Release.Name }}"` (ignored tempDir), causing OCI chart downloads to write to CWD. Fixed to `"{{ .OutputDir }}/{{ .Release.Name }}"` and added `cleanupLeakedChartDirs` safety net.

Closes #1880