### PR TITLE
fix: skip chartification when chart renders zero resources

### DIFF
--- a/pkg/state/issue_1757_test.go
+++ b/pkg/state/issue_1757_test.go
@@ -1,0 +1,57 @@
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsChartifyEmptyRenderOutputError verifies that isChartifyEmptyRenderOutputError
+// only matches chartify's specific "empty rendered output dir" assertion failure, not
+// other, unrelated chartify errors. This is a regression test for issue #1757: a chart
+// that renders zero resources (e.g. everything gated behind a falsy `if`) combined with
+// transformers/jsonPatches/strategicMergePatches used to crash helmfile with
+//
+//	assertion failed: unexpected dir entry "" it must be the abs path to the output directory
+//
+// because chartify expects exactly one rendered output directory and found none.
+func TestIsChartifyEmptyRenderOutputError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "chartify empty render assertion error",
+			err:      errors.New(`assertion failed: unexpected dir entry "" it must be the abs path to the output directory`),
+			expected: true,
+		},
+		{
+			name:     "unrelated chartify error",
+			err:      errors.New("exec: \"kustomize\": executable file not found in %PATH%"),
+			expected: false,
+		},
+		{
+			name:     "unrelated multiple-dir-entries assertion",
+			err:      errors.New(`assertion failed: there should be only one dir entry under the helm output dir /tmp/foo`),
+			expected: false,
+		},
+		{
+			name:     "helm template failure",
+			err:      errors.New("Error: template: mychart/templates/broken.yaml:3:5: executing..."),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isChartifyEmptyRenderOutputError(tt.err))
+		})
+	}
+}

--- a/pkg/state/issue_1757_test.go
+++ b/pkg/state/issue_1757_test.go
@@ -42,6 +42,20 @@ func TestIsChartifyEmptyRenderOutputError(t *testing.T) {
 			expected: true,
 		},
 		{
+			// Same assertion, but chartOutputDir is a non-empty (merely
+			// relative) path rather than "" - a different, hypothetical
+			// chartify bug that happens to trip the same final assertion.
+			// This must NOT be treated as the empty-render no-op case:
+			// per review feedback (https://github.com/helmfile/helmfile/pull/2724),
+			// matching only on the trailing "...it must be the abs path to
+			// the output directory" phrase (without requiring the `""`
+			// empty-string dir entry) would have incorrectly matched this
+			// too, silently masking a genuinely different failure.
+			name:     "same assertion with a non-empty dir entry is not the empty-render case",
+			err:      errors.New(`assertion failed: unexpected dir entry "relative/path" it must be the abs path to the output directory`),
+			expected: false,
+		},
+		{
 			name:     "unrelated chartify error",
 			err:      errors.New("exec: \"kustomize\": executable file not found in %PATH%"),
 			expected: false,

--- a/pkg/state/issue_1757_test.go
+++ b/pkg/state/issue_1757_test.go
@@ -2,9 +2,18 @@ package state
 
 import (
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"testing"
 
+	"github.com/helmfile/chartify"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/helmfile/helmfile/pkg/filesystem"
 )
 
 // TestIsChartifyEmptyRenderOutputError verifies that isChartifyEmptyRenderOutputError
@@ -54,4 +63,124 @@ func TestIsChartifyEmptyRenderOutputError(t *testing.T) {
 			assert.Equal(t, tt.expected, isChartifyEmptyRenderOutputError(tt.err))
 		})
 	}
+}
+
+// TestProcessChartification_EmptyRenderReturnsSurvivingPath is an end-to-end
+// regression test for a bug found in review of the #1757 fix: the empty-render
+// no-op path must return the chart's original path, not the temp copy that
+// rewriteChartDependencies creates when the chart has relative file:// deps -
+// that temp dir is removed by a deferred cleanup as soon as processChartification
+// returns, so returning it would hand the caller a path to a directory that no
+// longer exists on disk.
+//
+// This exercises the real processChartification -> chartify.Chartify wiring
+// (unlike TestIsChartifyEmptyRenderOutputError above, which only tests the pure
+// string-matching helper), so it needs real helm and kustomize binaries on PATH
+// and is skipped if either is missing. Verified to pass on Linux; skipped on
+// Windows because the file:// dependency URL this test needs (to make
+// rewriteChartDependencies actually produce a temp copy) hits an unrelated,
+// pre-existing Windows path-handling issue in chartify/helm's dependency
+// resolution (a Windows drive letter embedded in a file:// URL gets
+// mis-joined onto another path), independent of the fix under test here.
+func TestProcessChartification_EmptyRenderReturnsSurvivingPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows: unrelated file:// dependency URL / drive letter handling issue in chartify's helm dependency resolution, not the code path under test; passes on Linux (CI)")
+	}
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm not found on PATH, skipping")
+	}
+	if _, err := exec.LookPath("kustomize"); err != nil {
+		t.Skip("kustomize not found on PATH, skipping")
+	}
+
+	tempDir := t.TempDir()
+
+	// A sibling chart referenced via a relative file:// dependency, so that
+	// processChartification takes the rewriteChartDependencies path (line
+	// `if st.fs.DirectoryExistsAt(chartPath) { ... }`) and reassigns its local
+	// chartPath variable to a temp copy before ever calling chartify.
+	depChartDir := filepath.Join(tempDir, "dep-chart")
+	require.NoError(t, os.MkdirAll(depChartDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(depChartDir, "Chart.yaml"), []byte(`
+apiVersion: v2
+name: dep-chart
+version: 0.1.0
+`), 0644))
+
+	chartDir := filepath.Join(tempDir, "chart")
+	require.NoError(t, os.MkdirAll(filepath.Join(chartDir, "templates"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte(`
+apiVersion: v2
+name: emptychart
+version: 0.1.0
+dependencies:
+  - name: dep-chart
+    version: 0.1.0
+    repository: "file://../dep-chart"
+`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte("enabled: false\n"), 0644))
+	// Every template is gated behind a falsy condition, so helm renders zero
+	// resources - the exact condition that triggers chartify's empty-output
+	// assertion.
+	require.NoError(t, os.WriteFile(filepath.Join(chartDir, "templates", "deployment.yaml"), []byte(`
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+{{- end }}
+`), 0644))
+
+	// A transformer is required for chartify to be invoked at all (see the
+	// call site in state.go: chartification is only non-nil, and processChartification
+	// only gets called, when transformers/jsonPatches/strategicMergePatches are set).
+	transformerPath := filepath.Join(tempDir, "transformer.yaml")
+	require.NoError(t, os.WriteFile(transformerPath, []byte(`
+apiVersion: builtin
+kind: AnnotationsTransformer
+metadata:
+  name: notImportantHere
+annotations:
+  area: "51"
+fieldSpecs:
+  - path: metadata/annotations
+    create: true
+`), 0644))
+
+	st := &HelmState{
+		logger: zap.NewNop().Sugar(),
+		fs:     filesystem.DefaultFileSystem(),
+		ReleaseSetSpec: ReleaseSetSpec{
+			DefaultHelmBinary:      "helm",
+			DefaultKustomizeBinary: "kustomize",
+		},
+	}
+
+	chartification := &Chartify{
+		Opts: &chartify.ChartifyOpts{
+			Transformers: []string{transformerPath},
+		},
+	}
+	release := &ReleaseSpec{}
+	release.Name = "empty-release"
+
+	resultPath, buildDeps, err := st.processChartification(
+		chartification, release, chartDir, ChartPrepareOptions{}, false, "template",
+	)
+
+	require.NoError(t, err)
+	assert.True(t, buildDeps, "buildDeps should be true (!skipDeps) for the no-op path")
+
+	// The returned path must still exist: it must be the original chart
+	// directory, not the deps-rewritten temp copy that gets deleted by
+	// rewriteChartDependencies' deferred cleanup on return.
+	info, statErr := os.Stat(resultPath)
+	require.NoError(t, statErr, "returned chart path %q must still exist after processChartification returns", resultPath)
+	assert.True(t, info.IsDir())
+
+	// It should specifically be the chart's own directory (or an
+	// equally-valid, not-yet-cleaned-up path to the same chart), not some
+	// other temp directory. Chart.yaml must be readable from it.
+	_, err = os.Stat(filepath.Join(resultPath, "Chart.yaml"))
+	assert.NoError(t, err, "Chart.yaml should be reachable from the returned path %q", resultPath)
 }

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1940,6 +1940,16 @@ func (st *HelmState) processChartification(chartification *Chartify, release *Re
 
 	out, err := c.Chartify(release.Name, chartPath, chartify.WithChartifyOpts(chartifyOpts))
 	if err != nil {
+		if isChartifyEmptyRenderOutputError(err) {
+			// The chart rendered zero resources (e.g. everything is gated behind a
+			// `{{- if .Values.enabled }}` that evaluated to false), so chartify has
+			// nothing to replace templates/charts/crds with and fails its internal
+			// "there must be exactly one rendered output dir" assertion. Treat this
+			// as a no-op: use the chart as-is, since there's nothing to chartify.
+			// See https://github.com/helmfile/helmfile/issues/1757
+			st.logger.Debugf("release %q: chart rendered no resources, skipping chartification: %v", release.Name, err)
+			return chartPath, !skipDeps, nil
+		}
 		return "", false, err
 	}
 
@@ -1952,6 +1962,23 @@ func (st *HelmState) processChartification(chartification *Chartify, release *Re
 	// explicitly skipped.
 	buildDeps := !skipDeps
 	return chartPath, buildDeps, nil
+}
+
+// chartifyEmptyRenderOutputErrSubstring is the distinctive part of the error that
+// github.com/helmfile/chartify (as of v0.28.0, see replace.go) returns when `helm template`
+// renders zero resources for a chart: it expects exactly one directory entry under its
+// `--output-dir`, and an empty render leaves that directory empty, so the "must be the abs
+// path to the output directory" assertion fails on the resulting empty string. Chartify does
+// not expose a typed/sentinel error for this case, so we match on the error text; if this
+// substring ever stops matching a real chartify error, chartify's wording has changed and
+// this check needs to be revisited (and ideally fixed upstream in chartify instead).
+const chartifyEmptyRenderOutputErrSubstring = "it must be the abs path to the output directory"
+
+// isChartifyEmptyRenderOutputError reports whether err is chartify's assertion failure caused
+// by a chart rendering zero resources, as opposed to some other, unrelated chartify failure
+// that should still be surfaced to the user.
+func isChartifyEmptyRenderOutputError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), chartifyEmptyRenderOutputErrSubstring)
 }
 
 func (st *HelmState) appendSkipSchemaValidationFlagToChartifyTemplateArgs(templateArgs string, release *ReleaseSpec, skipSchemaValidation bool) string {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1979,14 +1979,21 @@ func (st *HelmState) processChartification(chartification *Chartify, release *Re
 // renders zero resources for a chart: it expects exactly one directory entry under its
 // `--output-dir`, and an empty render leaves that directory empty, so the "must be the abs
 // path to the output directory" assertion fails on the resulting empty string. Chartify does
-// not expose a typed/sentinel error for this case, so we match on the error text; if this
-// substring ever stops matching a real chartify error, chartify's wording has changed and
-// this check needs to be revisited.
+// not expose a typed/sentinel error for this case, so we match on the error text.
+//
+// The matched string includes the `unexpected dir entry ""` prefix (not just the trailing
+// "...it must be the abs path to the output directory" phrase) so this can only match when
+// chartify's chartOutputDir was genuinely empty - i.e. the exact empty-render case - and not
+// some other, hypothetical failure of the same assertion against a non-empty (but still
+// relative) path, which would be a different bug that should still be surfaced as an error.
+//
+// If this substring ever stops matching a real chartify error, chartify's wording has
+// changed and this check needs to be revisited.
 //
 // Tracked upstream at https://github.com/helmfile/chartify/issues/206 - once chartify
 // exposes a sentinel error (or treats an empty render as a no-op itself) and this repo
 // bumps to that version, this text match can be retired.
-const chartifyEmptyRenderOutputErrSubstring = "it must be the abs path to the output directory"
+const chartifyEmptyRenderOutputErrSubstring = `unexpected dir entry "" it must be the abs path to the output directory`
 
 // isChartifyEmptyRenderOutputError reports whether err is chartify's assertion failure caused
 // by a chart rendering zero resources, as opposed to some other, unrelated chartify failure

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1868,6 +1868,11 @@ func (st *HelmState) rewriteChartDependencies(chartPath string) (string, func(),
 // If exists, it will also patch resources by json patches, strategic-merge patches, and injectors.
 // processChartification handles the chartification process
 func (st *HelmState) processChartification(chartification *Chartify, release *ReleaseSpec, chartPath string, opts ChartPrepareOptions, skipDeps bool, helmfileCommand string) (string, bool, error) {
+	// Preserved so the empty-render no-op path below can return this instead of the
+	// deps-rewritten temp copy assigned to chartPath further down, which the deferred
+	// cleanupTempChart() removes as soon as this function returns.
+	originalChartPath := chartPath
+
 	// Rewrite relative file:// dependencies in Chart.yaml to absolute paths before chartify processes them
 	// This prevents errors like "Error: directory /tmp/chartify.../argocd-application not found"
 	// when Chart.yaml contains dependencies like "file://../argocd-application"
@@ -1939,17 +1944,22 @@ func (st *HelmState) processChartification(chartification *Chartify, release *Re
 	)
 
 	out, err := c.Chartify(release.Name, chartPath, chartify.WithChartifyOpts(chartifyOpts))
+	if err != nil && isChartifyEmptyRenderOutputError(err) {
+		// The chart rendered zero resources (e.g. everything is gated behind a
+		// `{{- if .Values.enabled }}` that evaluated to false), so chartify has
+		// nothing to replace templates/charts/crds with and fails its internal
+		// "there must be exactly one rendered output dir" assertion. Treat this
+		// as a no-op: use the chart as-is, since there's nothing to chartify.
+		// See https://github.com/helmfile/helmfile/issues/1757 and the upstream
+		// tracking issue https://github.com/helmfile/chartify/issues/206.
+		st.logger.Debugf("release %q: chart rendered no resources, skipping chartification: %v", release.Name, err)
+		// Return originalChartPath, NOT chartPath: chartPath may have been reassigned
+		// above to the deps-rewritten temp copy, which the deferred cleanupTempChart()
+		// removes as soon as this function returns. Since chartify never actually ran,
+		// relative file:// deps resolve fine from the original location anyway.
+		return originalChartPath, !skipDeps, nil
+	}
 	if err != nil {
-		if isChartifyEmptyRenderOutputError(err) {
-			// The chart rendered zero resources (e.g. everything is gated behind a
-			// `{{- if .Values.enabled }}` that evaluated to false), so chartify has
-			// nothing to replace templates/charts/crds with and fails its internal
-			// "there must be exactly one rendered output dir" assertion. Treat this
-			// as a no-op: use the chart as-is, since there's nothing to chartify.
-			// See https://github.com/helmfile/helmfile/issues/1757
-			st.logger.Debugf("release %q: chart rendered no resources, skipping chartification: %v", release.Name, err)
-			return chartPath, !skipDeps, nil
-		}
 		return "", false, err
 	}
 
@@ -1971,7 +1981,11 @@ func (st *HelmState) processChartification(chartification *Chartify, release *Re
 // path to the output directory" assertion fails on the resulting empty string. Chartify does
 // not expose a typed/sentinel error for this case, so we match on the error text; if this
 // substring ever stops matching a real chartify error, chartify's wording has changed and
-// this check needs to be revisited (and ideally fixed upstream in chartify instead).
+// this check needs to be revisited.
+//
+// Tracked upstream at https://github.com/helmfile/chartify/issues/206 - once chartify
+// exposes a sentinel error (or treats an empty render as a no-op itself) and this repo
+// bumps to that version, this text match can be retired.
 const chartifyEmptyRenderOutputErrSubstring = "it must be the abs path to the output directory"
 
 // isChartifyEmptyRenderOutputError reports whether err is chartify's assertion failure caused


### PR DESCRIPTION
## Summary

Helmfile crashes when a release has `transformers`, `jsonPatches`, or `strategicMergePatches` configured and its chart renders zero resources (e.g. everything gated behind a falsy `{{- if .Values.enabled }}`):

```
assertion failed: unexpected dir entry "" it must be the abs path to the output directory
```

## Root cause

`processChartification` in `pkg/state/state.go` calls into `github.com/helmfile/chartify`, which runs `helm template --output-dir <dir>` and then expects to find **exactly one** directory entry under `<dir>` (the rendered chart's output). See [`replace.go`](https://github.com/helmfile/chartify/blob/v0.28.0/replace.go#L130-L152) in chartify v0.28.0 (the version this repo currently depends on).

When the chart renders zero resources, `helm template --output-dir` produces an empty directory, so the loop over directory entries never runs, `chartOutputDir` is left as `""`, and chartify's own `filepath.IsAbs(chartOutputDir)` assertion fails on that empty string. chartify doesn't expose a typed/sentinel error for this specific case, so this is only observable by matching on the assertion text.

## Fix

Since there's nothing to chartify when a chart renders no resources, treat this specific chartify error as a no-op: fall back to using the (already dependency-rewritten) chart path as-is, exactly like the non-chartified local-chart path already does (`buildDeps = !skipDeps`, matching the existing convention at the `processLocalChart` call site). `helm template`/`upgrade`/etc. then run against the original chart directly, producing the same empty output helm would have produced without chartify involved at all. Any other chartify error continues to be surfaced unchanged — only this specific, distinctive assertion message is matched.

I deliberately didn't try to fix this in `chartify` itself, even though that's arguably the more "proper" root-cause location, since a fix there wouldn't take effect here until a new chartify version is released and this repo's `go.mod` is bumped to it — this change gets a working fix out now, entirely within this repo.

## Prior art

There was an earlier attempt at this exact fix in #2306, which took a similar approach (catching the chartify error and no-op'ing) but went stale waiting on a DCO sign-off from the contributor and was closed by stale-bot — it was never actually rejected on technical grounds. This PR is a fresh implementation (smaller diff, reuses the existing `!skipDeps` convention for `buildDeps`, adds a dedicated helper function with its own unit tests), signed off per `CONTRIBUTING.md`.

## Test plan

- [x] `go build ./...`
- [x] Added `pkg/state/issue_1757_test.go` with unit tests for the new `isChartifyEmptyRenderOutputError` helper: matches chartify's specific empty-output assertion, does **not** match chartify's distinct "more than one dir entry" assertion, an unrelated `kustomize not found` error, or a generic helm template error.
- [x] `go test ./pkg/state/...` passes (pre-existing unrelated failures on my Windows dev box in `TestLocalChartWithTransformersPathNormalization` / `TestChartPathNormalizationBeforeChartification` reproduce identically on unmodified `main` via `git stash`, confirmed unrelated to this change — looks like a `normalizeChart` Windows path-separator issue)
- [x] Manually verified end-to-end with real `helm` + `kustomize` binaries, using a local chart with `{{- if .Values.enabled }}` gating all templates and an `AnnotationsTransformer` configured:
  - `enabled: false` → previously crashed with the assertion error; now `helmfile template` exits 0, logs `chart rendered no resources, skipping chartification`, and renders the (empty) chart normally
  - `enabled: true` → still correctly applies the transformer (verified the annotation shows up in the rendered output), confirming the normal chartify path is unaffected by this change

Fixes #1757