### PR TITLE
build(deps): bump github.com/helmfile/chartify from v0.28.0 to v0.28.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/go-cty-funcs v0.1.0
 	github.com/hashicorp/go-getter/v2 v2.2.3
 	github.com/hashicorp/hcl/v2 v2.24.0
-	github.com/helmfile/chartify v0.28.0
+	github.com/helmfile/chartify v0.28.1
 	github.com/helmfile/vals v0.45.0
 	github.com/sashabaranov/go-openai v1.41.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -536,8 +536,8 @@ github.com/hashicorp/jsonapi v1.4.3-0.20250220162346-81a76b606f3e h1:xwy/1T0cxHW
 github.com/hashicorp/jsonapi v1.4.3-0.20250220162346-81a76b606f3e/go.mod h1:kWfdn49yCjQvbpnvY1dxxAuAFzISwrrMDQOcu6NsFoM=
 github.com/hashicorp/vault/api v1.23.0 h1:gXgluBsSECfRWTSW9niY2jwg2e9mMJc4WoHNv4g3h6A=
 github.com/hashicorp/vault/api v1.23.0/go.mod h1:zransKiB9ftp+kgY8ydjnvCU7Wk8i9L0DYWpXeMj9ko=
-github.com/helmfile/chartify v0.28.0 h1:AK04JykpFXQAtIbEN2DwAZsoSNdDZdAGY5W5FIoK8bk=
-github.com/helmfile/chartify v0.28.0/go.mod h1:LKUELzZ2TaaCAD4EAFbaCkmRXNnt4uWlJts7GBdFVAQ=
+github.com/helmfile/chartify v0.28.1 h1:dv7XfWT+OYtqSQ3f4SqXwUk6FyTuS6aH1M3+eF4DkLc=
+github.com/helmfile/chartify v0.28.1/go.mod h1:LKUELzZ2TaaCAD4EAFbaCkmRXNnt4uWlJts7GBdFVAQ=
 github.com/helmfile/vals v0.45.0 h1:j5e9enLhBfaiYKKPJWEFAzW0DQJlVXyvnKPWWP3gdJg=
 github.com/helmfile/vals v0.45.0/go.mod h1:dJ5VGNN0cbusJoAFFINFeimbLV19hhtJJ1328ZFLJzA=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=


### PR DESCRIPTION
Bumps `github.com/helmfile/chartify` from v0.28.0 to v0.28.1.

Ran `go mod tidy` to clean up `go.sum`.