### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -131,4 +131,4 @@ Helmfile 已经被许多用户在生产环境中使用:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=helmfile/helmfile&type=Date)](https://star-history.com/#helmfile/helmfile&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=helmfile/helmfile&type=Date)](https://star-history.dera.page/#helmfile/helmfile&Date)

--- a/README.md
+++ b/README.md
@@ -160,4 +160,4 @@ For more users, please see: [Users](https://helmfile.readthedocs.io/en/latest/us
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=helmfile/helmfile&type=Date)](https://star-history.com/#helmfile/helmfile&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=helmfile/helmfile&type=Date)](https://star-history.dera.page/#helmfile/helmfile&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points the chart to a working alternative so the project's star history remains visible.